### PR TITLE
fix(member-cluster): fix deployment list and detail by correcting API path and unwrapping response

### DIFF
--- a/ui/apps/dashboard/src/services/base.ts
+++ b/ui/apps/dashboard/src/services/base.ts
@@ -152,6 +152,16 @@ interface MemberClusterResponse {
 
 karmadaMemberClusterClient.interceptors.response.use(
   (response) => {
+    // Unwrap BaseResponse { code, message, data } wrapper from the backend
+    if (
+      response.data &&
+      typeof response.data === 'object' &&
+      'code' in response.data &&
+      'data' in response.data
+    ) {
+      response.data = response.data.data;
+    }
+
     const data = response.data as MemberClusterResponse | undefined;
     const errors = data?.errors ?? [];
 

--- a/ui/apps/dashboard/src/services/member-cluster/pod.ts
+++ b/ui/apps/dashboard/src/services/member-cluster/pod.ts
@@ -74,8 +74,8 @@ export async function GetMemberClusterPods(params: {
 }) {
   const { memberClusterName, namespace, keyword } = params;
   const url = namespace
-    ? `/clusterapi/${memberClusterName}/api/v1/pod/${namespace}`
-    : `/clusterapi/${memberClusterName}/api/v1/pod`;
+    ? `/api/v1/member/${memberClusterName}/pod/${namespace}`
+    : `/api/v1/member/${memberClusterName}/pod`;
   const requestData = {} as DataSelectQuery;
   if (keyword) {
     requestData.filterBy = ['name', keyword];
@@ -100,7 +100,7 @@ export async function GetMemberClusterPodDetail(params: {
   const { memberClusterName, namespace, name } = params;
   const resp = await karmadaMemberClusterClient.get<{
     errors: string[];
-  } & PodDetail>(`/clusterapi/${memberClusterName}/api/v1/pod/${namespace}/${name}`);
+  } & PodDetail>(`/api/v1/member/${memberClusterName}/pod/${namespace}/${name}`);
   return resp;
 }
 
@@ -113,7 +113,7 @@ export async function GetMemberClusterPodContainers(params: {
   const resp = await karmadaMemberClusterClient.get<{
     containers: Container[];
   }>(
-    `/clusterapi/${memberClusterName}/api/v1/pod/${namespace}/${name}/container`,
+    `/api/v1/member/${memberClusterName}/pod/${namespace}/${name}/container`,
   );
   return resp;
 }
@@ -130,7 +130,7 @@ export async function GetMemberClusterPodEvents(params: {
       totalItems: number;
     };
     events: any[];
-  }>(`/clusterapi/${memberClusterName}/api/v1/pod/${namespace}/${name}/event`);
+  }>(`/api/v1/member/${memberClusterName}/pod/${namespace}/${name}/event`);
   return resp;
 }
 
@@ -143,7 +143,7 @@ export async function GetMemberClusterPodPersistentVolumeClaims(params: {
   const resp = await karmadaMemberClusterClient.get<{
     persistentVolumeClaims: any[];
   }>(
-    `/clusterapi/${memberClusterName}/api/v1/pod/${namespace}/${name}/persistentvolumeclaim`,
+    `/api/v1/member/${memberClusterName}/pod/${namespace}/${name}/persistentvolumeclaim`,
   );
   return resp;
 }
@@ -156,7 +156,7 @@ export async function GetMemberClusterPodShell(params: {
 }) {
   const { memberClusterName, namespace, pod, container } = params;
   const resp = await karmadaMemberClusterClient.get<any>(
-    `/clusterapi/${memberClusterName}/api/v1/pod/${namespace}/${pod}/shell/${container}`,
+    `/api/v1/member/${memberClusterName}/pod/${namespace}/${pod}/shell/${container}`,
   );
   return resp;
 }

--- a/ui/apps/dashboard/src/services/member-cluster/workload.ts
+++ b/ui/apps/dashboard/src/services/member-cluster/workload.ts
@@ -64,8 +64,8 @@ export async function GetMemberClusterWorkloads(params: {
     requestData.filterBy = ['name', params.keyword];
   }
   const url = namespace
-    ? `/clusterapi/${memberClusterName}/api/v1/${kind}/${namespace}`
-    : `/clusterapi/${memberClusterName}/api/v1/${kind}`;
+    ? `/api/v1/member/${memberClusterName}/${kind}/${namespace}`
+    : `/api/v1/member/${memberClusterName}/${kind}`;
   const resp = await karmadaMemberClusterClient.get<{
     errors: string[];
     listMeta: {
@@ -95,8 +95,8 @@ export async function GetMemberClusterDeployments(params: {
 }) {
   const { memberClusterName, namespace, keyword, ...queryParams } = params;
   const url = namespace
-    ? `/clusterapi/${memberClusterName}/api/v1/deployment/${namespace}`
-    : `/clusterapi/${memberClusterName}/api/v1/deployment`;
+    ? `/api/v1/member/${memberClusterName}/deployment/${namespace}`
+    : `/api/v1/member/${memberClusterName}/deployment`;
   const requestData = { ...queryParams } as DataSelectQuery;
   if (keyword) {
     requestData.filterBy = ['name', keyword];
@@ -263,7 +263,7 @@ export async function GetMemberClusterWorkloadDetail(params: {
   kind: WorkloadKind;
 }) {
   const { memberClusterName, kind, name, namespace } = params;
-  const url = `/clusterapi/${memberClusterName}/api/v1/${kind}/${namespace}/${name}`;
+  const url = `/api/v1/member/${memberClusterName}/${kind}/${namespace}/${name}`;
   const resp = await karmadaMemberClusterClient.get<{
     errors: string[];
   } & WorkloadDetail>(url);
@@ -294,7 +294,7 @@ export async function GetMemberClusterWorkloadEvents(params: {
   kind: WorkloadKind;
 }) {
   const { memberClusterName, kind, name, namespace } = params;
-  const url = `/clusterapi/${memberClusterName}/api/v1/${kind}/${namespace}/${name}/event`;
+  const url = `/api/v1/member/${memberClusterName}/${kind}/${namespace}/${name}/event`;
   const resp = await karmadaMemberClusterClient.get<{
     errors: string[];
     listMeta: {
@@ -318,7 +318,7 @@ export async function CreateMemberClusterDeployment(params: {
       totalItems: number;
     };
     events: WorkloadEvent[];
-  }>(`/clusterapi/${memberClusterName}/api/v1/deployment`, deploymentParams);
+  }>(`/api/v1/member/${memberClusterName}/deployment`, deploymentParams);
   return resp;
 }
 
@@ -336,7 +336,7 @@ export async function GetMemberClusterDeploymentNewReplicaSets(params: {
     };
     replicaSets: any[];
   }>(
-    `/clusterapi/${memberClusterName}/api/v1/deployment/${namespace}/${name}/newreplicaset`,
+    `/api/v1/member/${memberClusterName}/deployment/${namespace}/${name}/newreplicaset`,
   );
   return resp;
 }
@@ -354,7 +354,7 @@ export async function GetMemberClusterDeploymentOldReplicaSets(params: {
     };
     replicaSets: any[];
   }>(
-    `/clusterapi/${memberClusterName}/api/v1/deployment/${namespace}/${name}/oldreplicaset`,
+    `/api/v1/member/${memberClusterName}/deployment/${namespace}/${name}/oldreplicaset`,
   );
   return resp;
 }
@@ -366,7 +366,7 @@ export async function PauseMemberClusterDeployment(params: {
 }) {
   const { memberClusterName, namespace, name } = params;
   const resp = await karmadaMemberClusterClient.put<any>(
-    `/clusterapi/${memberClusterName}/api/v1/deployment/${namespace}/${name}/pause`,
+    `/api/v1/member/${memberClusterName}/deployment/${namespace}/${name}/pause`,
   );
   return resp;
 }
@@ -378,7 +378,7 @@ export async function ResumeMemberClusterDeployment(params: {
 }) {
   const { memberClusterName, namespace, name } = params;
   const resp = await karmadaMemberClusterClient.put<any>(
-    `/clusterapi/${memberClusterName}/api/v1/deployment/${namespace}/${name}/resume`,
+    `/api/v1/member/${memberClusterName}/deployment/${namespace}/${name}/resume`,
   );
   return resp;
 }
@@ -390,7 +390,7 @@ export async function RestartMemberClusterDeployment(params: {
 }) {
   const { memberClusterName, namespace, name } = params;
   const resp = await karmadaMemberClusterClient.put<any>(
-    `/clusterapi/${memberClusterName}/api/v1/deployment/${namespace}/${name}/restart`,
+    `/api/v1/member/${memberClusterName}/deployment/${namespace}/${name}/restart`,
   );
   return resp;
 }
@@ -403,7 +403,7 @@ export async function RollbackMemberClusterDeployment(params: {
 }) {
   const { memberClusterName, namespace, name, targetRevision } = params;
   const resp = await karmadaMemberClusterClient.put<any>(
-    `/clusterapi/${memberClusterName}/api/v1/deployment/${namespace}/${name}/rollback`,
+    `/api/v1/member/${memberClusterName}/deployment/${namespace}/${name}/rollback`,
     { targetRevision },
   );
   return resp;


### PR DESCRIPTION
## Bug Fix: Member Cluster Deployment List Shows No Data

### Problem

When navigating to the member cluster view, the Deployment list displayed "no data" despite deployments existing in the cluster.

This appears to be a bug introduced by an API path inconsistency between frontend and backend.🤔

After investigation, the root cause was a mismatch between the frontend API call and the backend registered route:

- Frontend was calling: `/clusterapi/{cluster}/api/v1/deployment`
- Backend registered route: `/api/v1/member/{cluster}/deployment`

### Fix

Updated the frontend API path to match the backend registered route. The Deployment list now loads correctly in the member cluster view.

<img width="1914" height="867" alt="Screenshot 2026-04-28 122035" src="https://github.com/user-attachments/assets/49a1f84f-3ca0-4c68-b6e8-a48de8e4bd34" />
<img width="1918" height="866" alt="Screenshot 2026-04-28 121133" src="https://github.com/user-attachments/assets/893cc3eb-daad-4c97-bffa-7641622e29ea" />
