### PR TITLE
test: increase unit test coverage for pkg/client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,20 @@ jobs:
         run: hack/verify-license.sh
       - name: lint
         run: hack/verify-staticcheck.sh
+
+  unit-test:
+    name: unit test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6
+      - name: install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Run tests
+        run: make test
+
   build-frontend:
     runs-on: ubuntu-22.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,16 @@ $(TARGETS):
 	hack/build.sh $@
 
 ###################
+# Test Targets    #
+###################
+
+# Run unit tests
+.PHONY: test
+test:
+	go test ./pkg/client/...
+
+
+###################
 # Docker Images   #
 ###################
 

--- a/pkg/client/auth_test.go
+++ b/pkg/client/auth_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestHasAuthorizationHeader(t *testing.T) {
+	testCases := []struct {
+		name     string
+		header   string
+		expected bool
+	}{
+		{
+			name:     "Valid Bearer token",
+			header:   "Bearer my-token",
+			expected: true,
+		},
+		{
+			name:     "Missing Bearer prefix",
+			header:   "my-token",
+			expected: false,
+		},
+		{
+			name:     "Empty header",
+			header:   "",
+			expected: false,
+		},
+		{
+			name:     "Bearer prefix only",
+			header:   "Bearer ",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			if tc.header != "" {
+				req.Header.Set(authorizationHeader, tc.header)
+			}
+			result := HasAuthorizationHeader(req)
+			if result != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetBearerToken(t *testing.T) {
+	testCases := []struct {
+		name        string
+		headerValue string
+		expected    string
+	}{
+		{
+			name:        "Valid Bearer token",
+			headerValue: "Bearer my-secret-token",
+			expected:    "my-secret-token",
+		},
+		{
+			name:        "Missing Bearer prefix",
+			headerValue: "my-secret-token",
+			expected:    "my-secret-token", // extractBearerToken just trims prefix
+		},
+		{
+			name:        "Empty header",
+			headerValue: "",
+			expected:    "",
+		},
+		{
+			name:        "Bearer prefix only",
+			headerValue: "Bearer ",
+			expected:    "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			if tc.headerValue != "" {
+				req.Header.Set(authorizationHeader, tc.headerValue)
+			}
+			result := GetBearerToken(req)
+			if result != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestHandleImpersonation(t *testing.T) {
+	testCases := []struct {
+		name     string
+		headers  map[string][]string
+		expected *clientcmdapi.AuthInfo
+	}{
+		{
+			name: "User impersonation",
+			headers: map[string][]string{
+				ImpersonateUserHeader: {"user1"},
+			},
+			expected: &clientcmdapi.AuthInfo{
+				Impersonate:          "user1",
+				ImpersonateUserExtra: make(map[string][]string),
+			},
+		},
+		{
+			name: "User and groups impersonation",
+			headers: map[string][]string{
+				ImpersonateUserHeader:  {"user1"},
+				ImpersonateGroupHeader: {"group1", "group2"},
+			},
+			expected: &clientcmdapi.AuthInfo{
+				Impersonate:          "user1",
+				ImpersonateGroups:    []string{"group1", "group2"},
+				ImpersonateUserExtra: make(map[string][]string),
+			},
+		},
+		{
+			name: "User and extra impersonation",
+			headers: map[string][]string{
+				ImpersonateUserHeader:               {"user1"},
+				ImpersonateUserExtraHeader + "key1": {"val1", "val2"},
+			},
+			expected: &clientcmdapi.AuthInfo{
+				Impersonate: "user1",
+				ImpersonateUserExtra: map[string][]string{
+					"key1": {"val1", "val2"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			for k, v := range tc.headers {
+				req.Header[k] = v
+			}
+
+			authInfo := &clientcmdapi.AuthInfo{
+				ImpersonateUserExtra: make(map[string][]string),
+			}
+			handleImpersonation(authInfo, req)
+
+			if !reflect.DeepEqual(authInfo, tc.expected) {
+				t.Errorf("expected %+v, got %+v", tc.expected, authInfo)
+			}
+		})
+	}
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadRestConfigFromKubeConfig(t *testing.T) {
+	validKubeconfig := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:6443
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+kind: Config
+preferences: {}
+users:
+- name: test
+  user:
+    token: test-token
+`
+	testCases := []struct {
+		name        string
+		kubeconfig  string
+		expectError bool
+	}{
+		{
+			name:        "valid kubeconfig",
+			kubeconfig:  validKubeconfig,
+			expectError: false,
+		},
+		{
+			name:        "invalid kubeconfig",
+			kubeconfig:  "invalid content",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := LoadRestConfigFromKubeConfig(tc.kubeconfig)
+			if (err != nil) != tc.expectError {
+				t.Errorf("LoadRestConfigFromKubeConfig() error = %v, expectError %v", err, tc.expectError)
+			}
+		})
+	}
+}
+
+func TestLoadAPIConfig(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "kubeconfig-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	kubeconfigPath := filepath.Join(tempDir, "config")
+	kubeconfigContent := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+kind: Config
+users:
+- name: test-user
+  user:
+    token: secret
+`
+	if err := os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		name            string
+		context         string
+		expectError     bool
+		expectedContext string
+	}{
+		{
+			name:            "valid context",
+			context:         "test-context",
+			expectError:     false,
+			expectedContext: "test-context",
+		},
+		{
+			name:            "empty context (uses current)",
+			context:         "",
+			expectError:     false,
+			expectedContext: "test-context",
+		},
+		{
+			name:        "non-existent context",
+			context:     "non-existent",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := LoadAPIConfig(kubeconfigPath, tc.context)
+			if (err != nil) != tc.expectError {
+				t.Errorf("LoadAPIConfig() error = %v, expectError %v", err, tc.expectError)
+				return
+			}
+			if !tc.expectError {
+				if config.CurrentContext != tc.expectedContext {
+					t.Errorf("expected context %s, got %s", tc.expectedContext, config.CurrentContext)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added unit tests for authentication logic in auth.go and configuration loading in client.go. Tested HasAuthorizationHeader, GetBearerToken, handleImpersonation, LoadRestConfigFromKubeConfig, and LoadAPIConfig.

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

This PR significantly increases the unit test coverage for the pkg/client package. It focuses on the core authentication logic and configuration loading mechanisms, which are critical for the dashboard's stability.

**Which issue(s) this PR fixes**:
Fixes #414 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

