### PR TITLE
Fix type inconsistency in SecretTable

### DIFF
--- a/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/components/secret-table.tsx
+++ b/ui/apps/dashboard/src/pages/multicloud-resource-manage/config/components/secret-table.tsx
@@ -21,7 +21,7 @@ import TagList from '@/components/tag-list';
 import { FC } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { GetResource } from '@/services/unstructured.ts';
-import { Config, GetSecrets, Secret } from '@/services/config.ts';
+import { GetSecrets, Secret } from '@/services/config.ts';
 interface SecretTableProps {
   labelTagNum?: number;
   selectedWorkSpace: string;
@@ -49,7 +49,7 @@ const SecretTable: FC<SecretTableProps> = (props) => {
       return services.data || {};
     },
   });
-  const columns: TableColumnProps<Config>[] = [
+  const columns: TableColumnProps<Secret>[] = [
     {
       title: i18nInstance.t('a4b28a416f0b6f3c215c51e79e517298', '命名空间'),
       key: 'namespaceName',
@@ -164,7 +164,7 @@ const SecretTable: FC<SecretTableProps> = (props) => {
   ];
   return (
     <Table
-      rowKey={(r: Config) =>
+      rowKey={(r: Secret) =>
         `${r.objectMeta.namespace}-${r.objectMeta.name}` || ''
       }
       columns={columns}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**: In secret-table.tsx, the table columns are defined using the Config type, while the component props and data source use the Secret type. Although they are structurally identical in config.ts, this inconsistency makes the code harder to maintain and less type-safe if the two resources diverge in the future.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

