### PR TITLE
feat: add ui for job and cronjob

### DIFF
--- a/ui/apps/dashboard/src/pages/multicloud-resource-manage/workload/index.tsx
+++ b/ui/apps/dashboard/src/pages/multicloud-resource-manage/workload/index.tsx
@@ -258,6 +258,14 @@ const WorkloadPage = () => {
                 label: 'Daemonset',
                 value: WorkloadKind.Daemonset,
               },
+              {
+                label: 'Cronjob',
+                value: WorkloadKind.Cronjob,
+              },
+              {
+                label: 'Job',
+                value: WorkloadKind.Job,
+              },
             ]}
           />
         </div>
@@ -315,6 +323,7 @@ const WorkloadPage = () => {
         mode={editorState.mode}
         workloadContent={editorState.content}
         open={showModal}
+        kind={filter.kind}
         onOk={async (ret) => {
           const msg =
             editorState.mode === 'edit'

--- a/ui/apps/dashboard/src/pages/multicloud-resource-manage/workload/workload-detail-drawer.tsx
+++ b/ui/apps/dashboard/src/pages/multicloud-resource-manage/workload/workload-detail-drawer.tsx
@@ -162,6 +162,7 @@ const WorkloadDetailDrawer: FC<WorkloadDetailDrawerProps> = (props) => {
         className={styles['schedule-container']}
       >
         <Table
+          rowKey={(e) => e.objectMeta.uid}
           columns={columns}
           pagination={false}
           dataSource={eventsData?.events || []}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
- implement web ui for job and cronjob resources
- 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
- add `job/cronjob` tab switcher under the workload resource.
```

