### PR TITLE
fix: script typo error in cn readme

### DIFF
--- a/README_cn.md
+++ b/README_cn.md
@@ -28,7 +28,7 @@ kubectl config use-context karmada-host
 2.部署Karmada-dashboard, 这里我们选择通过nodePort来暴露karmada-dashboard相关的服务, 用nodePort的好处在于可以避免依赖ingress等资源，无依赖。
 
 ```bash
-kubectl apply -k overlays/nodeport-mode
+kubectl apply -k artifacts/overlays/nodeport-mode
 ```
 待安装部署过程完成后，打开浏览器访问http://your-karmada-host:32000即可开始使用karmada-dashboard。
 在使用之前，还需要生成jwt token才能访问dashboard。

--- a/README_cn.md
+++ b/README_cn.md
@@ -30,7 +30,7 @@ kubectl config use-context karmada-host
 ```bash
 kubectl apply -k artifacts/overlays/nodeport-mode
 ```
-待安装部署过程完成后，打开浏览器访问http://your-karmada-host:32000即可开始使用karmada-dashboard。
+待安装部署过程完成后，打开浏览器访问 http://your-karmada-host:32000 即可开始使用karmada-dashboard。
 在使用之前，还需要生成jwt token才能访问dashboard。
 
 3.创建Service-Account资源


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
CN readme doesn't sync with EN readme for install karmada dashboard in nodeport mode.

BTW, optimize the dashboard url in cn reamde
![image](https://github.com/user-attachments/assets/483ab1a7-5c38-47e8-a27a-d5320480eafc)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

