### PR TITLE
pin github action runner to ubuntu-22.04 not the latest

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-fronted:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
 
   build-and-push-web:
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ "build-fronted" ]
     env:
       IMAGE_NAME: karmada/karmada-dashboard-web
@@ -88,7 +88,7 @@ jobs:
 
   build-and-push-api:
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       IMAGE_NAME: karmada/karmada-dashboard-api
       BINARY_NAME: karmada-dashboard-api


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Pin Github runner to the official release, not the latest. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The latest release might break our tests unexpectedly because the software installation might be different between releases.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

