### PR TITLE
fix: style fix after upgrade tailwindcss v4

### DIFF
--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -28,6 +28,7 @@
     ]
   },
   "dependencies": {
+    "@ant-design/cssinjs": "^2.1.2",
     "@chatui/core": "^3.8.0",
     "@karmada/chatui": "workspace:*",
     "@karmada/i18n-tool": "workspace:*",

--- a/ui/apps/dashboard/src/App.css
+++ b/ui/apps/dashboard/src/App.css
@@ -14,6 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@layer theme, base, antd, components, utilities;
+@import 'tailwindcss';

--- a/ui/apps/dashboard/src/App.tsx
+++ b/ui/apps/dashboard/src/App.tsx
@@ -20,6 +20,7 @@ import "./App.css";
 import Router from "./routes";
 import { Helmet, HelmetProvider } from "react-helmet-async";
 import { ConfigProvider, App as AntdApp } from "antd";
+import { StyleProvider } from "@ant-design/cssinjs";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AuthProvider from "@/components/auth";
 import { getAntdLocale } from "@/utils/i18n.tsx";
@@ -41,16 +42,17 @@ const queryClient = new QueryClient({
 function App() {
   const [cluster, setCluster] = useState<string>("");
   return (
-    <ConfigProvider
-      locale={getAntdLocale()}
-      theme={{
-        components: {
-          Layout: {
-            siderBg: "#ffffff",
+    <StyleProvider layer>
+      <ConfigProvider
+        locale={getAntdLocale()}
+        theme={{
+          components: {
+            Layout: {
+              siderBg: "#ffffff",
+            },
           },
-        },
-      }}
-    >
+        }}
+      >
       <AntdApp>
         <QueryClientProvider client={queryClient}>
           <ClusterContext.Provider value={{
@@ -93,7 +95,8 @@ function App() {
           </ClusterContext.Provider>
         </QueryClientProvider>
       </AntdApp>
-    </ConfigProvider>
+      </ConfigProvider>
+    </StyleProvider>
   );
 }
 

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
 
   apps/dashboard:
     dependencies:
+      '@ant-design/cssinjs':
+        specifier: ^2.1.2
+        version: 2.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@chatui/core':
         specifier: ^3.8.0
         version: 3.8.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
fix wrong style introduced by tailwindcss@v4 upgradation

before:
<img width="2108" height="914" alt="image" src="https://github.com/user-attachments/assets/0dd9ce7d-7c14-4826-80c0-2267a31e937e" />


after:
<img width="2282" height="754" alt="image" src="https://github.com/user-attachments/assets/90a3430f-064f-4db1-a3e3-3111286ae7f8" />


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
- fix wrong select-ui introducted by tailwindcss
```

