### PR TITLE
UI for configmap management

### DIFF
--- a/pkg/resource/configmap/list_test.go
+++ b/pkg/resource/configmap/list_test.go
@@ -1,0 +1,53 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configmap
+
+import (
+	"github.com/karmada-io/dashboard/pkg/common/types"
+	"github.com/karmada-io/dashboard/pkg/dataselect"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestToConfigMapList(t *testing.T) {
+	cases := []struct {
+		configMaps []v1.ConfigMap
+		expected   *ConfigMapList
+	}{
+		{nil, &ConfigMapList{Items: []ConfigMap{}}},
+		{
+			[]v1.ConfigMap{
+				{Data: map[string]string{"app": "my-name"}, ObjectMeta: metaV1.ObjectMeta{Name: "foo"}},
+			},
+			&ConfigMapList{
+				ListMeta: types.ListMeta{TotalItems: 1},
+				Items: []ConfigMap{{
+					TypeMeta:   types.TypeMeta{Kind: "configmap"},
+					ObjectMeta: types.ObjectMeta{Name: "foo"},
+				}},
+			},
+		},
+	}
+	for _, c := range cases {
+		actual := toConfigMapList(c.configMaps, nil, dataselect.NoDataSelect)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("toConfigMapList(%#v) == \n%#v\nexpected \n%#v\n",
+				c.configMaps, actual, c.expected)
+		}
+	}
+}

--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -42,7 +42,8 @@
     "react-i18next": "^14.1.0",
     "react-router-dom": "^6.22.3",
     "tailwind-merge": "^2.2.2",
-    "yaml": "^2.4.2"
+    "yaml": "^2.4.2",
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
     "@karmada/eslint-config-ts-react": "workspace:*",

--- a/ui/apps/dashboard/src/hooks/index.ts
+++ b/ui/apps/dashboard/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useNamespace } from './use-namespace';
+export { default as useTagNum } from './use-tag-num';

--- a/ui/apps/dashboard/src/hooks/use-namespace.ts
+++ b/ui/apps/dashboard/src/hooks/use-namespace.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { GetNamespaces } from '@/services/namespace.ts';
+import { DataSelectQuery } from '@/services/base.ts';
+
+const useNamespace = (props: { nsFilter?: DataSelectQuery }) => {
+  const { nsFilter = {} } = props;
+  const {
+    data: nsData,
+    isLoading,
+    refetch,
+  } = useQuery({
+    queryKey: ['GetNamespaces', nsFilter],
+    queryFn: async () => {
+      const response = await GetNamespaces(nsFilter);
+      return response.data || {};
+    },
+  });
+  const nsOptions = useMemo(() => {
+    if (!nsData?.namespaces) return [];
+    return nsData.namespaces.map((item) => {
+      return {
+        title: item.objectMeta.name,
+        value: item.objectMeta.name,
+      };
+    });
+  }, [nsData]);
+  return {
+    nsOptions,
+    isNsDataLoading: isLoading,
+    refetchNsData: refetch,
+  };
+};
+
+export default useNamespace;

--- a/ui/apps/dashboard/src/hooks/use-tag-num.ts
+++ b/ui/apps/dashboard/src/hooks/use-tag-num.ts
@@ -1,0 +1,21 @@
+import { useWindowSize } from '@uidotdev/usehooks';
+
+const useTagNum = (
+  params: {
+    targetWidth?: number;
+    defaultTagNum?: number;
+  } = {},
+) => {
+  const { targetWidth = 1800, defaultTagNum = 1 } = params;
+  const size = useWindowSize();
+  if (!size || !size.width)
+    return {
+      tagNum: undefined,
+    };
+  const tagNum = size.width > targetWidth ? undefined : defaultTagNum;
+  return {
+    tagNum,
+  };
+};
+
+export default useTagNum;

--- a/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/components/config-editor-modal.tsx
+++ b/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/components/config-editor-modal.tsx
@@ -1,0 +1,121 @@
+import { FC, useEffect, useMemo, useState } from 'react';
+import { Form, Modal, Select } from 'antd';
+import Editor from '@monaco-editor/react';
+import { parse } from 'yaml';
+import _ from 'lodash';
+import { CreateResource, PutResource } from '@/services/unstructured';
+import { ConfigKind, IResponse } from '@/services/base.ts';
+
+export interface NewWorkloadEditorModalProps {
+  mode: 'create' | 'edit' | 'read';
+  open: boolean;
+  kind: ConfigKind;
+  workloadContent?: string;
+  onOk: (ret: IResponse<any>) => Promise<void>;
+  onCancel: () => Promise<void> | void;
+}
+
+const NewConfigEditorModal: FC<NewWorkloadEditorModalProps> = (props) => {
+  const { mode, open, workloadContent = '', onOk, onCancel, kind } = props;
+  const [content, setContent] = useState<string>(workloadContent);
+  useEffect(() => {
+    setContent(workloadContent);
+  }, [workloadContent]);
+
+  function handleEditorChange(value: string | undefined) {
+    setContent(value || '');
+  }
+
+  const title = useMemo(() => {
+    switch (mode) {
+      case 'read':
+        return '查看配置';
+      case 'edit':
+        return '编辑配置';
+      case 'create':
+        return '新增配置';
+    }
+  }, [mode]);
+  return (
+    <Modal
+      title={title}
+      open={open}
+      width={1000}
+      okText={'确定'}
+      cancelText={'取消'}
+      destroyOnClose={true}
+      onOk={async () => {
+        try {
+          const yamlObject = parse(content) as Record<string, string>;
+          const kind = _.get(yamlObject, 'kind');
+          const namespace = _.get(yamlObject, 'metadata.namespace');
+          const name = _.get(yamlObject, 'metadata.name');
+          if (mode === 'create') {
+            const ret = await CreateResource({
+              kind,
+              name,
+              namespace,
+              content: yamlObject,
+            });
+            await onOk(ret);
+            setContent('');
+          } else if (mode === 'edit') {
+            const ret = await PutResource({
+              kind,
+              name,
+              namespace,
+              content: yamlObject,
+            });
+            await onOk(ret);
+            setContent('');
+          }
+        } catch (e) {
+          console.log('e', e);
+        }
+      }}
+      onCancel={async () => {
+        await onCancel();
+        setContent('');
+      }}
+    >
+      <Form.Item label={'配置类型'}>
+        <Select
+          value={kind}
+          disabled
+          options={[
+            {
+              label: 'ConfigMap',
+              value: ConfigKind.ConfigMap,
+            },
+            {
+              label: 'Secret',
+              value: ConfigKind.Secret,
+            },
+          ]}
+          style={{
+            width: 200,
+          }}
+        />
+      </Form.Item>
+
+      <Editor
+        height="600px"
+        defaultLanguage="yaml"
+        value={content}
+        theme="vs"
+        options={{
+          theme: 'vs',
+          lineNumbers: 'on',
+          fontSize: 15,
+          readOnly: mode === 'read',
+          minimap: {
+            enabled: false,
+          },
+        }}
+        onChange={handleEditorChange}
+      />
+    </Modal>
+  );
+};
+
+export default NewConfigEditorModal;

--- a/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/components/configmap-table.tsx
+++ b/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/components/configmap-table.tsx
@@ -1,0 +1,154 @@
+import { Button, Popconfirm, Space, Table, TableColumnProps, Tag } from 'antd';
+import TagList from '@/components/tag-list';
+import { FC } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { GetResource } from '@/services/unstructured.ts';
+import { Config, GetConfigMaps } from '@/services/config.ts';
+import { extractPropagationPolicy } from '@/services/base.ts';
+
+interface ConfigMapTableProps {
+  labelTagNum?: number;
+  selectedWorkSpace: string;
+  searchText: string;
+  onViewConfigMapContent: (r: any) => void;
+  onEditConfigMapContent: (r: any) => void;
+  onDeleteConfigMapContent: (r: Config) => void;
+}
+
+const ConfigMapTable: FC<ConfigMapTableProps> = (props) => {
+  const {
+    labelTagNum,
+    selectedWorkSpace,
+    searchText,
+    onViewConfigMapContent,
+    onEditConfigMapContent,
+    onDeleteConfigMapContent,
+  } = props;
+  const columns: TableColumnProps<Config>[] = [
+    {
+      title: '命名空间',
+      key: 'namespaceName',
+      width: 200,
+      render: (_, r) => {
+        return r.objectMeta.namespace;
+      },
+    },
+    {
+      title: '配置名称',
+      key: 'configmapName',
+      width: 300,
+      render: (_, r) => {
+        return r.objectMeta.name;
+      },
+    },
+    {
+      title: '标签信息',
+      key: 'labelName',
+      align: 'left',
+      width: '30%',
+      render: (_, r) => {
+        if (!r?.objectMeta?.labels) {
+          return '-';
+        }
+        const params = Object.keys(r.objectMeta.labels).map((key) => {
+          return {
+            key: `${r.objectMeta.name}-${key}`,
+            value: `${key}:${r.objectMeta.labels[key]}`,
+          };
+        });
+        return <TagList tags={params} maxLen={labelTagNum} />;
+      },
+    },
+    {
+      title: '分发策略',
+      key: 'propagationPolicies',
+      render: (_, r) => {
+        const pp = extractPropagationPolicy(r);
+        return pp ? <Tag>{pp}</Tag> : '-';
+      },
+    },
+    {
+      title: '覆盖策略',
+      key: 'overridePolicies',
+      width: 150,
+      render: () => {
+        return '-';
+      },
+    },
+    {
+      title: '操作',
+      key: 'op',
+      width: 200,
+      render: (_, r) => {
+        return (
+          <Space.Compact>
+            <Button
+              size={'small'}
+              type="link"
+              onClick={async () => {
+                const ret = await GetResource({
+                  kind: r.typeMeta.kind,
+                  name: r.objectMeta.name,
+                  namespace: r.objectMeta.namespace,
+                });
+                onViewConfigMapContent(ret?.data);
+              }}
+            >
+              查看
+            </Button>
+            <Button
+              size={'small'}
+              type="link"
+              onClick={async () => {
+                const ret = await GetResource({
+                  kind: r.typeMeta.kind,
+                  name: r.objectMeta.name,
+                  namespace: r.objectMeta.namespace,
+                });
+                onEditConfigMapContent(ret?.data);
+              }}
+            >
+              编辑
+            </Button>
+
+            <Popconfirm
+              placement="topRight"
+              title={`确认要删除${r.objectMeta.name}配置么`}
+              onConfirm={() => {
+                onDeleteConfigMapContent(r);
+              }}
+              okText={'确认'}
+              cancelText={'取消'}
+            >
+              <Button size={'small'} type="link" danger>
+                删除
+              </Button>
+            </Popconfirm>
+          </Space.Compact>
+        );
+      },
+    },
+  ];
+  const { data, isLoading } = useQuery({
+    queryKey: ['GetConfigMaps', selectedWorkSpace, searchText],
+    queryFn: async () => {
+      const services = await GetConfigMaps({
+        namespace: selectedWorkSpace,
+        keyword: searchText,
+      });
+      return services.data || {};
+    },
+  });
+  return (
+    <Table
+      rowKey={(r: Config) =>
+        `${r.objectMeta.namespace}-${r.objectMeta.name}` || ''
+      }
+      columns={columns}
+      loading={isLoading}
+      dataSource={data?.items || []}
+    />
+  );
+};
+
+export default ConfigMapTable;

--- a/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/components/query-filter.tsx
+++ b/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/components/query-filter.tsx
@@ -1,0 +1,100 @@
+import { Button, Input, Segmented, Select } from 'antd';
+import { Icons } from '@/components/icons';
+import { FC } from 'react';
+import { FilterState } from '../types';
+import { ConfigKind } from '@/services/base.ts';
+
+interface QueryFilterProps {
+  filter: FilterState;
+  setFilter: (d: Partial<FilterState>) => void;
+  onNewConfig: () => void;
+  nsOptions: { title: string; value: string }[];
+  isNsDataLoading: boolean;
+}
+
+const QueryFilter: FC<QueryFilterProps> = (props) => {
+  const { filter, setFilter, onNewConfig, nsOptions, isNsDataLoading } = props;
+  return (
+    <>
+      <div className={'flex flex-row justify-between mb-4'}>
+        <div>
+          <Segmented
+            value={filter.kind}
+            style={{ marginBottom: 8 }}
+            onChange={(value) => {
+              // reset filter when switch workload kind
+              const k = value as ConfigKind;
+              if (k !== filter.kind) {
+                setFilter({
+                  kind: k,
+                  selectedWorkspace: '',
+                  searchText: '',
+                });
+              } else {
+                setFilter({
+                  kind: k,
+                });
+              }
+            }}
+            options={[
+              {
+                label: 'ConfigMap',
+                value: ConfigKind.ConfigMap,
+              },
+              {
+                label: 'Secret',
+                value: ConfigKind.Secret,
+              },
+            ]}
+          />
+        </div>
+        <Button
+          type={'primary'}
+          icon={<Icons.add width={16} height={16} />}
+          className="flex flex-row items-center"
+          onClick={onNewConfig}
+        >
+          新增配置
+        </Button>
+      </div>
+      <div className={'flex flex-row space-x-4 mb-4'}>
+        <h3 className={'leading-[32px]'}>命名空间</h3>
+        <Select
+          options={nsOptions}
+          className={'min-w-[200px]'}
+          value={filter.selectedWorkspace}
+          loading={isNsDataLoading}
+          showSearch
+          allowClear
+          onChange={(v) => {
+            setFilter({
+              ...filter,
+              selectedWorkspace: v,
+            });
+          }}
+        />
+        <Input.Search
+          placeholder={'按名称搜索'}
+          className={'w-[300px]'}
+          value={filter.searchText}
+          onChange={(e) => {
+            const input = e.currentTarget.value;
+            setFilter({
+              ...filter,
+              searchText: input,
+            });
+          }}
+          onPressEnter={(e) => {
+            const input = e.currentTarget.value;
+            setFilter({
+              ...filter,
+              searchText: input,
+            });
+          }}
+        />
+      </div>
+    </>
+  );
+};
+
+export default QueryFilter;

--- a/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/index.tsx
+++ b/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/index.tsx
@@ -1,8 +1,109 @@
 import Panel from '@/components/panel';
+import { ConfigKind } from '@/services/base.ts';
+import QueryFilter from './components/query-filter';
+import ConfigMapTable from './components/configmap-table';
+import { stringify } from 'yaml';
+import { useTagNum, useNamespace } from '@/hooks/index';
+import ConfigEditorModal from './components/config-editor-modal';
+import { useStore } from './store.ts';
+import { message } from 'antd';
+import { DeleteResource } from '@/services/unstructured.ts';
+import { useQueryClient } from '@tanstack/react-query';
+
 const ConfigPage = () => {
+  const { nsOptions, isNsDataLoading } = useNamespace({});
+  const { tagNum } = useTagNum();
+  const filter = useStore((state) => state.filter);
+  const { setFilter } = useStore((state) => {
+    return {
+      setFilter: state.setFilter,
+    };
+  });
+  const editor = useStore((state) => state.editor);
+  const { editConfig, viewConfig, createConfig, hideEditor } = useStore(
+    (state) => {
+      return {
+        editConfig: state.editConfig,
+        viewConfig: state.viewConfig,
+        createConfig: state.createConfig,
+        hideEditor: state.hideEditor,
+      };
+    },
+  );
+  const queryClient = useQueryClient();
+  const [messageApi, messageContextHolder] = message.useMessage();
   return (
     <Panel>
-      <h1 className="text-3xl font-bold underline">this is ConfigPage</h1>
+      <QueryFilter
+        filter={filter}
+        setFilter={(v) => {
+          setFilter(v);
+        }}
+        onNewConfig={createConfig}
+        nsOptions={nsOptions}
+        isNsDataLoading={isNsDataLoading}
+      />
+
+      {filter.kind === ConfigKind.ConfigMap && (
+        <ConfigMapTable
+          labelTagNum={tagNum}
+          searchText={filter.searchText}
+          selectedWorkSpace={filter.selectedWorkspace}
+          onViewConfigMapContent={(r) => {
+            viewConfig(stringify(r));
+          }}
+          onEditConfigMapContent={(r) => {
+            editConfig(stringify(r));
+          }}
+          onDeleteConfigMapContent={async (r) => {
+            try {
+              const ret = await DeleteResource({
+                kind: r.typeMeta.kind,
+                name: r.objectMeta.name,
+                namespace: r.objectMeta.namespace,
+              });
+              if (ret.code !== 200) {
+                await messageApi.error('删除配置失败');
+              }
+              await queryClient.invalidateQueries({
+                queryKey: ['GetConfigMaps'],
+                exact: false,
+              });
+            } catch (e) {
+              console.log('error', e);
+            }
+          }}
+        />
+      )}
+
+      <ConfigEditorModal
+        mode={editor.mode}
+        workloadContent={editor.content}
+        open={editor.show}
+        kind={filter.kind}
+        onOk={async (ret) => {
+          if (editor.mode === 'read') {
+            hideEditor();
+            return;
+          }
+
+          const msg = editor.mode === 'edit' ? '修改' : '新增';
+          if (ret.code === 200) {
+            await messageApi.success(`${msg}配置成功`);
+            hideEditor();
+            if (editor.mode === 'create') {
+              await queryClient.invalidateQueries({
+                queryKey: ['GetConfigMaps'],
+                exact: false,
+              });
+            }
+          } else {
+            await messageApi.error(`${msg}配置失败`);
+          }
+        }}
+        onCancel={hideEditor}
+      />
+      {messageContextHolder}
     </Panel>
   );
 };

--- a/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/store.ts
+++ b/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/store.ts
@@ -1,0 +1,78 @@
+import { create } from 'zustand';
+import { ConfigKind } from '@/services/base.ts';
+import { FilterState, EditorState } from './types.ts';
+
+type State = {
+  filter: FilterState;
+  editor: EditorState;
+};
+
+type Actions = {
+  setFilter: (k: Partial<FilterState>) => void;
+  viewConfig: (config: string) => void;
+  editConfig: (config: string) => void;
+  hideEditor: () => void;
+  createConfig: () => void;
+};
+
+export type Store = State & Actions;
+
+export const useStore = create<Store>((set) => ({
+  filter: {
+    kind: ConfigKind.ConfigMap,
+    selectedWorkspace: '',
+    searchText: '',
+  },
+  editor: {
+    show: false,
+    mode: 'create',
+    content: '',
+  },
+  setFilter: (k: Partial<FilterState>) => {
+    set((state) => {
+      const f = state.filter;
+      return {
+        filter: {
+          ...f,
+          ...k,
+        },
+      };
+    });
+  },
+  viewConfig: (config: string) => {
+    set({
+      editor: {
+        show: true,
+        mode: 'read',
+        content: config,
+      },
+    });
+  },
+  editConfig: (config: string) => {
+    set({
+      editor: {
+        show: true,
+        mode: 'edit',
+        content: config,
+      },
+    });
+  },
+  hideEditor: () => {
+    set({
+      editor: {
+        show: false,
+        mode: 'edit',
+        content: '',
+      },
+    });
+  },
+  createConfig: () => {
+    set({
+      editor: {
+        show: true,
+        mode: 'create',
+        content: '',
+      },
+    });
+  },
+}));

--- a/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/types.ts
+++ b/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/types.ts
@@ -1,0 +1,13 @@
+import { ConfigKind } from '@/services/base.ts';
+
+export interface FilterState {
+  kind: ConfigKind;
+  selectedWorkspace: string;
+  searchText: string;
+}
+
+export interface EditorState {
+  show: boolean;
+  mode: 'create' | 'edit' | 'read';
+  content: string;
+}

--- a/ui/apps/dashboard/src/services/base.ts
+++ b/ui/apps/dashboard/src/services/base.ts
@@ -61,3 +61,9 @@ export enum WorkloadKind {
   Deployment = 'deployment',
   Statefulset = 'statefulset',
 }
+
+export enum ConfigKind {
+  Unknown = '',
+  Secret = 'secret',
+  ConfigMap = 'configmap',
+}

--- a/ui/apps/dashboard/src/services/base.ts
+++ b/ui/apps/dashboard/src/services/base.ts
@@ -67,3 +67,14 @@ export enum ConfigKind {
   Secret = 'secret',
   ConfigMap = 'configmap',
 }
+
+export const propagationpolicyKey = 'propagationpolicy.karmada.io/name';
+// safely extract propagationpolicy
+export const extractPropagationPolicy = (r: { objectMeta: ObjectMeta }) => {
+  if (!r?.objectMeta?.annotations?.[propagationpolicyKey]) {
+    return '';
+  }
+  return r?.objectMeta?.annotations?.[propagationpolicyKey];
+};
+
+

--- a/ui/apps/dashboard/src/services/config.ts
+++ b/ui/apps/dashboard/src/services/config.ts
@@ -1,0 +1,37 @@
+import {
+  convertDataSelectQuery,
+  DataSelectQuery,
+  IResponse,
+  karmadaClient,
+  ObjectMeta,
+  TypeMeta,
+} from '@/services/base.ts';
+
+export interface Config {
+  objectMeta: ObjectMeta;
+  typeMeta: TypeMeta;
+}
+
+export async function GetConfigMaps(params: {
+  namespace?: string;
+  keyword?: string;
+}) {
+  const { namespace, keyword } = params;
+  const url = namespace ? `/configmap/${namespace}` : `/configmap`;
+  const requestData = {} as DataSelectQuery;
+  if (keyword) {
+    requestData.filterBy = ['name', keyword];
+  }
+  const resp = await karmadaClient.get<
+    IResponse<{
+      errors: string[];
+      listMeta: {
+        totalItems: number;
+      };
+      items: Config[];
+    }>
+  >(url, {
+    params: convertDataSelectQuery(requestData),
+  });
+  return resp.data;
+}

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       yaml:
         specifier: ^2.4.2
         version: 2.4.2
+      zustand:
+        specifier: ^4.5.4
+        version: 4.5.4(@types/react@18.3.1)(react@18.3.1)
     devDependencies:
       '@karmada/eslint-config-ts-react':
         specifier: workspace:*
@@ -3091,6 +3094,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.2.0:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -3203,6 +3211,21 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@4.5.4:
+    resolution: {integrity: sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -6380,6 +6403,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.2.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   util-deprecate@1.0.2: {}
 
   vite-plugin-svgr@4.2.0(rollup@4.17.2)(typescript@5.4.5)(vite@5.2.11(@types/node@20.12.11)(less@4.2.0)):
@@ -6495,3 +6522,10 @@ snapshots:
   yaml@2.4.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@4.5.4(@types/react@18.3.1)(react@18.3.1):
+    dependencies:
+      use-sync-external-store: 1.2.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.1
+      react: 18.3.1


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
1. add store management, we use zustand now
2. ui for configmap management
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
- implement management for configmap under the config
- introduct zustand as store management
```

