### PR TITLE
Member cluster node

### DIFF
--- a/cmd/api/app/api.go
+++ b/cmd/api/app/api.go
@@ -25,7 +25,7 @@ import (
 	_ "github.com/karmada-io/dashboard/cmd/api/app/routes/deployment"
 	_ "github.com/karmada-io/dashboard/cmd/api/app/routes/ingress"
 	_ "github.com/karmada-io/dashboard/cmd/api/app/routes/job"
-	_ "github.com/karmada-io/dashboard/cmd/api/app/routes/member/node"
+	_ "github.com/karmada-io/dashboard/cmd/api/app/routes/member"
 	_ "github.com/karmada-io/dashboard/cmd/api/app/routes/namespace"
 	_ "github.com/karmada-io/dashboard/cmd/api/app/routes/overview"
 	_ "github.com/karmada-io/dashboard/cmd/api/app/routes/propagationpolicy"

--- a/cmd/api/app/router/setup.go
+++ b/cmd/api/app/router/setup.go
@@ -8,6 +8,7 @@ import (
 var (
 	router *gin.Engine
 	v1     *gin.RouterGroup
+	member *gin.RouterGroup
 )
 
 func init() {
@@ -18,6 +19,7 @@ func init() {
 	router = gin.Default()
 	_ = router.SetTrustedProxies(nil)
 	v1 = router.Group("/api/v1")
+	member = v1.Group("/member/:clustername")
 
 	router.GET("/livez", func(c *gin.Context) {
 		c.String(200, "livez")
@@ -33,4 +35,8 @@ func V1() *gin.RouterGroup {
 
 func Router() *gin.Engine {
 	return router
+}
+
+func MemberV1() *gin.RouterGroup {
+	return member
 }

--- a/cmd/api/app/routes/member/deployment/handler.go
+++ b/cmd/api/app/routes/member/deployment/handler.go
@@ -1,0 +1,76 @@
+package deployment
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"github.com/karmada-io/dashboard/cmd/api/app/router"
+	"github.com/karmada-io/dashboard/cmd/api/app/types/common"
+	"github.com/karmada-io/dashboard/pkg/client"
+	"github.com/karmada-io/dashboard/pkg/resource/deployment"
+	"github.com/karmada-io/dashboard/pkg/resource/event"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func handleGetMemberDeployments(c *gin.Context) {
+	karmadaClient := client.InClusterKarmadaClient()
+	_, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), c.Param("clustername"), metav1.GetOptions{})
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	memberClient := client.InClusterClientForMemberCluster(c.Param("clustername"))
+	namespace := common.ParseNamespacePathParameter(c)
+	dataSelect := common.ParseDataSelectPathParameter(c)
+	result, err := deployment.GetDeploymentList(memberClient, namespace, dataSelect)
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	common.Success(c, result)
+}
+
+func handleGetMemberDeploymentDetail(c *gin.Context) {
+	karmadaClient := client.InClusterKarmadaClient()
+	_, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), c.Param("clustername"), metav1.GetOptions{})
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	memberClient := client.InClusterClientForMemberCluster(c.Param("clustername"))
+	namespace := c.Param("namespace")
+	name := c.Param("deployment")
+	result, err := deployment.GetDeploymentDetail(memberClient, namespace, name)
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	common.Success(c, result)
+}
+
+func handleGetMemberDeploymentEvents(c *gin.Context) {
+	karmadaClient := client.InClusterKarmadaClient()
+	_, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), c.Param("clustername"), metav1.GetOptions{})
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	memberClient := client.InClusterClientForMemberCluster(c.Param("clustername"))
+	namespace := c.Param("namespace")
+	name := c.Param("deployment")
+	dataSelect := common.ParseDataSelectPathParameter(c)
+	result, err := event.GetResourceEvents(memberClient, dataSelect, namespace, name)
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	common.Success(c, result)
+}
+
+func init() {
+	r := router.MemberV1()
+	r.GET("/deployment", handleGetMemberDeployments)
+	r.GET("/deployment/:namespace", handleGetMemberDeployments)
+	r.GET("/deployment/:namespace/:deployment", handleGetMemberDeploymentDetail)
+	r.GET("/deployment/:namespace/:deployment/event", handleGetMemberDeploymentEvents)
+}

--- a/cmd/api/app/routes/member/member.go
+++ b/cmd/api/app/routes/member/member.go
@@ -1,0 +1,9 @@
+package member
+
+// Importing member route packages forces route registration
+import (
+	_ "github.com/karmada-io/dashboard/cmd/api/app/routes/member/deployment"
+	_ "github.com/karmada-io/dashboard/cmd/api/app/routes/member/namespace"
+	_ "github.com/karmada-io/dashboard/cmd/api/app/routes/member/node"
+	_ "github.com/karmada-io/dashboard/cmd/api/app/routes/member/pod"
+)

--- a/cmd/api/app/routes/member/namespace/handler.go
+++ b/cmd/api/app/routes/member/namespace/handler.go
@@ -1,0 +1,75 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"github.com/karmada-io/dashboard/cmd/api/app/router"
+	"github.com/karmada-io/dashboard/cmd/api/app/types/common"
+	"github.com/karmada-io/dashboard/pkg/client"
+	"github.com/karmada-io/dashboard/pkg/resource/event"
+	ns "github.com/karmada-io/dashboard/pkg/resource/namespace"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func handleGetMemberNamespace(c *gin.Context) {
+	karmadaClient := client.InClusterKarmadaClient()
+	_, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), c.Param("clustername"), metav1.GetOptions{})
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	memberClient := client.InClusterClientForMemberCluster(c.Param("clustername"))
+
+	dataSelect := common.ParseDataSelectPathParameter(c)
+	result, err := ns.GetNamespaceList(memberClient, dataSelect)
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	common.Success(c, result)
+}
+
+func handleGetMemberNamespaceDetail(c *gin.Context) {
+	karmadaClient := client.InClusterKarmadaClient()
+	_, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), c.Param("clustername"), metav1.GetOptions{})
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	memberClient := client.InClusterClientForMemberCluster(c.Param("clustername"))
+
+	name := c.Param("name")
+	result, err := ns.GetNamespaceDetail(memberClient, name)
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	common.Success(c, result)
+}
+
+func handleGetMemberNamespaceEvents(c *gin.Context) {
+	karmadaClient := client.InClusterKarmadaClient()
+	_, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), c.Param("clustername"), metav1.GetOptions{})
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	memberClient := client.InClusterClientForMemberCluster(c.Param("clustername"))
+
+	name := c.Param("name")
+	dataSelect := common.ParseDataSelectPathParameter(c)
+	result, err := event.GetNamespaceEvents(memberClient, dataSelect, name)
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	common.Success(c, result)
+}
+
+func init() {
+	r := router.MemberV1()
+	r.GET("/namespace", handleGetMemberNamespace)
+	r.GET("/namespace/:name", handleGetMemberNamespaceDetail)
+	r.GET("/namespace/:name/event", handleGetMemberNamespaceEvents)
+}

--- a/cmd/api/app/routes/member/node/handler.go
+++ b/cmd/api/app/routes/member/node/handler.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+
 	"github.com/gin-gonic/gin"
 	"github.com/karmada-io/dashboard/cmd/api/app/router"
 	"github.com/karmada-io/dashboard/cmd/api/app/types/common"
@@ -28,6 +29,6 @@ func handleGetClusterNode(c *gin.Context) {
 }
 
 func init() {
-	r := router.V1()
-	r.GET("/member/:clustername/node", handleGetClusterNode)
+	r := router.MemberV1()
+	r.GET("/node", handleGetClusterNode)
 }

--- a/cmd/api/app/routes/member/pod/handler.go
+++ b/cmd/api/app/routes/member/pod/handler.go
@@ -1,0 +1,55 @@
+package pod
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"github.com/karmada-io/dashboard/cmd/api/app/router"
+	"github.com/karmada-io/dashboard/cmd/api/app/types/common"
+	"github.com/karmada-io/dashboard/pkg/client"
+	"github.com/karmada-io/dashboard/pkg/resource/pod"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func handleGetMemberPod(c *gin.Context) {
+	karmadaClient := client.InClusterKarmadaClient()
+	_, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), c.Param("clustername"), metav1.GetOptions{})
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	memberClient := client.InClusterClientForMemberCluster(c.Param("clustername"))
+	dataSelect := common.ParseDataSelectPathParameter(c)
+	nsQuery := common.ParseNamespacePathParameter(c)
+	result, err := pod.GetPodList(memberClient, nsQuery, dataSelect)
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	common.Success(c, result)
+}
+
+func handleGetMemberPodDetail(c *gin.Context) {
+	karmadaClient := client.InClusterKarmadaClient()
+	_, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), c.Param("clustername"), metav1.GetOptions{})
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	memberClient := client.InClusterClientForMemberCluster(c.Param("clustername"))
+	namespace := c.Param("namespace")
+	name := c.Param("name")
+	result, err := pod.GetPodDetail(memberClient, namespace, name)
+	if err != nil {
+		common.Fail(c, err)
+		return
+	}
+	common.Success(c, result)
+}
+
+func init() {
+	r := router.MemberV1()
+	r.GET("/pod", handleGetMemberPod)
+	r.GET("/pod/:namespace", handleGetMemberPod)
+	r.GET("/pod/:namespace/:name", handleGetMemberPodDetail)
+}

--- a/cmd/api/app/routes/member/pod/handler.go
+++ b/cmd/api/app/routes/member/pod/handler.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// return a pods list
 func handleGetMemberPod(c *gin.Context) {
 	karmadaClient := client.InClusterKarmadaClient()
 	_, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), c.Param("clustername"), metav1.GetOptions{})
@@ -29,6 +30,7 @@ func handleGetMemberPod(c *gin.Context) {
 	common.Success(c, result)
 }
 
+// return a pod detail
 func handleGetMemberPodDetail(c *gin.Context) {
 	karmadaClient := client.InClusterKarmadaClient()
 	_, err := karmadaClient.ClusterV1alpha1().Clusters().Get(context.TODO(), c.Param("clustername"), metav1.GetOptions{})

--- a/pkg/resource/pod/common.go
+++ b/pkg/resource/pod/common.go
@@ -1,0 +1,38 @@
+package pod
+
+import (
+	"github.com/karmada-io/dashboard/pkg/dataselect"
+	api "k8s.io/api/core/v1"
+)
+
+type PodCell api.Pod
+
+func (self PodCell) GetProperty(name dataselect.PropertyName) dataselect.ComparableValue {
+	switch name {
+	case dataselect.NameProperty:
+		return dataselect.StdComparableString(self.ObjectMeta.Name)
+	case dataselect.CreationTimestampProperty:
+		return dataselect.StdComparableTime(self.ObjectMeta.CreationTimestamp.Time)
+	case dataselect.NamespaceProperty:
+		return dataselect.StdComparableString(self.ObjectMeta.Namespace)
+	default:
+		// if name is not supported then just return a constant dummy value, sort will have no effect.
+		return nil
+	}
+}
+
+func toCells(std []api.Pod) []dataselect.DataCell {
+	cells := make([]dataselect.DataCell, len(std))
+	for i := range std {
+		cells[i] = PodCell(std[i])
+	}
+	return cells
+}
+
+func fromCells(cells []dataselect.DataCell) []api.Pod {
+	std := make([]api.Pod, len(cells))
+	for i := range std {
+		std[i] = api.Pod(cells[i].(PodCell))
+	}
+	return std
+}

--- a/pkg/resource/pod/detail.go
+++ b/pkg/resource/pod/detail.go
@@ -1,0 +1,25 @@
+package pod
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type PodDeatil struct {
+	ObjectMeta metaV1.ObjectMeta `json:"objectMeta"`
+	TypeMeta   metaV1.TypeMeta   `json:"typeMeta"`
+	Spec       v1.PodSpec        `json:"podSpec"`
+	Status     v1.PodStatus      `json:"status"`
+}
+
+// GetPodDetail returns a Pod detail
+func GetPodDetail(client kubernetes.Interface, namespace, name string) (*v1.Pod, error) {
+	podData, err := client.CoreV1().Pods(namespace).Get(context.TODO(), name, metaV1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return podData, nil
+}

--- a/pkg/resource/pod/list.go
+++ b/pkg/resource/pod/list.go
@@ -1,0 +1,86 @@
+package pod
+
+import (
+	"log"
+
+	"github.com/karmada-io/dashboard/pkg/common/errors"
+	"github.com/karmada-io/dashboard/pkg/common/types"
+	"github.com/karmada-io/dashboard/pkg/dataselect"
+	"github.com/karmada-io/dashboard/pkg/resource/common"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Pod struct {
+	ObjectMeta types.ObjectMeta `json:"objectMeta"`
+	TypeMeta   types.TypeMeta   `json:"typeMeta"`
+	Status     v1.PodStatus     `json:"status"`
+}
+
+// PodList contains a list of pod.
+type PodList struct {
+	ListMeta types.ListMeta `json:"listMeta"`
+
+	// Unordered list of Pods
+	Items []Pod `json:"items"`
+
+	// List of non-critical errors, that occurred during resource retrieval.
+	Errors []error `json:"errors"`
+}
+
+// GetPodList returns a list of all Pods in all cluster.
+func GetPodList(client kubernetes.Interface, nsQuery *common.NamespaceQuery, dsQuery *dataselect.DataSelectQuery) (*PodList, error) {
+	log.Printf("Getting pods")
+	channels := &common.ResourceChannels{
+		PodList: common.GetPodListChannel(client, nsQuery, 1),
+	}
+
+	return GetPodListFromChannels(channels, dsQuery)
+}
+
+// GetPodListFromChannels returns a list of all Pods in the cluster reading required resource list once from the channels.
+func GetPodListFromChannels(channels *common.ResourceChannels, dsQuery *dataselect.DataSelectQuery) (*PodList, error) {
+	pods := <-channels.PodList.List
+	err := <-channels.PodList.Error
+	nonCriticalErrors, criticalError := errors.ExtractErrors(err)
+	if criticalError != nil {
+		return nil, criticalError
+	}
+
+	result := toPodList(pods.Items, nonCriticalErrors, dsQuery)
+
+	return result, nil
+}
+
+func toPod(meta metav1.ObjectMeta, status v1.PodStatus) Pod {
+	return Pod{
+		ObjectMeta: types.NewObjectMeta(meta),
+		TypeMeta:   types.NewTypeMeta(types.ResourceKindPod),
+		Status:     NewStatus(status),
+	}
+}
+
+func toPodList(pods []v1.Pod, nonCriticalErrors []error, dsQuery *dataselect.DataSelectQuery) *PodList {
+	result := &PodList{
+		Items:    make([]Pod, 0),
+		ListMeta: types.ListMeta{TotalItems: len(pods)},
+		Errors:   nonCriticalErrors,
+	}
+
+	podCells, filteredTotal := dataselect.GenericDataSelectWithFilter(toCells(pods), dsQuery)
+	pods = fromCells(podCells)
+	result.ListMeta = types.ListMeta{TotalItems: filteredTotal}
+
+	for _, item := range pods {
+		result.Items = append(result.Items, toPod(item.ObjectMeta, item.Status))
+	}
+
+	return result
+}
+
+func NewStatus(status v1.PodStatus) v1.PodStatus {
+	return v1.PodStatus{
+		Conditions: status.Conditions,
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
More granular resources should be displayed from the member cluster perspective. I add pod resource and a route to get pod list from member cluster.
Get member cluster namespace/deployment/pods.
Extract the common part of the member cluster route.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We have added some front-end pages to display these resources for member clusters, but there are still some issues left.
![微信图片_20241127032626](https://github.com/user-attachments/assets/c5bf6a20-8d64-430b-9201-16336bd1f0f3)


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

