### PR TITLE
fix delete namespace in control plane

### DIFF
--- a/cmd/api/app/routes/unstructured/handler.go
+++ b/cmd/api/app/routes/unstructured/handler.go
@@ -39,9 +39,6 @@ func handleDeleteResource(c *gin.Context) {
 	}
 	kind := c.Param("kind")
 	namespace := c.Param("namespace")
-	if namespace == "" {
-		namespace = "default"
-	}
 	name := c.Param("name")
 	deleteNow := c.Param("deleteNow") == "true"
 

--- a/ui/apps/dashboard/src/pages/multicloud-resource-manage/namespace/index.tsx
+++ b/ui/apps/dashboard/src/pages/multicloud-resource-manage/namespace/index.tsx
@@ -114,7 +114,7 @@ const NamespacePage = () => {
                   name: r.objectMeta.name,
                 });
                 if (ret.code === 200) {
-                  await messageApi.error(
+                  await messageApi.success(
                     i18nInstance.t(
                       '919994bf077d49f68f016811ffb5600e',
                       '删除命名空间成功',

--- a/ui/apps/dashboard/src/pages/multicloud-resource-manage/workload/index.tsx
+++ b/ui/apps/dashboard/src/pages/multicloud-resource-manage/workload/index.tsx
@@ -312,7 +312,13 @@ const WorkloadPage = () => {
         columns={columns}
         loading={isLoading}
         dataSource={
-          data ? data.deployments || data.statefulSets || data.daemonSets : []
+          data
+            ? data.deployments ||
+              data.statefulSets ||
+              data.daemonSets ||
+              data.jobs ||
+              data.items
+            : []
         }
       />
 

--- a/ui/apps/dashboard/src/services/workload.ts
+++ b/ui/apps/dashboard/src/services/workload.ts
@@ -81,6 +81,8 @@ export async function GetWorkloads(params: {
       deployments?: Workload[];
       statefulSets?: Workload[];
       daemonSets?: Workload[];
+      jobs?: Workload[];
+      items?: Workload[];
     }>
   >(url, {
     params: convertDataSelectQuery(requestData),


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
we use unified raw api to delete namespace resources, but it should not set default namespace when resource kind is namespace resource. Also fix the alert message, if delete namespace successfully, it should use `messageApi.success` method


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

