### PR TITLE
fix ci build error

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -33,6 +33,7 @@ jobs:
           name: dashboard_artifact
 
   build-and-push-web:
+    if: ${{ github.repository == 'karmada-io/dashboard' }}
     runs-on: ubuntu-latest
     needs: [ "build-fronted" ]
     env:
@@ -86,6 +87,7 @@ jobs:
 
 
   build-and-push-api:
+    if: ${{ github.repository == 'karmada-io/dashboard' }}
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: karmada/karmada-dashboard-api

--- a/ui/apps/dashboard/src/pages/multicloud-resource-manage/workload/index.tsx
+++ b/ui/apps/dashboard/src/pages/multicloud-resource-manage/workload/index.tsx
@@ -34,7 +34,7 @@ const WorkloadPage = () => {
   const { data: nsData } = useQuery({
     queryKey: ['GetNamespaces'],
     queryFn: async () => {
-      const clusters = await GetNamespaces();
+      const clusters = await GetNamespaces({});
       return clusters.data || {};
     },
   });


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind flake
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #
- Fix ci build error：
  CI build error 👉🏻：https://github.com/karmada-io/dashboard/actions/runs/10279472346/job/28444903136
  ![image](https://github.com/user-attachments/assets/c519176f-c7d5-430d-9432-ca300687497d)
  in the PR: https://github.com/karmada-io/dashboard/pull/61/files
  I updated the signature of `GetNamespaces`
  https://github.com/karmada-io/dashboard/blob/48a9a9740c3a2c3436fb1319d68579e78a7af9c3/ui/apps/dashboard/src/services/namespace.ts#L17C1-L30C2

  But did not update the invoke of `GetNamespaces` in  `src/pages/multicloud-resource-manage/workload/index.tsx`
  https://github.com/karmada-io/dashboard/blob/48a9a9740c3a2c3436fb1319d68579e78a7af9c3/ui/apps/dashboard/src/pages/multicloud-resource-manage/workload/index.tsx#L34C3-L40C6
   Then it caused one typescript error.
- Optimize ci push image:
   I always receive ci push image error as following
  ![image](https://github.com/user-attachments/assets/5b876b9e-7a1f-44d1-8c10-160b811d6ba9)
  so I decided to execute push image conditionally, only push images for repo `karmada-io/dashboard`  


**Special notes for your reviewer**:
After solve the ci build error, i'll continue the process of resolving conflict

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

