### PR TITLE
Group github/codeql-action updates in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,13 @@ updates:
     day: "monday"
     time: "00:00"
     timezone: "UTC"
-    
+  groups:
+    # The init/autobuild/analyze actions of github/codeql-action must be
+    # upgraded together to the same version, so group them into one PR.
+    codeql-action:
+      patterns:
+        - "github/codeql-action*"
+
 - package-ecosystem: "docker"
   directory: "/cluster/images/"
   schedule:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR introduces a group for `github/codeql-action` actions, ensuring that related actions are upgraded together in a single pull request.

**Which issue(s) this PR fixes**:
Fixes #644
Fixes #645
Fixes #646

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

