### PR TITLE
Added DataTable Component

### DIFF
--- a/src/assets/styles/components/datatable.styles.js
+++ b/src/assets/styles/components/datatable.styles.js
@@ -1,0 +1,33 @@
+import { Table, MenuItem } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import { grey } from "@mui/material/colors";
+import TableCell, { tableCellClasses } from "@mui/material/TableCell";
+
+const StyledTable = styled(Table)(() => ({
+  minWidth: "600px",
+  width: "100%",
+  maxWidth: "94vw",
+  margin: "1vw 2vw"
+}));
+
+const StyledTableCell = styled(TableCell)(({ theme }) => ({
+  fontFamily: '"Roboto Slab", serif',
+  border: `1px solid ${grey[500]}`,
+  padding: "5px 15px",
+  [`&.${tableCellClasses.head}`]: {
+    backgroundColor: theme.palette.action.hover,
+    color: grey[700],
+    fontWeight: "bold"
+  },
+  [`&.${tableCellClasses.body}`]: {
+    fontSize: 14,
+    color: grey[600]
+  }
+}));
+
+const StyledMenuItem = styled(MenuItem)(() => ({
+  fontFamily: '"Roboto Slab", serif',
+  fontSize: 14
+}));
+
+export { StyledTable, StyledTableCell, StyledMenuItem };

--- a/src/components/DataTable.data.js
+++ b/src/components/DataTable.data.js
@@ -1,0 +1,94 @@
+// Single Map having labels for all the tables
+export const labelMap = {
+  clustername: "Cluster Name",
+  labels: "Labels",
+  annotations: "Annotations",
+  syncmode: "SyncMode",
+  apiendpoint: "APIEndpoint",
+  provider: "Provider",
+  region: "Region",
+  zones: "Zones",
+  availablenodes: "Number of Available Nodes",
+  clusterstate: "Cluster State",
+  k8sversion: "Kubernetes Version",
+  creationtime: "Creation"
+};
+
+// Example rowsdata for a table
+export const rowsdata = [
+  {
+    id: "1",
+    clustername: "member1",
+    labels: "Label-1",
+    annotations: "Annot-1",
+    syncmode: "Push",
+    apiendpoint: "https://172.18.0.2:6443",
+    provider: "",
+    region: "",
+    zones: "",
+    availablenodes: "500/500",
+    clusterstate: "Ready",
+    k8sversion: "v1.22.0",
+    creationtime: "2022-04-15-T19:20:55Z"
+  },
+  {
+    id: "2",
+    clustername: "member2",
+    labels: "Label-2",
+    annotations: "Annot-2",
+    syncmode: "Push",
+    apiendpoint: "https://172.18.0.2:6447",
+    provider: "",
+    region: "",
+    zones: "",
+    availablenodes: "1000/1000",
+    clusterstate: "Ready",
+    k8sversion: "v1.22.0",
+    creationtime: "2022-04-16-T19:21:55Z"
+  },
+  {
+    id: "3",
+    clustername: "member3",
+    labels: "Label-3",
+    annotations: "Annot-3",
+    syncmode: "Push",
+    apiendpoint: "https://172.18.0.2:6445",
+    provider: "",
+    region: "",
+    zones: "",
+    availablenodes: "2000/2000",
+    clusterstate: "Ready",
+    k8sversion: "v1.22.0",
+    creationtime: "2022-04-15-T19:20:55Z"
+  },
+  {
+    id: "4",
+    clustername: "member4",
+    labels: "Label-4",
+    annotations: "Annot-4",
+    syncmode: "Push",
+    apiendpoint: "https://172.18.0.2:6143",
+    provider: "",
+    region: "",
+    zones: "",
+    availablenodes: "3000/3000",
+    clusterstate: "Ready",
+    k8sversion: "v1.22.0",
+    creationtime: "2022-04-17-T19:19:55Z"
+  },
+  {
+    id: "5",
+    clustername: "member5",
+    labels: "Label-5",
+    annotations: "Annot-5",
+    syncmode: "Push",
+    apiendpoint: "https://172.18.0.2:6443",
+    provider: "",
+    region: "",
+    zones: "",
+    availablenodes: "500/500",
+    clusterstate: "Ready",
+    k8sversion: "v1.22.0",
+    creationtime: "2022-04-15-T19:21:55Z"
+  }
+];

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -1,0 +1,99 @@
+import React, { useState } from "react";
+import {
+  TableBody,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  IconButton,
+  Menu
+} from "@mui/material";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import {
+  StyledTable,
+  StyledTableCell,
+  StyledMenuItem
+} from "../assets/styles/components/datatable.styles";
+import { labelMap, rowsdata } from "./DataTable.data.js";
+
+let allKeys = Object.keys(rowsdata[0]) || [];
+allKeys = allKeys.filter((key) => key !== "id");
+
+// rowsdata will be in props
+const DataTable = () => {
+  return (
+    <TableContainer component={Paper}>
+      <StyledTable aria-label="customized table">
+        <TableHead>
+          <TableRow>
+            {allKeys.map((currKey) => (
+              <StyledTableCell align="center" key={currKey}>
+                {labelMap[currKey]}
+              </StyledTableCell>
+            ))}
+            <StyledTableCell key="actionmenu" />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rowsdata.map((row) => (
+            <TableRow key={row.id}>
+              {allKeys.map((currKey) => (
+                <StyledTableCell key={`${currKey}-${row.id}`} align="center">
+                  {row[currKey] || "NIL"}
+                </StyledTableCell>
+              ))}
+              <StyledTableCell key={`actionrow-${row.id}`} align="center">
+                <ActionMenu />
+              </StyledTableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </StyledTable>
+    </TableContainer>
+  );
+};
+
+const ActionMenu = () => {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const actions = ["Edit", "Delete"];
+
+  return (
+    <>
+      <IconButton
+        aria-label="more"
+        id="long-button"
+        aria-controls={open ? "long-menu" : undefined}
+        aria-expanded={open ? "true" : undefined}
+        aria-haspopup="true"
+        onClick={handleClick}
+      >
+        <MoreVertIcon />
+      </IconButton>
+      <Menu
+        id="long-menu"
+        MenuListProps={{
+          "aria-labelledby": "long-button"
+        }}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+      >
+        {actions.map((action) => (
+          <StyledMenuItem key={action} onClick={handleClose}>
+            {action}
+          </StyledMenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
+
+export default DataTable;


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The PR includes a reusable Table component to be used on different pages with different types of data. 
This is the first iteration of the component. It will be modified further with API integration and required functionalities working.
It is static and currently implementing this [Figma Design](https://www.figma.com/file/lEDkjr4gdIn35BSi1hXAGT/Karmada?node-id=42%3A18) ( Overview Page - iteration 7 frame ).

**Which issue(s) this PR fixes**:
It's a general component useful for different pages of the entire application.

**Special notes for your reviewer**:
@RainbowMango I'm attaching the screenshot of the developed UI, which was taken by using the component on a new page just for testing. Although, it is not used in any of the pages currently. So, the PR is just having its implementation.

![karmada table component](https://user-images.githubusercontent.com/56475750/187094827-6770d2e1-9334-40a9-b008-7aae9ce41d80.jpg)


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

Signed-off-by: @ShwetKhatri2001 