### PR TITLE
feat(api): add chat handler and integrate mcp/llm clients

### DIFF
--- a/cmd/api/app/api.go
+++ b/cmd/api/app/api.go
@@ -141,7 +141,17 @@ func run(ctx context.Context, opts *options.Options) error {
 		if opts.MCPTransportMode == "sse" {
 			mcpOpts = append(mcpOpts, mcpclient.WithSSEMode(opts.MCPSSEEndpoint))
 		} else {
-			mcpOpts = append(mcpOpts, mcpclient.WithStdioMode(opts.MCPServerPath))
+			karmadaMCPServerArguments := []string{
+				"--karmada-kubeconfig", opts.KarmadaKubeConfig,
+				"--karmada-context", opts.KarmadaContext,
+			}
+			if opts.SkipKarmadaApiserverTLSVerify {
+				karmadaMCPServerArguments = append(karmadaMCPServerArguments, "--skip-karmada-apiserver-tls-verify")
+			}
+			mcpOpts = append(mcpOpts,
+				mcpclient.WithStdioMode(opts.MCPServerPath),
+				mcpclient.WithStdioArguments(karmadaMCPServerArguments...),
+			)
 		}
 
 		var err error

--- a/cmd/api/app/routes/assistant/assistant.go
+++ b/cmd/api/app/routes/assistant/assistant.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Karmada Authors.
+Copyright 2025 The Karmada Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -68,6 +68,9 @@ func Answering(c *gin.Context) {
 
 	if err := session.run(); err != nil {
 		klog.Errorf("Answering session run failed: %v", err)
+		// Send error response to client
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to process your request"})
+		return
 	}
 }
 

--- a/cmd/api/app/routes/assistant/sse_helper.go
+++ b/cmd/api/app/routes/assistant/sse_helper.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assistant
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
+)
+
+// setupSSEHeaders sets up Server-Sent Events headers
+func setupSSEHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+}
+
+// sendSSEEvent sends a ChatResponse as an SSE event
+func sendSSEEvent(c *gin.Context, msg ChatResponse) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		klog.Errorf("Failed to marshal SSE message: %v", err)
+		return fmt.Errorf("failed to marshal SSE message: %w", err)
+	}
+
+	fmt.Fprintf(c.Writer, "data: %s\n\n", data)
+	c.Writer.Flush()
+	return nil
+}
+
+// sendCompletionSignal sends a completion event to the client
+func sendCompletionSignal(c *gin.Context) {
+	completionMsg := ChatResponse{
+		Type:    "completion",
+		Content: nil,
+	}
+	if err := sendSSEEvent(c, completionMsg); err != nil {
+		klog.Errorf("Failed to send completion signal: %v", err)
+	}
+}
+
+// sendErrorEvent sends an error event to the client
+func sendErrorEvent(c *gin.Context, errorMsg string) {
+	msg := ChatResponse{
+		Type:    "error",
+		Content: errorMsg,
+	}
+	if err := sendSSEEvent(c, msg); err != nil {
+		klog.Errorf("Failed to send error event: %v", err)
+	}
+}

--- a/cmd/api/app/routes/assistant/stream.go
+++ b/cmd/api/app/routes/assistant/stream.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assistant
+
+import (
+	"errors"
+	"io"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sashabaranov/go-openai"
+	"k8s.io/klog/v2"
+
+	"github.com/karmada-io/dashboard/pkg/llm"
+	"github.com/karmada-io/dashboard/pkg/mcpclient"
+)
+
+// streamResponse streams the LLM response and accumulates tool calls
+func streamResponse(c *gin.Context, resp *openai.ChatCompletionStream, toolCallBuffer map[int]*openai.ToolCall, enableMCP bool, mcpClient *mcpclient.MCPClient) error {
+	for {
+		// Check if context is cancelled
+		select {
+		case <-c.Request.Context().Done():
+			klog.Infof("Client disconnected during streaming")
+			return c.Request.Context().Err()
+		default:
+		}
+
+		response, err := resp.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			klog.Errorf("Error receiving stream response: %v", err)
+			return err
+		}
+
+		if len(response.Choices) > 0 {
+			choice := response.Choices[0]
+
+			// Handle regular content
+			if choice.Delta.Content != "" {
+				msg := ChatResponse{
+					Type:    "content",
+					Content: choice.Delta.Content,
+				}
+				if err := sendSSEEvent(c, msg); err != nil {
+					return err
+				}
+			}
+
+			// Handle tool calls - accumulate them
+			if enableMCP && mcpClient != nil && choice.Delta.ToolCalls != nil {
+				accumulateToolCalls(choice.Delta.ToolCalls, toolCallBuffer)
+			}
+		}
+	}
+	return nil
+}
+
+// makeFinalCall makes a final LLM call with tool results and streams the response
+func makeFinalCall(c *gin.Context, client *openai.Client, messages []openai.ChatCompletionMessage, assistantMessage openai.ChatCompletionMessage, toolResponses []openai.ChatCompletionMessage) error {
+	messages = append(messages, assistantMessage)
+	messages = append(messages, toolResponses...)
+
+	finalChatReq := openai.ChatCompletionRequest{
+		Model:    llm.GetLLMModel(),
+		Messages: messages,
+		Stream:   true,
+	}
+
+	finalResp, err := client.CreateChatCompletionStream(c.Request.Context(), finalChatReq)
+	if err != nil {
+		klog.Errorf("Failed to create final chat completion stream: %v", err)
+		sendErrorEvent(c, "Failed to generate response after tool execution")
+		return err
+	}
+	defer finalResp.Close()
+
+	for {
+		// Check if context is cancelled
+		select {
+		case <-c.Request.Context().Done():
+			klog.Infof("Client disconnected during final streaming")
+			return c.Request.Context().Err()
+		default:
+		}
+
+		response, err := finalResp.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			klog.Errorf("Error receiving final stream response: %v", err)
+			return err
+		}
+
+		if len(response.Choices) > 0 && response.Choices[0].Delta.Content != "" {
+			msg := ChatResponse{Type: "content", Content: response.Choices[0].Delta.Content}
+			if err := sendSSEEvent(c, msg); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/api/app/routes/assistant/tool_executor.go
+++ b/cmd/api/app/routes/assistant/tool_executor.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assistant
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sashabaranov/go-openai"
+	"k8s.io/klog/v2"
+
+	"github.com/karmada-io/dashboard/pkg/mcpclient"
+)
+
+// executeTool executes a single tool call and returns the result message
+func executeTool(toolCall *openai.ToolCall, mcpClient *mcpclient.MCPClient, c *gin.Context) openai.ChatCompletionMessage {
+	toolName := strings.TrimPrefix(toolCall.Function.Name, "mcp_")
+	var args map[string]interface{}
+	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
+		klog.Errorf("Failed to parse tool arguments: %v, args: %s", err, toolCall.Function.Arguments)
+
+		// Return error message to LLM so it can handle the error
+		errorMsg := fmt.Sprintf("Error parsing tool arguments: %v", err)
+		return openai.ChatCompletionMessage{
+			Role:       openai.ChatMessageRoleTool,
+			Content:    errorMsg,
+			Name:       toolCall.Function.Name,
+			ToolCallID: toolCall.ID,
+		}
+	}
+
+	// Send tool call start notification to the client
+	toolStartInfo := ToolCallInfo{
+		ToolName: toolName,
+		Args:     args,
+		Result:   "Executing...",
+	}
+	msg := ChatResponse{Type: "tool_call_start", ToolCall: &toolStartInfo}
+	if err := sendSSEEvent(c, msg); err != nil {
+		klog.Errorf("Failed to send tool call start event: %v", err)
+	}
+
+	result, err := mcpClient.CallTool(toolName, args)
+	if err != nil {
+		klog.Errorf("Failed to execute tool %s: %v", toolName, err)
+		result = fmt.Sprintf("Error executing tool %s: %v", toolName, err)
+	}
+
+	// Send tool call completion info to the client for visibility
+	toolInfo := ToolCallInfo{
+		ToolName: toolName,
+		Args:     args,
+		Result:   result,
+	}
+	msg = ChatResponse{Type: "tool_call", ToolCall: &toolInfo}
+	if err := sendSSEEvent(c, msg); err != nil {
+		klog.Errorf("Failed to send tool call completion event: %v", err)
+	}
+
+	// Return tool result for the next AI call
+	return openai.ChatCompletionMessage{
+		Role:       openai.ChatMessageRoleTool,
+		Content:    result,
+		Name:       toolCall.Function.Name,
+		ToolCallID: toolCall.ID,
+	}
+}
+
+// accumulateToolCalls accumulates streamed tool call chunks into the buffer
+func accumulateToolCalls(toolCalls []openai.ToolCall, toolCallBuffer map[int]*openai.ToolCall) {
+	for _, toolCall := range toolCalls {
+		if toolCall.Index == nil {
+			continue
+		}
+		index := *toolCall.Index
+		if toolCallBuffer[index] == nil {
+			toolCallBuffer[index] = &openai.ToolCall{Index: &index}
+		}
+		if toolCall.ID != "" {
+			toolCallBuffer[index].ID = toolCall.ID
+		}
+		if toolCall.Type != "" {
+			toolCallBuffer[index].Type = toolCall.Type
+		}
+		if toolCall.Function.Name != "" {
+			toolCallBuffer[index].Function.Name = toolCall.Function.Name
+		}
+		if toolCall.Function.Arguments != "" {
+			toolCallBuffer[index].Function.Arguments += toolCall.Function.Arguments
+		}
+	}
+}
+
+// processToolCalls executes all accumulated tool calls and makes a final LLM call with results
+func processToolCalls(c *gin.Context, client *openai.Client, messages []openai.ChatCompletionMessage, toolCallBuffer map[int]*openai.ToolCall, mcpClient *mcpclient.MCPClient) error {
+	// Send notification that tool processing is starting
+	processingMsg := ChatResponse{Type: "tool_processing", Content: "Processing tool calls..."}
+	if err := sendSSEEvent(c, processingMsg); err != nil {
+		return fmt.Errorf("failed to send tool processing notification: %w", err)
+	}
+
+	// Append the assistant's response (tool calls) to the message history
+	assistantMessage := openai.ChatCompletionMessage{
+		Role:    openai.ChatMessageRoleAssistant,
+		Content: "",
+	}
+	for _, toolCall := range toolCallBuffer {
+		assistantMessage.ToolCalls = append(assistantMessage.ToolCalls, *toolCall)
+	}
+
+	// Execute tools and gather results
+	var toolResponses []openai.ChatCompletionMessage
+	for _, toolCall := range toolCallBuffer {
+		if toolCall.Function.Name != "" && toolCall.Function.Arguments != "" {
+			toolResponse := executeTool(toolCall, mcpClient, c)
+			if toolResponse.Role != "" { // Only add valid responses
+				toolResponses = append(toolResponses, toolResponse)
+			}
+		}
+	}
+
+	// Send notification that tool processing is complete
+	completedMsg := ChatResponse{Type: "tool_processing_complete", Content: "Tool processing complete, generating response..."}
+	if err := sendSSEEvent(c, completedMsg); err != nil {
+		return fmt.Errorf("failed to send tool processing complete notification: %w", err)
+	}
+
+	// Make a second call to OpenAI with the tool results
+	if len(toolResponses) > 0 {
+		if err := makeFinalCall(c, client, messages, assistantMessage, toolResponses); err != nil {
+			return fmt.Errorf("failed to make final call: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/api/app/routes/assistant/types.go
+++ b/cmd/api/app/routes/assistant/types.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assistant
+
+// ChatRequest represents the request payload for chat endpoint
+type ChatRequest struct {
+	Message   string        `json:"message"`
+	History   []ChatMessage `json:"history,omitempty"`
+	EnableMCP bool          `json:"enableMcp,omitempty"`
+}
+
+// ChatMessage represents a message in the conversation
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// ChatResponse represents the response for chat endpoint
+type ChatResponse struct {
+	Type     string        `json:"type"`
+	Content  interface{}   `json:"content"`
+	ToolCall *ToolCallInfo `json:"toolCall,omitempty"`
+}
+
+// ToolCallInfo represents information about a tool call
+type ToolCallInfo struct {
+	ToolName string                 `json:"toolName"`
+	Args     map[string]interface{} `json:"args"`
+	Result   string                 `json:"result"`
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
This PR introduces the main chat handler and exposes the /api/v1/chat API endpoint. This handler serves as the core backend logic for the AI Assistant, orchestrating the MCP and LLM clients to:
   - Process user messages.
   - Handle tool calls to the MCP server.
   - Stream responses back to the frontend.

**Which issue(s) this PR fixes**:
Part of #273 

**Special notes for your reviewer**:
It depends on the changes from PR #275 & PR #276 。

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

