### PR TITLE
build: upgrade github actions

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - uses: pnpm/action-setup@v4
@@ -27,7 +27,7 @@ jobs:
           pnpm install -w
           pnpm run dashboard:build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ui/apps/dashboard/dist
           name: dashboard_artifact
@@ -58,16 +58,13 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build karmada-dashboard-web binary
         run: make bin-karmada-dashboard-web
-      - name: Download a Build Artifact
+      - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: dashboard_artifact
-          path: .
-      - name: Unzip Artifact
+          path: _output/bin/${{ steps.misc.outputs.os }}/${{ steps.misc.outputs.arch }}/dist
+      - name: Display artifact
         run: |
-          pwd
-          mkdir -p _output/bin/${{ steps.misc.outputs.os }}/${{ steps.misc.outputs.arch }}/dist
-          tar xf ./artifact.tar -C _output/bin/${{ steps.misc.outputs.os }}/${{ steps.misc.outputs.arch }}/dist
           ls -al _output/bin
           ls -al _output/bin/${{ steps.misc.outputs.os }}/${{ steps.misc.outputs.arch }}/dist
       - name: Extract metadata for the Docker image


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind bug

**What this PR does / why we need it**:
Fix ci build error, after upgrade `actions/download-artifact@v4`, it's not necessary to unzip artifact manually.


**Which issue(s) this PR fixes**:
Fixes #44 

**Special notes for your reviewer**:
Upgrade other github actions:
- actions/setup-node to v4
- actions/upload-artifact to v4

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

