### PR TITLE
ci: update GitHub runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -38,7 +38,7 @@ jobs:
 
   unit-test:
     name: unit test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -50,7 +50,7 @@ jobs:
         run: make test
 
   build-frontend:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -76,7 +76,7 @@ jobs:
           pnpm turbo build
   build-bin:
     name: build-bin
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -91,7 +91,7 @@ jobs:
       - name: compile
         run: make all
   e2e-frontend:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dockerhub-latest-chart.yml
+++ b/.github/workflows/dockerhub-latest-chart.yml
@@ -13,7 +13,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -12,7 +12,7 @@ jobs:
   build-fronted:
     name: build frontend bundle
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -46,7 +46,7 @@ jobs:
   build-and-push-web:
     name: build and push web image
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ "build-fronted" ]
     env:
       IMAGE_NAME: karmada/karmada-dashboard-web
@@ -101,7 +101,7 @@ jobs:
   build-and-push-api:
     name: build and push api image
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       IMAGE_NAME: karmada/karmada-dashboard-api
       BINARY_NAME: karmada-dashboard-api
@@ -146,7 +146,7 @@ jobs:
   build-and-push-terminal:
     name: build and push terminal image
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       IMAGE_NAME: karmada/karmada-dashboard-terminal
       PLATFORMS: linux/amd64,linux/arm64
@@ -195,7 +195,7 @@ jobs:
     # action doesn't support YAML anchors, so we need to duplicate the job
     name: build and push kubernetes-dashboard-api image
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       IMAGE_NAME: karmada/kubernetes-dashboard-api
       BINARY_NAME: kubernetes-dashboard-api

--- a/.github/workflows/dockerhub-released-chart.yml
+++ b/.github/workflows/dockerhub-released-chart.yml
@@ -13,7 +13,7 @@ jobs:
     # 1. running on the forked repository would fail as missing necessary secret.
     # 2. running on the forked repository would use unnecessary GitHub Action time.
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -12,7 +12,7 @@ jobs:
   build-fronted:
     name: build frontend bundle
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -46,7 +46,7 @@ jobs:
   build-and-push-web:
     name: build and push web image
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ "build-fronted" ]
     env:
       IMAGE_NAME: karmada/karmada-dashboard-web
@@ -101,7 +101,7 @@ jobs:
   build-and-push-api:
     name: build and push api image
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       IMAGE_NAME: karmada/karmada-dashboard-api
       BINARY_NAME: karmada-dashboard-api
@@ -146,7 +146,7 @@ jobs:
   build-and-push-terminal:
     name: build and push terminal image
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       IMAGE_NAME: karmada/karmada-dashboard-terminal
       PLATFORMS: linux/amd64,linux/arm64
@@ -191,7 +191,7 @@ jobs:
   build-and-push-kubernetes-dashboard-api:
     name: build and push kubernetes-dashboard-api image
     if: ${{ github.repository == 'karmada-io/dashboard' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       IMAGE_NAME: karmada/kubernetes-dashboard-api
       BINARY_NAME: kubernetes-dashboard-api


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR updates GitHub-hosted Ubuntu runners from `ubuntu-22.04` to `ubuntu-24.04` across the workflow files under `.github/workflows`.

This follows up on karmada-io/karmada#7728 and the same GitHub Actions runner-images deprecation notice for `ubuntu-22.04`:

https://github.com/actions/runner-images/issues/14254

`ubuntu-24.04` is the current GA Ubuntu runner image, while `ubuntu-26.04` is still in preview. This keeps the dashboard workflows on a fixed Ubuntu runner label instead of switching to `ubuntu-latest`.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

Changed files:

- Updated all `runs-on: ubuntu-22.04` labels under `.github/workflows` to `runs-on: ubuntu-24.04`.
- No workflow logic, job matrix, action version, script, or test command was changed.

Validation:

- `git grep -n "ubuntu-22.04" HEAD -- .github/workflows || true`
- `git diff --check upstream/main...HEAD`
- Parsed all `.github/workflows/*.yml` and `.github/workflows/*.yaml` with Python `yaml.safe_load`

Fork push CI on `ranxi2001/dashboard:chore/update-github-runner-ubuntu-24`, commit `8f6ba046914e3e1bcc3a4d94f33912c10e33c64f`:

- `CI Workflow`: passed, including lint, unit test, build-bin, build-frontend, and e2e-frontend tests on Kubernetes v1.33.0, v1.34.0, and v1.35.0

This PR was prepared with AI assistance.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
