### PR TITLE
feat: add unified CI automation targets to Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         run: hack/verify-license.sh
       - name: lint
         run: hack/verify-staticcheck.sh
+      - name: test
+        run: make test
   build-frontend:
     runs-on: ubuntu-22.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,37 @@ install-ui-deps:
 install: install-deps install-ui-deps
 
 ###################
+# Quality & Test  #
+###################
+
+# Run all verification targets (lint and test)
+.PHONY: verify
+verify: lint test
+
+# Lint all components
+.PHONY: lint
+lint: lint-api
+
+# Run Go staticcheck
+.PHONY: lint-api
+lint-api:
+	hack/verify-staticcheck.sh
+
+# Format all Go code
+.PHONY: fmt
+fmt:
+	go fmt ./pkg/... ./cmd/...
+
+# Run all unit tests
+.PHONY: test
+test: test-api
+
+# Run Go unit tests
+.PHONY: test-api
+test-api:
+	go test -v ./pkg/... ./cmd/...
+
+###################
 # Development     #
 ###################
 


### PR DESCRIPTION
Introduced standard targets: lint, fmt, test, and verify to provide a consistent interface for local development and CI pipelines. These targets wrap existing project scripts and standard Go tools.

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:

 This PR introduces standard automation targets to the Makefile to unify the development.

**Which issue(s) this PR fixes**:
Fixes #416 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
NONE

```release-note
Added standard Makefile targets (lint, fmt, test, verify) for better developer automation across all Go components.
```

