### PR TITLE
Auto update npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,20 @@ updates:
     # Check for updates to GitHub Actions every week
     interval: "weekly"
     
-- package-ecosystem: docker
-  directory: /cluster/images/
+- package-ecosystem: "docker"
+  directory: "/cluster/images/"
   schedule:
-    interval: weekly
+    # Check for updates to Docker images every week
+    interval: "weekly"
+
+- package-ecosystem: "npm"
+  directory: "/ui"
+  schedule:
+    # Check for updates to npm packages every week
+    interval: "weekly"
+
+- package-ecosystem: "npm"
+  directory: "/ui/apps/dashboard"
+  schedule:
+    # Check for updates to npm packages in dashboard app every week
+    interval: "weekly"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Add dependabot configuration to update npm packages every week.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We are using `weekly` interval because:
- Less noise: Daily updates can create too many PRs, especially for us with many dependencies
- More stable: Gives new package versions time to surface any issues before they're proposed to our project
- Sustainable: We won't get overwhelmed reviewing dependency updates
- Common practice: Weekly is the most common interval for most projects

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

