### PR TITLE
Added usePagination CustomHook and TableWithPagination component

### DIFF
--- a/src/assets/styles/components/datatable.styles.js
+++ b/src/assets/styles/components/datatable.styles.js
@@ -1,0 +1,37 @@
+import { Table, MenuItem } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import { grey } from "@mui/material/colors";
+import TableCell, { tableCellClasses } from "@mui/material/TableCell";
+
+const StyledTable = styled(Table)(() => ({
+  minWidth: "600px",
+  width: "100%",
+  maxWidth: "94vw",
+  margin: "1vw 2vw"
+}));
+
+const StyledTableCell = styled(TableCell)(({ theme }) => ({
+  fontFamily: '"Roboto Slab", serif',
+  border: `1px solid ${grey[500]}`,
+  padding: "5px 15px",
+  [`&.${tableCellClasses.head}`]: {
+    backgroundColor: theme.palette.action.hover,
+    color: grey[700],
+    fontWeight: "bold"
+  },
+  [`&.${tableCellClasses.body}`]: {
+    fontSize: 14,
+    color: grey[600]
+  }
+}));
+
+const StyledMenuItem = styled(MenuItem)(() => ({
+  fontFamily: '"Roboto Slab", serif',
+  fontSize: 14
+}));
+
+export {
+  StyledTable,
+  StyledTableCell,
+  StyledMenuItem,
+};

--- a/src/assets/styles/components/pagination.styles.js
+++ b/src/assets/styles/components/pagination.styles.js
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+
+const TablePaginationContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center;
+`;
+
+const PaginationContainer = styled.div`
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+  align-items: center;
+`;
+
+const PageNoInput = styled.input`
+  width: 35px;
+  height: 28px;
+  text-align: center;
+  border: 1px solid #aaa;
+  border-radius: 3px;
+  outline: 0;
+
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+`;
+
+export { TablePaginationContainer, PaginationContainer, PageNoInput };

--- a/src/components/DataTable.data.js
+++ b/src/components/DataTable.data.js
@@ -1,0 +1,94 @@
+// Single Map having labels for all the tables
+export const labelMap = {
+  clustername: "Cluster Name",
+  labels: "Labels",
+  annotations: "Annotations",
+  syncmode: "SyncMode",
+  apiendpoint: "APIEndpoint",
+  provider: "Provider",
+  region: "Region",
+  zones: "Zones",
+  availablenodes: "Number of Available Nodes",
+  clusterstate: "Cluster State",
+  k8sversion: "Kubernetes Version",
+  creationtime: "Creation"
+};
+
+// Example rowsdata for a table
+export const rowsdata = [
+  {
+    id: "1",
+    clustername: "member1",
+    labels: "Label-1",
+    annotations: "Annot-1",
+    syncmode: "Push",
+    apiendpoint: "https://172.18.0.2:6443",
+    provider: "",
+    region: "",
+    zones: "",
+    availablenodes: "500/500",
+    clusterstate: "Ready",
+    k8sversion: "v1.22.0",
+    creationtime: "2022-04-15-T19:20:55Z"
+  },
+  {
+    id: "2",
+    clustername: "member2",
+    labels: "Label-2",
+    annotations: "Annot-2",
+    syncmode: "Push",
+    apiendpoint: "https://172.18.0.2:6447",
+    provider: "",
+    region: "",
+    zones: "",
+    availablenodes: "1000/1000",
+    clusterstate: "Ready",
+    k8sversion: "v1.22.0",
+    creationtime: "2022-04-16-T19:21:55Z"
+  },
+  {
+    id: "3",
+    clustername: "member3",
+    labels: "Label-3",
+    annotations: "Annot-3",
+    syncmode: "Push",
+    apiendpoint: "https://172.18.0.2:6445",
+    provider: "",
+    region: "",
+    zones: "",
+    availablenodes: "2000/2000",
+    clusterstate: "Ready",
+    k8sversion: "v1.22.0",
+    creationtime: "2022-04-15-T19:20:55Z"
+  },
+  {
+    id: "4",
+    clustername: "member4",
+    labels: "Label-4",
+    annotations: "Annot-4",
+    syncmode: "Push",
+    apiendpoint: "https://172.18.0.2:6143",
+    provider: "",
+    region: "",
+    zones: "",
+    availablenodes: "3000/3000",
+    clusterstate: "Ready",
+    k8sversion: "v1.22.0",
+    creationtime: "2022-04-17-T19:19:55Z"
+  },
+  {
+    id: "5",
+    clustername: "member5",
+    labels: "Label-5",
+    annotations: "Annot-5",
+    syncmode: "Push",
+    apiendpoint: "https://172.18.0.2:6443",
+    provider: "",
+    region: "",
+    zones: "",
+    availablenodes: "500/500",
+    clusterstate: "Ready",
+    k8sversion: "v1.22.0",
+    creationtime: "2022-04-15-T19:21:55Z"
+  }
+];

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -1,0 +1,103 @@
+import React, { useState } from "react";
+import {
+  TableBody,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  IconButton,
+  Menu
+} from "@mui/material";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import {
+  StyledTable,
+  StyledTableCell,
+  StyledMenuItem
+} from "../assets/styles/components/datatable.styles";
+import { labelMap } from "./DataTable.data.js";
+import PropTypes from "prop-types";
+
+const DataTable = ({ data }) => {
+  let allKeys = Object.keys(data[0]) || [];
+  allKeys = allKeys.filter((key) => key !== "id");
+
+  return (
+    <TableContainer component={Paper}>
+      <StyledTable aria-label="customized table">
+        <TableHead>
+          <TableRow>
+            {allKeys.map((currKey) => (
+              <StyledTableCell align="center" key={currKey}>
+                {labelMap[currKey]}
+              </StyledTableCell>
+            ))}
+            <StyledTableCell key="actionmenu" />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.map((row) => (
+            <TableRow key={row.id}>
+              {allKeys.map((currKey) => (
+                <StyledTableCell key={`${currKey}-${row.id}`} align="center">
+                  {row[currKey] || "NIL"}
+                </StyledTableCell>
+              ))}
+              <StyledTableCell key={`actionrow-${row.id}`} align="center">
+                <ActionMenu />
+              </StyledTableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </StyledTable>
+    </TableContainer>
+  );
+};
+
+const ActionMenu = () => {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const actions = ["Edit", "Delete"];
+
+  return (
+    <>
+      <IconButton
+        aria-label="more"
+        id="long-button"
+        aria-controls={open ? "long-menu" : undefined}
+        aria-expanded={open ? "true" : undefined}
+        aria-haspopup="true"
+        onClick={handleClick}
+      >
+        <MoreVertIcon />
+      </IconButton>
+      <Menu
+        id="long-menu"
+        MenuListProps={{
+          "aria-labelledby": "long-button"
+        }}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+      >
+        {actions.map((action) => (
+          <StyledMenuItem key={action} onClick={handleClose}>
+            {action}
+          </StyledMenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
+
+DataTable.propTypes = {
+  data: PropTypes.array
+};
+
+export default DataTable;

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -1,0 +1,77 @@
+import React, { useState } from "react";
+import { Typography, Pagination } from "@mui/material/";
+import { rowsdata } from "./DataTable.data.js";
+import DataTable from "./DataTable.js";
+import {
+  TablePaginationContainer,
+  PaginationContainer,
+  PageNoInput
+} from "../assets/styles/components/pagination.styles";
+
+export function usePagination(data, itemsPerPage) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const maxPage = Math.ceil(data.length / itemsPerPage);
+
+  function currentData() {
+    const begin = (currentPage - 1) * itemsPerPage;
+    const end = begin + itemsPerPage;
+    return data.slice(begin, end);
+  }
+
+  function next() {
+    setCurrentPage(Math.min(currentPage + 1, maxPage));
+  }
+
+  function prev() {
+    setCurrentPage(Math.max(currentPage - 1, 1));
+  }
+
+  function jump(page) {
+    const pageNumber = Math.max(1, page);
+    setCurrentPage(Math.min(pageNumber, maxPage));
+  }
+
+  return { next, prev, jump, currentData, currentPage, maxPage };
+}
+
+const TableWithPagination = () => {
+  let [page, setPage] = useState(1);
+  const PER_PAGE = 2;
+
+  const count = Math.ceil(rowsdata.length / PER_PAGE);
+  const pagedData = usePagination(rowsdata, PER_PAGE);
+
+  const handlePageChange = (e, p) => {
+    setPage(p);
+    pagedData.jump(p);
+  };
+
+  return (
+    <TablePaginationContainer>
+      <DataTable data={pagedData.currentData()} />
+      <PaginationContainer>
+        <Typography variant="body1" component="body1">
+          Total {page} of 10
+        </Typography>
+        <Pagination
+          count={count}
+          page={page}
+          variant="outlined"
+          shape="rounded"
+          color="primary"
+          onChange={handlePageChange}
+        />
+        <Typography variant="body1" component="body1">
+          Go to
+        </Typography>
+        <PageNoInput
+          type="number"
+          value={page}
+          onChange={(e) => handlePageChange(e, e.target.value)}
+        />
+      </PaginationContainer>
+    </TablePaginationContainer>
+  );
+};
+
+export default TableWithPagination;


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR includes a reusable function/custom-hook to generate pagination for all types of data on different pages. Also, it includes an example of how to include it with data. The example shows how table data can be divided into pages and shown dynamically based on the page number. It is the implementation of this [Figma Design](https://www.figma.com/file/lEDkjr4gdIn35BSi1hXAGT/Karmada?node-id=42%3A18) ( Overview Page - iteration 7 frame ).

This PR is also using the DataTable component included in the last PR with some modifications to attach pagination for data in a table.

**Which issue(s) this PR fixes**:
It's a general component useful for different pages of the entire application.

**Special notes for your reviewer**:
@RainbowMango I'm attaching a preview and video link to show how the functionality of pagination included with the table works. We can use the pagination component similarly on any page for any usecase in future.

![TablePagination](https://user-images.githubusercontent.com/56475750/189500505-dab11376-a3e0-49f6-a74a-0e528f46370e.gif)

Video : https://www.loom.com/share/a1ab8e5047a74535a6cb601a2c99295d

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Signed-off-by: ShwetKhatri2001 <19dcs001@lnmiit.ac.in>

