### PR TITLE
feat: implement replace-path-prefix vite plugin, for local dev

### DIFF
--- a/ui/apps/dashboard/vite.config.ts
+++ b/ui/apps/dashboard/vite.config.ts
@@ -1,8 +1,20 @@
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig, loadEnv, Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import path from 'path';
 import { dynamicBase } from 'vite-plugin-dynamic-base';
+
+const replacePathPrefixPlugin = (): Plugin => {
+  return {
+    name: 'replace-path-prefix',
+    transformIndexHtml: async (html) => {
+      if (process.env.NODE_ENV !== 'production') {
+        return html.replace('{{PathPrefix}}', '');
+      }
+      return html;
+    },
+  };
+};
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -12,6 +24,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react(),
       svgr(),
+      replacePathPrefixPlugin(),
       dynamicBase({
         publicPath: 'window.__dynamic_base__',
         transformIndexHtml: true,


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
As we modify the vite template for support feature of pathPrefix.
For the product development, the web app will replace the placeholder `{{PathPrefix}}`, the implement as following:
https://github.com/karmada-io/dashboard/blob/a8315b9b8a7a988e7756408c4ff08c93029f3908/cmd/web/app/web.go#L104-L117

But for local development,  the placeholder `{{PathPrefix}}` will not be replaced,  so we developd an vite plugin, for scenario of local development, the plugin will replace the placeholder `{{PathPrefix}}` before the html output to brower:
![image](https://github.com/user-attachments/assets/fafec949-28a2-454f-9dcf-b99a8259a3b1)



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
- add replace-path-prefix vite plugin
```

