### PR TITLE
feat: ui for op and cluster op

### DIFF
--- a/ui/apps/dashboard/src/pages/multicloud-policy-manage/override-policy/index.tsx
+++ b/ui/apps/dashboard/src/pages/multicloud-policy-manage/override-policy/index.tsx
@@ -1,12 +1,360 @@
+import i18nInstance from '@/utils/i18n';
+import { useMemo, useState } from 'react';
 import Panel from '@/components/panel';
+import {
+  Input,
+  Button,
+  Segmented,
+  TableColumnProps,
+  Space,
+  Table,
+  message,
+  Popconfirm,
+  Tag,
+  Select,
+} from 'antd';
+import { Icons } from '@/components/icons';
+import { useQuery } from '@tanstack/react-query';
+import {
+  DeleteOverridePolicy,
+  extractClusterNames,
+  extractRuleTypes,
+  GetClusterOverridePolicies,
+} from '@/services/overridepolicy.ts';
+import { stringify } from 'yaml';
+import { GetResource } from '@/services/unstructured.ts';
+import {
+  GetOverridePolicies,
+  OverridePolicy,
+  ClusterOverridePolicy,
+} from '@/services/overridepolicy.ts';
+import OverridePolicyEditorDrawer, {
+  OverridePolicyEditorDrawerProps,
+} from './override-policy-editor-drawer.tsx';
+import { GetNamespaces } from '@/services/namespace.ts';
+
+export type PolicyScope = 'namespace-scope' | 'cluster-scope';
 const OverridePolicyManage = () => {
+  const [filter, setFilter] = useState<{
+    policyScope: PolicyScope;
+    selectedWorkSpace: string;
+    searchText: string;
+  }>({
+    policyScope: 'namespace-scope',
+    selectedWorkSpace: '',
+    searchText: '',
+  });
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['GetOverridePolicies', JSON.stringify(filter)],
+    queryFn: async () => {
+      if (filter.policyScope === 'cluster-scope') {
+        console.log('x');
+        const ret = await GetClusterOverridePolicies({
+          keyword: filter.searchText,
+        });
+        return ret?.data?.clusterOverridePolicies || [];
+      } else {
+        const ret = await GetOverridePolicies({
+          namespace: filter.selectedWorkSpace,
+          keyword: filter.searchText,
+        });
+        return ret?.data?.overridepolicys || [];
+      }
+    },
+  });
+  const { data: nsData, isLoading: isNsDataLoading } = useQuery({
+    queryKey: ['GetNamespaces'],
+    queryFn: async () => {
+      const clusters = await GetNamespaces({});
+      return clusters.data || {};
+    },
+  });
+  const nsOptions = useMemo(() => {
+    if (!nsData?.namespaces) return [];
+    return nsData.namespaces.map((item) => {
+      return {
+        title: item.objectMeta.name,
+        value: item.objectMeta.name,
+      };
+    });
+  }, [nsData]);
+  const [editorDrawerData, setEditorDrawerData] = useState<
+    Omit<OverridePolicyEditorDrawerProps, 'onClose' | 'onUpdate' | 'onCreate'>
+  >({
+    open: false,
+    mode: 'detail',
+    name: '',
+    namespace: '',
+    overrideContent: '',
+    isClusterScope: filter.policyScope === 'cluster-scope',
+  });
+  const columns = [
+    filter.policyScope === 'namespace-scope' && {
+      title: '命名空间',
+      key: 'namespaceName',
+      width: 200,
+      render: (_v: string, r: OverridePolicy | ClusterOverridePolicy) => {
+        return r.objectMeta.namespace;
+      },
+    },
+    {
+      title: '策略名称',
+      key: 'policyName',
+      width: 200,
+      render: (_v: string, r: OverridePolicy | ClusterOverridePolicy) => {
+        return r.objectMeta.name;
+      },
+    },
+    {
+      title: '差异化策略类型',
+      key: 'ruleTypes',
+      dataIndex: 'ruleTypes',
+      render: (_v: string, r: OverridePolicy | ClusterOverridePolicy) => {
+        const ruleTypes = extractRuleTypes(r);
+        if (ruleTypes.length === 0) return '-';
+        return (
+          <div>
+            {ruleTypes.map((key) => (
+              <Tag key={`${r.objectMeta.name}-${key}`}>{key}</Tag>
+            ))}
+          </div>
+        );
+      },
+    },
+    {
+      title: '关联集群',
+      key: 'cluster',
+      render: (_v: string, r: OverridePolicy | ClusterOverridePolicy) => {
+        const clusters = extractClusterNames(r);
+        if (clusters.length === 0) return '-';
+        return (
+          <div>
+            {clusters.map((key) => (
+              <Tag key={`${r.objectMeta.name}-${key}`}>{key}</Tag>
+            ))}
+          </div>
+        );
+      },
+    },
+    {
+      title: '操作',
+      key: 'op',
+      width: 200,
+      render: (_v: string, r: OverridePolicy | ClusterOverridePolicy) => {
+        return (
+          <Space.Compact>
+            <Button
+              size={'small'}
+              type="link"
+              onClick={async () => {
+                const ret = await GetResource({
+                  name: r.objectMeta.name,
+                  namespace: r.objectMeta.namespace,
+                  kind:
+                    filter.policyScope === 'namespace-scope'
+                      ? 'overridepolicy'
+                      : 'clusteroverridepolicy',
+                });
+                const content = stringify(ret.data);
+                setEditorDrawerData({
+                  open: true,
+                  mode: 'detail',
+                  name: r.objectMeta.name,
+                  namespace: r.objectMeta.namespace,
+                  overrideContent: content,
+                });
+              }}
+            >
+              查看
+            </Button>
+            <Button
+              size={'small'}
+              type="link"
+              onClick={async () => {
+                const ret = await GetResource({
+                  name: r.objectMeta.name,
+                  namespace: r.objectMeta.namespace,
+                  kind:
+                    filter.policyScope === 'namespace-scope'
+                      ? 'overridepolicy'
+                      : 'clusteroverridepolicy',
+                });
+                const content = stringify(ret.data);
+                setEditorDrawerData({
+                  open: true,
+                  mode: 'edit',
+                  name: r.objectMeta.name,
+                  namespace: r.objectMeta.namespace,
+                  overrideContent: content,
+                });
+              }}
+            >
+              编辑
+            </Button>
+            <Popconfirm
+              placement="topRight"
+              title={`确认要删除${r.objectMeta.name}覆盖策略么`}
+              onConfirm={async () => {
+                const ret = await DeleteOverridePolicy({
+                  isClusterScope: filter.policyScope === 'cluster-scope',
+                  namespace: r.objectMeta.namespace,
+                  name: r.objectMeta.name,
+                });
+                if (ret.code === 200) {
+                  await messageApi.success(i18nInstance.t('删除成功'));
+                  await refetch();
+                } else {
+                  await messageApi.error(i18nInstance.t('删除失败'));
+                }
+              }}
+              okText={'确认'}
+              cancelText={'取消'}
+            >
+              <Button size={'small'} type="link" danger>
+                删除
+              </Button>
+            </Popconfirm>
+          </Space.Compact>
+        );
+      },
+    },
+  ].filter(Boolean) as TableColumnProps<
+    OverridePolicy | ClusterOverridePolicy
+  >[];
+  const [messageApi, messageContextHolder] = message.useMessage();
+
+  function resetEditorDrawerData() {
+    setEditorDrawerData({
+      open: false,
+      mode: 'detail',
+      name: '',
+      namespace: '',
+      overrideContent: '',
+    });
+  }
+
   return (
     <Panel>
-      <h1 className="text-3xl font-bold underline">
-        this is OverridePolicyManage
-      </h1>
+      <Segmented
+        value={filter.policyScope}
+        style={{
+          marginBottom: 8,
+        }}
+        onChange={(value) => {
+          setFilter({
+            ...filter,
+            policyScope: value as PolicyScope,
+          });
+        }}
+        options={[
+          {
+            label: '命名空间级别',
+            value: 'namespace-scope',
+          },
+          {
+            label: '集群级别',
+            value: 'cluster-scope',
+          },
+        ]}
+      />
+
+      <div className={'flex flex-row mb-4 justify-between'}>
+        <div className={'flex flex-row space-x-4'}>
+          {filter.policyScope === 'namespace-scope' && (
+            <>
+              <h3 className={'leading-[32px]'}>命名空间</h3>
+              <Select
+                options={nsOptions}
+                className={'min-w-[200px]'}
+                value={filter.selectedWorkSpace}
+                loading={isNsDataLoading}
+                showSearch
+                allowClear
+                placeholder={''}
+                onChange={(v) => {
+                  setFilter({
+                    ...filter,
+                    selectedWorkSpace: v,
+                  });
+                }}
+              />
+            </>
+          )}
+
+          <Input.Search
+            placeholder={'按名称检索，按下回车开始搜索'}
+            className={'w-[400px]'}
+            onPressEnter={(e) => {
+              const input = e.currentTarget.value;
+              setFilter({
+                ...filter,
+                searchText: input,
+              });
+            }}
+          />
+        </div>
+        <div>
+          <Button
+            type={'primary'}
+            icon={<Icons.add width={16} height={16} />}
+            className="flex flex-row items-center"
+            onClick={() => {
+              setEditorDrawerData({
+                open: true,
+                mode: 'create',
+                isClusterScope: filter.policyScope === 'cluster-scope',
+              });
+            }}
+          >
+            {filter.policyScope === 'namespace-scope'
+              ? '新增差异化策略'
+              : '新增集群差异化策略'}
+          </Button>
+        </div>
+      </div>
+      <Table
+        rowKey={(r: OverridePolicy) => r.objectMeta.name || ''}
+        columns={columns}
+        loading={isLoading}
+        dataSource={data || []}
+      />
+      <OverridePolicyEditorDrawer
+        open={editorDrawerData.open}
+        name={editorDrawerData.name}
+        namespace={editorDrawerData.namespace}
+        mode={editorDrawerData.mode}
+        overrideContent={editorDrawerData.overrideContent}
+        isClusterScope={editorDrawerData.isClusterScope}
+        onClose={() => {
+          setEditorDrawerData({
+            open: false,
+            mode: 'detail',
+            name: '',
+            namespace: '',
+            overrideContent: '',
+          });
+        }}
+        onCreate={async (ret) => {
+          if (ret.code === 200) {
+            await messageApi.success('新增覆盖策略成功');
+            resetEditorDrawerData();
+            await refetch();
+          } else {
+            await messageApi.error('新增覆盖策略失败');
+          }
+        }}
+        onUpdate={async (ret) => {
+          if (ret.code === 200) {
+            await messageApi.success('编辑覆盖策略成功');
+            resetEditorDrawerData();
+            await refetch();
+          } else {
+            await messageApi.error('编辑覆盖策略失败');
+          }
+        }}
+      />
+      {messageContextHolder}
     </Panel>
   );
 };
-
 export default OverridePolicyManage;

--- a/ui/apps/dashboard/src/pages/multicloud-policy-manage/override-policy/override-policy-editor-drawer.tsx
+++ b/ui/apps/dashboard/src/pages/multicloud-policy-manage/override-policy/override-policy-editor-drawer.tsx
@@ -1,0 +1,122 @@
+import { FC, useEffect, useState } from 'react';
+import Editor from '@monaco-editor/react';
+import { Button, Drawer, Space } from 'antd';
+import { PutResource } from '@/services/unstructured';
+import { IResponse } from '@/services/base.ts';
+import { parse } from 'yaml';
+import _ from 'lodash';
+import { CreateOverridePolicy } from '@/services/overridepolicy.ts';
+export interface OverridePolicyEditorDrawerProps {
+  open: boolean;
+  mode: 'create' | 'edit' | 'detail';
+  name?: string;
+  namespace?: string;
+  isClusterScope?: boolean;
+  overrideContent?: string;
+  onClose: () => void;
+  onUpdate: (ret: IResponse<string>) => void;
+  onCreate: (ret: IResponse<string>) => void;
+}
+function getTitle(
+  mode: OverridePolicyEditorDrawerProps['mode'],
+  name: string = '',
+) {
+  switch (mode) {
+    case 'create':
+      return '新增调度策略';
+    case 'edit':
+      return `编辑覆盖策略`;
+    case 'detail':
+      return `${name}策略详情`;
+    default:
+      return '';
+  }
+}
+const OverridePolicyEditorDrawer: FC<OverridePolicyEditorDrawerProps> = (
+  props,
+) => {
+  const {
+    open,
+    mode,
+    name,
+    namespace,
+    isClusterScope = false,
+    overrideContent,
+    onClose,
+    onCreate,
+    onUpdate,
+  } = props;
+  const [content, setContent] = useState<string>(overrideContent || '');
+  useEffect(() => {
+    setContent(overrideContent || '');
+  }, [overrideContent]);
+
+  function handleEditorChange(value: string | undefined) {
+    setContent(value || '');
+  }
+  return (
+    <Drawer
+      open={open}
+      title={getTitle(mode, name)}
+      width={800}
+      styles={{
+        body: {
+          padding: 0,
+        },
+      }}
+      closeIcon={false}
+      onClose={onClose}
+      footer={
+        <div className={'flex flex-row justify-end'}>
+          <Space>
+            <Button onClick={onClose}>取消</Button>
+            <Button
+              type="primary"
+              onClick={async () => {
+                const yamlObject = parse(content) as Record<string, string>;
+                if (mode === 'edit') {
+                  const updateRet = await PutResource({
+                    kind: 'overridepolicy',
+                    name: name || '',
+                    namespace: namespace || '',
+                    content: yamlObject,
+                  });
+                  onUpdate(updateRet as IResponse<string>);
+                } else {
+                  const name = _.get(yamlObject, 'metadata.name');
+                  const namespace = _.get(yamlObject, 'metadata.namespace');
+                  const createRet = await CreateOverridePolicy({
+                    isClusterScope,
+                    name: name || '',
+                    namespace: namespace || '',
+                    overrideData: content,
+                  });
+                  onCreate(createRet);
+                }
+              }}
+            >
+              确定
+            </Button>
+          </Space>
+        </div>
+      }
+    >
+      <Editor
+        defaultLanguage="yaml"
+        value={content}
+        theme="vs"
+        options={{
+          theme: 'vs',
+          lineNumbers: 'on',
+          fontSize: 15,
+          readOnly: mode === 'detail',
+          minimap: {
+            enabled: false,
+          },
+        }}
+        onChange={handleEditorChange}
+      />
+    </Drawer>
+  );
+};
+export default OverridePolicyEditorDrawer;

--- a/ui/apps/dashboard/src/services/overridepolicy.ts
+++ b/ui/apps/dashboard/src/services/overridepolicy.ts
@@ -1,0 +1,216 @@
+import {
+  convertDataSelectQuery,
+  DataSelectQuery,
+  IResponse,
+  karmadaClient,
+  ObjectMeta,
+  TypeMeta,
+} from './base';
+import { ClusterAffinity } from '@/services/propagationpolicy.ts';
+
+export interface OverridePolicy {
+  objectMeta: ObjectMeta;
+  typeMeta: TypeMeta;
+  resourceSelectors: ResourceSelector[];
+  overrideRules: OverrideRule[];
+}
+
+export interface ResourceSelector {
+  apiVersion: string;
+  kind: string;
+  namespace: string;
+  name: string;
+  labelSelector: LabelSelector;
+}
+
+export type LabelSelector = Record<string, string>;
+
+export interface OverrideRule {
+  targetCluster: ClusterAffinity;
+  overriders: Overriders;
+}
+
+export interface Overriders {
+  imageOverrider: ImageOverrider[];
+  commandOverrider: CommandOverrider[];
+  argsOverrider: ArgsOverrider[];
+  labelsOverrider: LabelsOverrider[];
+  annotationsOverrider: AnnotationsOverrider[];
+  plaintextOverrider: PlaintextOverrider[];
+}
+
+export interface ImageOverrider {
+  operator: 'add' | 'remove' | 'replace';
+  component: 'Registry' | 'Repository' | 'Tag';
+  value: string;
+}
+
+export interface CommandOverrider {
+  containerName: string;
+  operator: 'add' | 'remove';
+  value: string[];
+}
+
+export interface ArgsOverrider {
+  containerName: string;
+  operator: 'add' | 'remove';
+  value: string[];
+}
+
+export interface LabelsOverrider {
+  operator: 'add' | 'remove' | 'replace';
+  value: Record<string, string>;
+}
+
+export interface AnnotationsOverrider {
+  operator: 'add' | 'remove' | 'replace';
+  value: Record<string, string>;
+}
+
+export interface PlaintextOverrider {
+  operator: 'add' | 'remove' | 'replace';
+  path: string;
+  value: string;
+}
+
+export function extractOverridePolicyType(rule: OverrideRule): string {
+  const overriders = rule.overriders;
+  if (overriders.imageOverrider) {
+    return 'ImageOverrider';
+  }
+  if (overriders.commandOverrider) {
+    return 'CommandOverrider';
+  }
+  if (overriders.argsOverrider) {
+    return 'ArgsOverrider';
+  }
+  if (overriders.labelsOverrider) {
+    return 'LabelsOverrider';
+  }
+  if (overriders.annotationsOverrider) {
+    return 'AnnotationsOverrider';
+  }
+  if (overriders.plaintextOverrider) {
+    return 'PlaintextOverrider';
+  }
+  return '';
+}
+
+export function extractRuleTypes(op: OverridePolicy): string[] {
+  const ruleTypeSets = new Set<string>();
+  op.overrideRules.forEach((rule) => {
+    const type = extractOverridePolicyType(rule);
+    if (type) {
+      ruleTypeSets.add(type);
+    }
+  });
+  return Array.from(ruleTypeSets);
+}
+
+export function extractClusterNames(op: OverridePolicy): string[] {
+  const clusterNames = new Set<string>();
+  op.overrideRules.forEach((rule) => {
+    (rule.targetCluster?.clusterNames ?? []).forEach((clusterName) => {
+      clusterNames.add(clusterName);
+    });
+  });
+  return Array.from(clusterNames);
+}
+
+export async function GetOverridePolicies(params: {
+  namespace?: string;
+  keyword?: string;
+}) {
+  const { namespace } = params;
+  const requestData = {} as DataSelectQuery;
+  if (params.keyword) {
+    requestData.filterBy = ['name', params.keyword];
+  }
+  const resp = await karmadaClient.get<
+    IResponse<{
+      errors: string[];
+      listMeta: {
+        totalItems: number;
+      };
+      overridepolicys: OverridePolicy[];
+    }>
+  >(`/overridepolicy/${namespace}`, {
+    params: convertDataSelectQuery(requestData),
+  });
+  return resp.data;
+}
+
+export async function GetOverridePolicyDetail(params: {
+  namespace: string;
+  name: string;
+}) {
+  const { name, namespace } = params;
+  const url = `/overridepolicy/namespace/${namespace}/${name}`;
+  const resp = await karmadaClient.get<IResponse<OverridePolicy>>(url);
+  return resp.data;
+}
+
+export async function CreateOverridePolicy(params: {
+  isClusterScope: boolean;
+  namespace: string;
+  name: string;
+  overrideData: string;
+}) {
+  const resp = await karmadaClient.post<IResponse<string>>(
+    '/overridepolicy',
+    params,
+  );
+  return resp.data;
+}
+
+export async function UpdateOverridePolicy(params: {
+  isClusterScope: boolean;
+  namespace: string;
+  name: string;
+  overrideData: string;
+}) {
+  const resp = await karmadaClient.put<IResponse<string>>(
+    '/overridepolicy',
+    params,
+  );
+  return resp.data;
+}
+
+export async function DeleteOverridePolicy(params: {
+  isClusterScope: boolean;
+  namespace: string;
+  name: string;
+}) {
+  const resp = await karmadaClient.delete<IResponse<string>>(
+    '/overridepolicy',
+    {
+      data: params,
+    },
+  );
+  return resp.data;
+}
+
+export interface ClusterOverridePolicy {
+  objectMeta: ObjectMeta;
+  typeMeta: TypeMeta;
+  resourceSelectors: ResourceSelector[];
+  overrideRules: OverrideRule[];
+}
+export async function GetClusterOverridePolicies(params: { keyword?: string }) {
+  const requestData = {} as DataSelectQuery;
+  if (params.keyword) {
+    requestData.filterBy = ['name', params.keyword];
+  }
+  const resp = await karmadaClient.get<
+    IResponse<{
+      errors: string[];
+      listMeta: {
+        totalItems: number;
+      };
+      clusterOverridePolicies: ClusterOverridePolicy[];
+    }>
+  >('/clusteroverridepolicy', {
+    params: convertDataSelectQuery(requestData),
+  });
+  return resp.data;
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
as the op management (for ospp 2024) didn't finished, so we decided to finish the rest of work by ourselves. The pr contains ui for overridepolicy and clusteroverridepolicy management.
**Which issue(s) this PR fixes**:
https://github.com/karmada-io/dashboard/pull/132

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
- add management for overridepolicy and cluster overridepolicy
```

