### PR TITLE
Add MUI Theme Variables

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,9 @@
   },
   "plugins": ["react"],
   "rules": {
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "no-unused-vars": 0
+
   },
   "globals": {
     "process": true,

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "useTabs": false,
   "singleQuote": false,
   "trailingComma": "none",
-  "jsxBracketSameLine": false
+  "jsxBracketSameLine": false,
+  "endOfLine": "auto"
 }

--- a/src/assets/styles/theme.js
+++ b/src/assets/styles/theme.js
@@ -1,6 +1,17 @@
 import { createTheme } from "@mui/material";
 
 const THEME = createTheme({
+  palette: {
+    primary: {
+      dark: "#30344E",
+      main: "#E9E9E9",
+      light: "#EFEFEF"
+    },
+    // Border
+    secondary: {
+      main: "#F5F5F5"
+    }
+  },
   breakpoints: {
     values: {
       xs: 0,
@@ -11,11 +22,22 @@ const THEME = createTheme({
     }
   },
   typography: {
-    fontFamily: '"Roboto Slab", serif'
+    fontFamily: '"Roboto Slab", serif',
+    h1: { fontSize: "24px" },
+    h2: { fontSize: "22px" },
+    h3: { fontSize: "16px" },
+    h4: { fontSize: "15px", fontWeight: "700" },
+    h5: { fontSize: "15px", fontWeight: "500" },
+    subtitle1: { fontSize: "14px" },
+    subtitle2: { fontSize: "10px" },
+    body1: { fontSize: "15px" },
+    body2: { fontSize: "13px" },
+    button: { fontSize: "14px" }
   },
   select: {
     fontFamily: '"Roboto Slab", serif'
-  }
+  },
+  drawerWidth: "240"
 });
 
 export default THEME;


### PR DESCRIPTION
Add fonts, platette colors, and etc.
Source from figma design, https://www.figma.com/file/nAhWBN06v6hMCHDlIT9mzk/KARMADA?node-id=6%3A134.

Also tweak eslint and prettier setup a bit to make it allow used variable and "auto" end of line. That  makes testing much easier.

**What type of PR is this?**
/kind design
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR adds theme variables in theme.js for globally styling our MUI components.  

**Which issue(s) this PR fixes**:
None. This PR adds content to theme.js, and should not have any breaking change.

**Special notes for your reviewer**:
If your have conflict or your design is changed, we can work this out together. Changing global theme may change default style of some components, there is always some trade-off.

**Does this PR introduce a user-facing change?**:
"None"
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

Signed-off-by: @ada2468 <jx2161@nyu.edu>
