### PR TITLE
Add Playwright E2E testing framework to Karmada Dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,69 @@ jobs:
           go-version-file: go.mod
       - name: compile
         run: make all
+  e2e-frontend:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # Here support the latest three minor releases of Kubernetes, this can be considered to be roughly
+        # the same as the End of Life of the Kubernetes release: https://kubernetes.io/releases/
+        # Please remember to update the CI Schedule Workflow when we add a new version.
+        k8s: [ v1.31.0, v1.32.0, v1.33.0 ]
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed, if set to "true" but frees about 6 GB
+          tool-cache: false
+          # all of these default to true, but feel free to set to "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+      - name: Checkout karmada repo
+        uses: actions/checkout@v4
+        with:
+          repository: karmada-io/karmada
+          path: karmada
+      - name: setup e2e test environment
+        run: |
+          cd karmada
+          export CLUSTER_VERSION=kindest/node:${{ matrix.k8s }}
+          hack/local-up-karmada.sh
+      - name: Checkout dashboard repo
+        uses: actions/checkout@v4
+        with:
+          path: karmada-dashboard
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: pnpm/action-setup@v4
+        with:
+          # keep in sync with the packageManager version in `ui/package.json`
+          version: 9.1.2
+      - name: Install dependencies
+        run: |
+          echo "Start build"
+          pnpm --version
+          cd karmada-dashboard/ui
+          pnpm install
+          pnpm turbo build
+      - name: Install Playwright Browsers
+        run: |
+          cd karmada-dashboard/ui/apps/dashboard
+          pnpm exec playwright install --with-deps
+      - name: Run Playwright tests
+        run: |
+          cd karmada-dashboard/ui/apps/dashboard
+          pnpm exec playwright test
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-${{ matrix.k8s }}
+          path: karmada-dashboard/ui/apps/dashboard/playwright-report/
+          retention-days: 30
+

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@ cmd/ops
 .api.pid
 .tmp
 
+reports
+
+test-results/
+
+# Playwright
+playwright-report/
+playwright/.cache/
+

--- a/ui/apps/dashboard/e2e/login.spec.ts
+++ b/ui/apps/dashboard/e2e/login.spec.ts
@@ -1,0 +1,44 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { test, expect } from '@playwright/test';
+
+test('should navigate to the login page', async ({ page }) => {
+  // Navigate to the home page
+  await page.goto('/');
+
+  await page.waitForTimeout(2 * 1000);
+
+  await expect(page.getByText('Sign in')).toBeVisible({
+    timeout: 10000,
+  });
+});
+
+/*
+test('should navigate to overview after login', async ({ page }) => {
+  // Navigate to the home page
+  await page.goto('/');
+
+  await page.waitForTimeout(2 * 1000);
+
+  await page.getByTestId('login-input').fill('{token placeholder}')
+
+  await page.getByTestId('login-button').click()
+  await expect(page).toHaveURL(/overview/, {
+    timeout: 5* 1000
+  })
+});
+*/

--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -10,7 +10,9 @@
     "lint": "eslint . --ext ts,tsx,js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "i18n:init": "i18n-tool init",
-    "i18n:scan": "i18n-tool scan"
+    "i18n:scan": "i18n-tool scan",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed"
   },
   "keywords": [],
   "author": "",
@@ -51,7 +53,9 @@
   },
   "devDependencies": {
     "@karmada/eslint-config-ts-react": "workspace:*",
+    "@playwright/test": "^1.53.2",
     "@types/lodash": "^4.17.10",
+    "@types/node": "^20.12.11",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/ui/apps/dashboard/playwright.config.ts
+++ b/ui/apps/dashboard/playwright.config.ts
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { defineConfig, devices } from '@playwright/test';
+
+// Use process.env.PORT by default and fallback to port 3000
+const PORT = process.env.PORT || 5173;
+
+// Set webServer.url and use.baseURL with the location of the WebServer
+const baseURL = `http://localhost:${PORT}`;
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  // Timeout per test
+  timeout: 30 * 1000,
+
+  // Look for test files in the "tests" directory, relative to this configuration file.
+  testDir: 'e2e',
+
+  // Retry on CI only.
+  retries: process.env.CI ? 2 : 0,
+
+  // Opt out of parallel tests on CI.
+  workers: process.env.CI ? 1 : undefined,
+
+  // Reporter to use
+  reporter: 'html',
+
+  // Artifacts folder where screenshots, videos, and traces are stored.
+  outputDir: 'test-results/',
+
+  use: {
+    // Use baseURL so to make navigations relative.
+    // More information: https://playwright.dev/docs/api/class-page#page-goto
+    baseURL,
+
+    // Retry a test if its failing with enabled tracing. This allows you to analyse the DOM, console logs, network traffic etc.
+    // More information: https://playwright.dev/docs/trace-viewer
+    trace: 'retry-with-trace',
+
+    // All available context options: https://playwright.dev/docs/api/class-browser#browser-new-context
+    // contextOptions: {
+    //   ignoreHTTPSErrors: true,
+    // },
+  },
+
+  // Configure projects for major browsers.
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  // Run your local dev server before starting the tests:
+  // https://playwright.dev/docs/test-advanced#launching-a-development-web-server-during-the-tests
+  webServer: {
+    command: 'pnpm dev',
+    url: baseURL,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/ui/apps/dashboard/src/pages/login/index.tsx
+++ b/ui/apps/dashboard/src/pages/login/index.tsx
@@ -69,6 +69,7 @@ const LoginPage = () => {
           />
 
           <Input.TextArea
+            data-testid="login-input"
             className={'mt-4'}
             rows={6}
             value={authToken}
@@ -80,6 +81,7 @@ const LoginPage = () => {
           <div className={'mt-4'}>
             <Button
               type="primary"
+              data-testid="login-button"
               onClick={async () => {
                 try {
                   const ret = await Login(authToken);

--- a/ui/apps/dashboard/tsconfig.json
+++ b/ui/apps/dashboard/tsconfig.json
@@ -23,6 +23,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"],
+  "include": ["src", "playwright.config.ts", "e2e"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -111,9 +111,15 @@ importers:
       '@karmada/eslint-config-ts-react':
         specifier: workspace:*
         version: link:../../packages/eslint-config-ts-react
+      '@playwright/test':
+        specifier: ^1.53.2
+        version: 1.53.2
       '@types/lodash':
         specifier: ^4.17.10
         version: 4.17.10
+      '@types/node':
+        specifier: ^20.12.11
+        version: 20.12.11
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.11
@@ -1025,6 +1031,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.53.2':
+    resolution: {integrity: sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rc-component/async-validator@5.0.3':
     resolution: {integrity: sha512-eN5chKrc0ANerXjLJuoqh/YJpor0u4T1bgaph5BPh42cJ2afDihaHJ2Mh3Up3XIFk05EfKG4nIQxbqC6y2eM4Q==}
@@ -2488,6 +2499,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3373,6 +3389,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.53.2:
+    resolution: {integrity: sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.53.2:
+    resolution: {integrity: sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
@@ -5203,6 +5229,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.53.2':
+    dependencies:
+      playwright: 1.53.2
+
   '@rc-component/async-validator@5.0.3':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -6877,6 +6907,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -7719,6 +7752,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.53.2: {}
+
+  playwright@1.53.2:
+    dependencies:
+      playwright-core: 1.53.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.0.0: {}
 


### PR DESCRIPTION
## Summary
Add Playwright E2E testing framework to Karmada Dashboard

## What's Added
Basic Playwright configuration for E2E testing
Login page test as foundation for future test coverage
NPM scripts for running E2E tests
## Why This Change
Establishes automated testing foundation for UI stability
Enables regression testing during development
Provides framework for testing critical user workflows
## Test Coverage
 Login page loads and renders correctly
 Full authentication flow (ready for expansion)
## Usage
```
pnpm test:e2e        # headless mode
pnpm test:e2e:headed # with browser UI
```