### PR TITLE
fix: enable topology as top-level menu by default

### DIFF
--- a/artifacts/dashboard/karmada-dashboard-configmap.yaml
+++ b/artifacts/dashboard/karmada-dashboard-configmap.yaml
@@ -11,6 +11,9 @@ data:
       - path: /overview
         enable: true
         sidebar_key: OVERVIEW
+      - path: /topology
+        enable: true
+        sidebar_key: TOPOLOGY
       - path: /multicloud-resource-manage
         enable: true
         sidebar_key: MULTICLOUD-RESOURCE-MANAGE
@@ -27,9 +30,6 @@ data:
           - path: config
             enable: true
             sidebar_key: CONFIG
-          - path: topology
-            enable: true
-            sidebar_key: TOPOLOGY
       - path: /multicloud-policy-manage
         enable: true
         sidebar_key: MULTICLOUD-POLICY-MANAGE
@@ -92,6 +92,9 @@ data:
       - path: /overview
         enable: true
         sidebar_key: OVERVIEW
+      - path: /topology
+        enable: true
+        sidebar_key: TOPOLOGY
       - path: /multicloud-resource-manage
         enable: true
         sidebar_key: MULTICLOUD-RESOURCE-MANAGE
@@ -108,9 +111,6 @@ data:
           - path: config
             enable: true
             sidebar_key: CONFIG
-          - path: topology
-            enable: true
-            sidebar_key: TOPOLOGY
       - path: /multicloud-policy-manage
         enable: true
         sidebar_key: MULTICLOUD-POLICY-MANAGE
@@ -166,4 +166,3 @@ data:
           - path: thirdparty
             enable: true
             sidebar_key: THIRDPARTY
-

--- a/artifacts/overlays/ingress-mode/dashboard-config.yaml
+++ b/artifacts/overlays/ingress-mode/dashboard-config.yaml
@@ -6,6 +6,9 @@ menu_configs:
   - path: /overview
     enable: true
     sidebar_key: OVERVIEW
+  - path: /topology
+    enable: true
+    sidebar_key: TOPOLOGY
   - path: /multicloud-resource-manage
     enable: true
     sidebar_key: MULTICLOUD-RESOURCE-MANAGE

--- a/artifacts/overlays/nodeport-mode/dashboard-config.yaml
+++ b/artifacts/overlays/nodeport-mode/dashboard-config.yaml
@@ -6,6 +6,9 @@ menu_configs:
   - path: /overview
     enable: true
     sidebar_key: OVERVIEW
+  - path: /topology
+    enable: true
+    sidebar_key: TOPOLOGY
   - path: /multicloud-resource-manage
     enable: true
     sidebar_key: MULTICLOUD-RESOURCE-MANAGE

--- a/charts/karmada-dashboard/templates/karmada-dashboard-configmap.yaml
+++ b/charts/karmada-dashboard/templates/karmada-dashboard-configmap.yaml
@@ -11,6 +11,9 @@ data:
       - path: /overview
         enable: true
         sidebar_key: OVERVIEW
+      - path: /topology
+        enable: true
+        sidebar_key: TOPOLOGY
       - path: /multicloud-resource-manage
         enable: true
         sidebar_key: MULTICLOUD-RESOURCE-MANAGE
@@ -27,9 +30,6 @@ data:
           - path: config
             enable: true
             sidebar_key: CONFIG
-          - path: topology
-            enable: true
-            sidebar_key: TOPOLOGY
       - path: /multicloud-policy-manage
         enable: true
         sidebar_key: MULTICLOUD-POLICY-MANAGE
@@ -92,6 +92,9 @@ data:
       - path: /overview
         enable: true
         sidebar_key: OVERVIEW
+      - path: /topology
+        enable: true
+        sidebar_key: TOPOLOGY
       - path: /multicloud-resource-manage
         enable: true
         sidebar_key: MULTICLOUD-RESOURCE-MANAGE
@@ -108,9 +111,6 @@ data:
           - path: config
             enable: true
             sidebar_key: CONFIG
-          - path: topology
-            enable: true
-            sidebar_key: TOPOLOGY
       - path: /multicloud-policy-manage
         enable: true
         sidebar_key: MULTICLOUD-POLICY-MANAGE


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Fix the menu item for topology, and make topology menu visible by default. 
<img width="728" height="1022" alt="image" src="https://github.com/user-attachments/assets/5b845415-a51c-45ef-8745-cc2c0e3d9291" />

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
- show topology menu by default.
```

