### PR TITLE
feat: add component metrics visualization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ VERSION 				?= $(shell hack/version.sh)
 # Build targets
 TARGETS := karmada-dashboard-api \
 		   karmada-dashboard-web \
-		   kubernetes-dashboard-api
+		   kubernetes-dashboard-api \
+		   karmada-dashboard-metrics-scraper
 
 # Docker image related variables
 REGISTRY				?= docker.io/karmada
@@ -148,6 +149,20 @@ endif
 .PHONY: run-web
 run-web: install-ui-deps build
 	cd ui && VITE_API_HOST=$(API_HOST) pnpm run dashboard:dev
+
+# Run Metrics Scraper only
+.PHONY: run-metrics-scraper
+run-metrics-scraper: build
+ifndef KUBECONFIG
+	$(error KUBECONFIG is required. Please specify the path to karmada kubeconfig)
+endif
+	_output/bin/$(GOOS)/$(GOARCH)/karmada-dashboard-metrics-scraper \
+		--karmada-kubeconfig=$(KUBECONFIG) \
+		--karmada-context=$(KARMADA_CTX) \
+		--kubeconfig=$(KUBECONFIG) \
+		--context=$(HOST_CTX) \
+		--insecure-port=8001 \
+		$(if $(filter true,$(SKIP_TLS_VERIFY)),--skip-karmada-apiserver-tls-verify)
 
 # Generate JWT token for dashboard login
 .PHONY: gen-token

--- a/artifacts/dashboard/karmada-dashboard-configmap.yaml
+++ b/artifacts/dashboard/karmada-dashboard-configmap.yaml
@@ -14,6 +14,9 @@ data:
       - path: /topology
         enable: true
         sidebar_key: TOPOLOGY
+      - path: /metrics
+        enable: true
+        sidebar_key: METRICS
       - path: /multicloud-resource-manage
         enable: true
         sidebar_key: MULTICLOUD-RESOURCE-MANAGE
@@ -88,6 +91,724 @@ data:
   prod.yaml: |-
     docker_registries: [ ]
     chart_registries: [ ]
+    metrics_dashboards:
+      - version: 1
+        component: karmada-scheduler
+        panels:
+          - id: karmada-scheduler-01
+            metric_name: karmada_scheduler_schedule_attempts_total
+            chart_type: line
+            title: Karmada Scheduler Schedule Attempts Total
+            visible: true
+            order: 0
+          - id: karmada-scheduler-02
+            metric_name: karmada_scheduler_queue_incoming_bindings_total
+            chart_type: line
+            title: Karmada Scheduler Queue Incoming Bindings Total
+            visible: true
+            order: 1
+          - id: karmada-scheduler-03
+            metric_name: karmada_scheduler_e2e_scheduling_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler E2e Scheduling Duration Seconds
+            visible: true
+            order: 2
+          - id: karmada-scheduler-04
+            metric_name: karmada_scheduler_scheduling_algorithm_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Scheduling Algorithm Duration Seconds
+            visible: true
+            order: 3
+          - id: karmada-scheduler-05
+            metric_name: karmada_scheduler_framework_extension_point_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Framework Extension Point Duration Seconds
+            visible: true
+            order: 4
+          - id: karmada-scheduler-06
+            metric_name: karmada_scheduler_plugin_execution_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Plugin Execution Duration Seconds
+            visible: true
+            order: 5
+          - id: karmada-scheduler-07
+            metric_name: leader_election_master_status
+            chart_type: gauge
+            title: Leader Election Master Status
+            visible: true
+            order: 6
+          - id: karmada-scheduler-08
+            metric_name: workqueue_depth
+            chart_type: gauge
+            title: Workqueue Depth
+            visible: true
+            order: 7
+          - id: karmada-scheduler-09
+            metric_name: workqueue_retries_total
+            chart_type: line
+            title: Workqueue Retries Total
+            visible: true
+            order: 8
+          - id: karmada-scheduler-10
+            metric_name: workqueue_longest_running_processor_seconds
+            chart_type: gauge
+            title: Workqueue Longest Running Processor Seconds
+            visible: true
+            order: 9
+      - version: 1
+        component: karmada-controller-manager
+        panels:
+          - id: karmada-controller-manager-01
+            metric_name: cluster_ready_state
+            chart_type: gauge
+            title: Cluster Ready State
+            visible: true
+            order: 0
+          - id: karmada-controller-manager-02
+            metric_name: cluster_ready_node_number
+            chart_type: gauge
+            title: Cluster Ready Node Number
+            visible: true
+            order: 1
+          - id: karmada-controller-manager-03
+            metric_name: cluster_node_number
+            chart_type: gauge
+            title: Cluster Node Number
+            visible: true
+            order: 2
+          - id: karmada-controller-manager-04
+            metric_name: cluster_cpu_allocatable_number
+            chart_type: gauge
+            title: Cluster Cpu Allocatable Number
+            visible: true
+            order: 3
+          - id: karmada-controller-manager-05
+            metric_name: cluster_cpu_allocated_number
+            chart_type: gauge
+            title: Cluster Cpu Allocated Number
+            visible: true
+            order: 4
+          - id: karmada-controller-manager-06
+            metric_name: cluster_memory_allocatable_bytes
+            chart_type: area
+            title: Cluster Memory Allocatable Bytes
+            visible: true
+            order: 5
+          - id: karmada-controller-manager-07
+            metric_name: cluster_memory_allocated_bytes
+            chart_type: area
+            title: Cluster Memory Allocated Bytes
+            visible: true
+            order: 6
+          - id: karmada-controller-manager-08
+            metric_name: cluster_pod_allocatable_number
+            chart_type: gauge
+            title: Cluster Pod Allocatable Number
+            visible: true
+            order: 7
+          - id: karmada-controller-manager-09
+            metric_name: cluster_pod_allocated_number
+            chart_type: gauge
+            title: Cluster Pod Allocated Number
+            visible: true
+            order: 8
+          - id: karmada-controller-manager-10
+            metric_name: cluster_sync_status_duration_seconds
+            chart_type: bar
+            title: Cluster Sync Status Duration Seconds
+            visible: true
+            order: 9
+          - id: karmada-controller-manager-11
+            metric_name: policy_apply_attempts_total
+            chart_type: line
+            title: Policy Apply Attempts Total
+            visible: true
+            order: 10
+          - id: karmada-controller-manager-12
+            metric_name: resource_apply_policy_duration_seconds
+            chart_type: bar
+            title: Resource Apply Policy Duration Seconds
+            visible: true
+            order: 11
+      - version: 1
+        component: karmada-agent
+        panels:
+          - id: karmada-agent-01
+            metric_name: cluster_ready_state
+            chart_type: gauge
+            title: Cluster Ready State
+            visible: true
+            order: 0
+          - id: karmada-agent-02
+            metric_name: cluster_ready_node_number
+            chart_type: gauge
+            title: Cluster Ready Node Number
+            visible: true
+            order: 1
+          - id: karmada-agent-03
+            metric_name: cluster_node_number
+            chart_type: gauge
+            title: Cluster Node Number
+            visible: true
+            order: 2
+          - id: karmada-agent-04
+            metric_name: cluster_cpu_allocatable_number
+            chart_type: gauge
+            title: Cluster Cpu Allocatable Number
+            visible: true
+            order: 3
+          - id: karmada-agent-05
+            metric_name: cluster_cpu_allocated_number
+            chart_type: gauge
+            title: Cluster Cpu Allocated Number
+            visible: true
+            order: 4
+          - id: karmada-agent-06
+            metric_name: cluster_memory_allocatable_bytes
+            chart_type: area
+            title: Cluster Memory Allocatable Bytes
+            visible: true
+            order: 5
+          - id: karmada-agent-07
+            metric_name: cluster_memory_allocated_bytes
+            chart_type: area
+            title: Cluster Memory Allocated Bytes
+            visible: true
+            order: 6
+          - id: karmada-agent-08
+            metric_name: cluster_pod_allocatable_number
+            chart_type: gauge
+            title: Cluster Pod Allocatable Number
+            visible: true
+            order: 7
+          - id: karmada-agent-09
+            metric_name: cluster_pod_allocated_number
+            chart_type: gauge
+            title: Cluster Pod Allocated Number
+            visible: true
+            order: 8
+          - id: karmada-agent-10
+            metric_name: cluster_sync_status_duration_seconds
+            chart_type: bar
+            title: Cluster Sync Status Duration Seconds
+            visible: true
+            order: 9
+          - id: karmada-agent-11
+            metric_name: workqueue_depth
+            chart_type: gauge
+            title: Workqueue Depth
+            visible: true
+            order: 10
+      - version: 1
+        component: karmada-aggregated-apiserver
+        panels:
+          - id: karmada-aggregated-apiserver-01
+            metric_name: apiserver_request_total
+            chart_type: line
+            title: Apiserver Request Total
+            visible: true
+            order: 0
+          - id: karmada-aggregated-apiserver-02
+            metric_name: apiserver_request_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-aggregated-apiserver-03
+            metric_name: apiserver_current_inflight_requests
+            chart_type: gauge
+            title: Apiserver Current Inflight Requests
+            visible: true
+            order: 2
+          - id: karmada-aggregated-apiserver-04
+            metric_name: apiserver_longrunning_requests
+            chart_type: gauge
+            title: Apiserver Longrunning Requests
+            visible: true
+            order: 3
+          - id: karmada-aggregated-apiserver-05
+            metric_name: apiserver_request_sli_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Sli Duration Seconds
+            visible: true
+            order: 4
+          - id: karmada-aggregated-apiserver-06
+            metric_name: apiserver_response_sizes
+            chart_type: bar
+            title: Apiserver Response Sizes
+            visible: true
+            order: 5
+          - id: karmada-aggregated-apiserver-07
+            metric_name: apiserver_storage_objects
+            chart_type: gauge
+            title: Apiserver Storage Objects
+            visible: true
+            order: 6
+          - id: karmada-aggregated-apiserver-08
+            metric_name: apiserver_storage_size_bytes
+            chart_type: area
+            title: Apiserver Storage Size Bytes
+            visible: true
+            order: 7
+          - id: karmada-aggregated-apiserver-09
+            metric_name: apiserver_storage_db_total_size_in_bytes
+            chart_type: area
+            title: Apiserver Storage Db Total Size In Bytes
+            visible: true
+            order: 8
+          - id: karmada-aggregated-apiserver-10
+            metric_name: apiserver_tls_handshake_errors_total
+            chart_type: line
+            title: Apiserver Tls Handshake Errors Total
+            visible: true
+            order: 9
+          - id: karmada-aggregated-apiserver-11
+            metric_name: apiserver_delegated_authz_request_total
+            chart_type: line
+            title: Apiserver Delegated Authz Request Total
+            visible: true
+            order: 10
+          - id: karmada-aggregated-apiserver-12
+            metric_name: apiserver_delegated_authz_request_duration_seconds
+            chart_type: bar
+            title: Apiserver Delegated Authz Request Duration Seconds
+            visible: true
+            order: 11
+      - version: 1
+        component: karmada-apiserver
+        panels:
+          - id: karmada-apiserver-01
+            metric_name: apiserver_request_total
+            chart_type: line
+            title: Apiserver Request Total
+            visible: true
+            order: 0
+          - id: karmada-apiserver-02
+            metric_name: apiserver_request_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-apiserver-03
+            metric_name: apiserver_current_inflight_requests
+            chart_type: gauge
+            title: Apiserver Current Inflight Requests
+            visible: true
+            order: 2
+          - id: karmada-apiserver-04
+            metric_name: apiserver_current_inqueue_requests
+            chart_type: gauge
+            title: Apiserver Current Inqueue Requests
+            visible: true
+            order: 3
+          - id: karmada-apiserver-05
+            metric_name: apiserver_longrunning_requests
+            chart_type: gauge
+            title: Apiserver Longrunning Requests
+            visible: true
+            order: 4
+          - id: karmada-apiserver-06
+            metric_name: apiserver_flowcontrol_current_executing_requests
+            chart_type: gauge
+            title: Apiserver Flowcontrol Current Executing Requests
+            visible: true
+            order: 5
+          - id: karmada-apiserver-07
+            metric_name: apiserver_flowcontrol_current_inqueue_requests
+            chart_type: gauge
+            title: Apiserver Flowcontrol Current Inqueue Requests
+            visible: true
+            order: 6
+          - id: karmada-apiserver-08
+            metric_name: apiserver_flowcontrol_request_wait_duration_seconds
+            chart_type: bar
+            title: Apiserver Flowcontrol Request Wait Duration Seconds
+            visible: true
+            order: 7
+          - id: karmada-apiserver-09
+            metric_name: apiserver_admission_controller_admission_duration_seconds
+            chart_type: bar
+            title: Apiserver Admission Controller Admission Duration Seconds
+            visible: true
+            order: 8
+          - id: karmada-apiserver-10
+            metric_name: apiserver_storage_objects
+            chart_type: gauge
+            title: Apiserver Storage Objects
+            visible: true
+            order: 9
+          - id: karmada-apiserver-11
+            metric_name: apiserver_storage_size_bytes
+            chart_type: area
+            title: Apiserver Storage Size Bytes
+            visible: true
+            order: 10
+          - id: karmada-apiserver-12
+            metric_name: apiserver_tls_handshake_errors_total
+            chart_type: line
+            title: Apiserver Tls Handshake Errors Total
+            visible: true
+            order: 11
+      - version: 1
+        component: karmada-descheduler
+        panels:
+          - id: karmada-descheduler-01
+            metric_name: leader_election_master_status
+            chart_type: gauge
+            title: Leader Election Master Status
+            visible: true
+            order: 0
+          - id: karmada-descheduler-02
+            metric_name: workqueue_depth
+            chart_type: gauge
+            title: Workqueue Depth
+            visible: true
+            order: 1
+          - id: karmada-descheduler-03
+            metric_name: workqueue_adds_total
+            chart_type: line
+            title: Workqueue Adds Total
+            visible: true
+            order: 2
+          - id: karmada-descheduler-04
+            metric_name: workqueue_retries_total
+            chart_type: line
+            title: Workqueue Retries Total
+            visible: true
+            order: 3
+          - id: karmada-descheduler-05
+            metric_name: workqueue_queue_duration_seconds
+            chart_type: bar
+            title: Workqueue Queue Duration Seconds
+            visible: true
+            order: 4
+          - id: karmada-descheduler-06
+            metric_name: workqueue_work_duration_seconds
+            chart_type: bar
+            title: Workqueue Work Duration Seconds
+            visible: true
+            order: 5
+          - id: karmada-descheduler-07
+            metric_name: workqueue_longest_running_processor_seconds
+            chart_type: gauge
+            title: Workqueue Longest Running Processor Seconds
+            visible: true
+            order: 6
+          - id: karmada-descheduler-08
+            metric_name: workqueue_unfinished_work_seconds
+            chart_type: gauge
+            title: Workqueue Unfinished Work Seconds
+            visible: true
+            order: 7
+      - version: 1
+        component: karmada-kube-controller-manager
+        panels:
+          - id: karmada-kube-controller-manager-01
+            metric_name: node_collector_update_all_nodes_health_duration_seconds
+            chart_type: bar
+            title: Node Collector Update All Nodes Health Duration Seconds
+            visible: true
+            order: 0
+          - id: karmada-kube-controller-manager-02
+            metric_name: node_collector_update_node_health_duration_seconds
+            chart_type: bar
+            title: Node Collector Update Node Health Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-kube-controller-manager-03
+            metric_name: garbagecollector_controller_resources_sync_error_total
+            chart_type: line
+            title: Garbagecollector Controller Resources Sync Error Total
+            visible: true
+            order: 2
+          - id: karmada-kube-controller-manager-04
+            metric_name: ttl_after_finished_controller_job_deletion_duration_seconds
+            chart_type: bar
+            title: Ttl After Finished Controller Job Deletion Duration Seconds
+            visible: true
+            order: 3
+          - id: karmada-kube-controller-manager-05
+            metric_name: leader_election_master_status
+            chart_type: gauge
+            title: Leader Election Master Status
+            visible: true
+            order: 4
+          - id: karmada-kube-controller-manager-06
+            metric_name: workqueue_depth
+            chart_type: gauge
+            title: Workqueue Depth
+            visible: true
+            order: 5
+          - id: karmada-kube-controller-manager-07
+            metric_name: workqueue_adds_total
+            chart_type: line
+            title: Workqueue Adds Total
+            visible: true
+            order: 6
+          - id: karmada-kube-controller-manager-08
+            metric_name: workqueue_retries_total
+            chart_type: line
+            title: Workqueue Retries Total
+            visible: true
+            order: 7
+          - id: karmada-kube-controller-manager-09
+            metric_name: workqueue_longest_running_processor_seconds
+            chart_type: gauge
+            title: Workqueue Longest Running Processor Seconds
+            visible: true
+            order: 8
+          - id: karmada-kube-controller-manager-10
+            metric_name: workqueue_unfinished_work_seconds
+            chart_type: gauge
+            title: Workqueue Unfinished Work Seconds
+            visible: true
+            order: 9
+      - version: 1
+        component: karmada-metrics-adapter
+        panels:
+          - id: karmada-metrics-adapter-01
+            metric_name: apiserver_request_total
+            chart_type: line
+            title: Apiserver Request Total
+            visible: true
+            order: 0
+          - id: karmada-metrics-adapter-02
+            metric_name: apiserver_request_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-metrics-adapter-03
+            metric_name: apiserver_request_sli_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Sli Duration Seconds
+            visible: true
+            order: 2
+          - id: karmada-metrics-adapter-04
+            metric_name: apiserver_request_slo_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Slo Duration Seconds
+            visible: true
+            order: 3
+          - id: karmada-metrics-adapter-05
+            metric_name: apiserver_request_filter_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Filter Duration Seconds
+            visible: true
+            order: 4
+          - id: karmada-metrics-adapter-06
+            metric_name: apiserver_current_inflight_requests
+            chart_type: gauge
+            title: Apiserver Current Inflight Requests
+            visible: true
+            order: 5
+          - id: karmada-metrics-adapter-07
+            metric_name: workqueue_depth
+            chart_type: gauge
+            title: Workqueue Depth
+            visible: true
+            order: 6
+          - id: karmada-metrics-adapter-08
+            metric_name: workqueue_adds_total
+            chart_type: line
+            title: Workqueue Adds Total
+            visible: true
+            order: 7
+          - id: karmada-metrics-adapter-09
+            metric_name: workqueue_retries_total
+            chart_type: line
+            title: Workqueue Retries Total
+            visible: true
+            order: 8
+      - version: 1
+        component: karmada-scheduler-estimator-member1
+        panels:
+          - id: karmada-scheduler-estimator-member1-01
+            metric_name: karmada_scheduler_estimator_estimating_request_total
+            chart_type: line
+            title: Karmada Scheduler Estimator Estimating Request Total
+            visible: true
+            order: 0
+          - id: karmada-scheduler-estimator-member1-02
+            metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-scheduler-estimator-member1-03
+            metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+            visible: true
+            order: 2
+          - id: karmada-scheduler-estimator-member1-04
+            metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+            visible: true
+            order: 3
+      - version: 1
+        component: karmada-scheduler-estimator-member2
+        panels:
+          - id: karmada-scheduler-estimator-member2-01
+            metric_name: karmada_scheduler_estimator_estimating_request_total
+            chart_type: line
+            title: Karmada Scheduler Estimator Estimating Request Total
+            visible: true
+            order: 0
+          - id: karmada-scheduler-estimator-member2-02
+            metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-scheduler-estimator-member2-03
+            metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+            visible: true
+            order: 2
+          - id: karmada-scheduler-estimator-member2-04
+            metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+            visible: true
+            order: 3
+      - version: 1
+        component: karmada-scheduler-estimator-member3
+        panels:
+          - id: karmada-scheduler-estimator-member3-01
+            metric_name: karmada_scheduler_estimator_estimating_request_total
+            chart_type: line
+            title: Karmada Scheduler Estimator Estimating Request Total
+            visible: true
+            order: 0
+          - id: karmada-scheduler-estimator-member3-02
+            metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-scheduler-estimator-member3-03
+            metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+            visible: true
+            order: 2
+          - id: karmada-scheduler-estimator-member3-04
+            metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+            visible: true
+            order: 3
+      - version: 1
+        component: karmada-search
+        panels:
+          - id: karmada-search-01
+            metric_name: apiserver_request_total
+            chart_type: line
+            title: Apiserver Request Total
+            visible: true
+            order: 0
+          - id: karmada-search-02
+            metric_name: apiserver_request_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-search-03
+            metric_name: apiserver_current_inflight_requests
+            chart_type: gauge
+            title: Apiserver Current Inflight Requests
+            visible: true
+            order: 2
+          - id: karmada-search-04
+            metric_name: apiserver_longrunning_requests
+            chart_type: gauge
+            title: Apiserver Longrunning Requests
+            visible: true
+            order: 3
+          - id: karmada-search-05
+            metric_name: apiserver_request_sli_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Sli Duration Seconds
+            visible: true
+            order: 4
+          - id: karmada-search-06
+            metric_name: apiserver_request_slo_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Slo Duration Seconds
+            visible: true
+            order: 5
+          - id: karmada-search-07
+            metric_name: apiserver_request_filter_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Filter Duration Seconds
+            visible: true
+            order: 6
+          - id: karmada-search-08
+            metric_name: apiserver_storage_objects
+            chart_type: gauge
+            title: Apiserver Storage Objects
+            visible: true
+            order: 7
+          - id: karmada-search-09
+            metric_name: apiserver_storage_size_bytes
+            chart_type: area
+            title: Apiserver Storage Size Bytes
+            visible: true
+            order: 8
+          - id: karmada-search-10
+            metric_name: etcd_request_duration_seconds
+            chart_type: bar
+            title: Etcd Request Duration Seconds
+            visible: true
+            order: 9
+          - id: karmada-search-11
+            metric_name: etcd_requests_total
+            chart_type: line
+            title: Etcd Requests Total
+            visible: true
+            order: 10
+          - id: karmada-search-12
+            metric_name: workqueue_depth
+            chart_type: gauge
+            title: Workqueue Depth
+            visible: true
+            order: 11
+      - version: 1
+        component: karmada-webhook
+        panels:
+          - id: karmada-webhook-01
+            metric_name: controller_runtime_webhook_requests_total
+            chart_type: line
+            title: Controller Runtime Webhook Requests Total
+            visible: true
+            order: 0
+          - id: karmada-webhook-02
+            metric_name: controller_runtime_webhook_latency_seconds
+            chart_type: bar
+            title: Controller Runtime Webhook Latency Seconds
+            visible: true
+            order: 1
+          - id: karmada-webhook-03
+            metric_name: controller_runtime_webhook_requests_in_flight
+            chart_type: gauge
+            title: Controller Runtime Webhook Requests In Flight
+            visible: true
+            order: 2
+          - id: karmada-webhook-04
+            metric_name: controller_runtime_webhook_panics_total
+            chart_type: line
+            title: Controller Runtime Webhook Panics Total
+            visible: true
+            order: 3
+          - id: karmada-webhook-05
+            metric_name: controller_runtime_conversion_webhook_panics_total
+            chart_type: line
+            title: Controller Runtime Conversion Webhook Panics Total
+            visible: true
+            order: 4
     menu_configs:
       - path: /overview
         enable: true
@@ -95,6 +816,9 @@ data:
       - path: /topology
         enable: true
         sidebar_key: TOPOLOGY
+      - path: /metrics
+        enable: true
+        sidebar_key: METRICS
       - path: /multicloud-resource-manage
         enable: true
         sidebar_key: MULTICLOUD-RESOURCE-MANAGE

--- a/artifacts/overlays/ingress-mode/dashboard-config.yaml
+++ b/artifacts/overlays/ingress-mode/dashboard-config.yaml
@@ -2,6 +2,724 @@ docker_registries: []
 chart_registries: []
 # path_prefix: '/karmada'
 path_prefix: ''
+metrics_dashboards:
+  - version: 1
+    component: karmada-scheduler
+    panels:
+      - id: karmada-scheduler-01
+        metric_name: karmada_scheduler_schedule_attempts_total
+        chart_type: line
+        title: Karmada Scheduler Schedule Attempts Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-02
+        metric_name: karmada_scheduler_queue_incoming_bindings_total
+        chart_type: line
+        title: Karmada Scheduler Queue Incoming Bindings Total
+        visible: true
+        order: 1
+      - id: karmada-scheduler-03
+        metric_name: karmada_scheduler_e2e_scheduling_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler E2e Scheduling Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-04
+        metric_name: karmada_scheduler_scheduling_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Scheduling Algorithm Duration Seconds
+        visible: true
+        order: 3
+      - id: karmada-scheduler-05
+        metric_name: karmada_scheduler_framework_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Framework Extension Point Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-scheduler-06
+        metric_name: karmada_scheduler_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Plugin Execution Duration Seconds
+        visible: true
+        order: 5
+      - id: karmada-scheduler-07
+        metric_name: leader_election_master_status
+        chart_type: gauge
+        title: Leader Election Master Status
+        visible: true
+        order: 6
+      - id: karmada-scheduler-08
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 7
+      - id: karmada-scheduler-09
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 8
+      - id: karmada-scheduler-10
+        metric_name: workqueue_longest_running_processor_seconds
+        chart_type: gauge
+        title: Workqueue Longest Running Processor Seconds
+        visible: true
+        order: 9
+  - version: 1
+    component: karmada-controller-manager
+    panels:
+      - id: karmada-controller-manager-01
+        metric_name: cluster_ready_state
+        chart_type: gauge
+        title: Cluster Ready State
+        visible: true
+        order: 0
+      - id: karmada-controller-manager-02
+        metric_name: cluster_ready_node_number
+        chart_type: gauge
+        title: Cluster Ready Node Number
+        visible: true
+        order: 1
+      - id: karmada-controller-manager-03
+        metric_name: cluster_node_number
+        chart_type: gauge
+        title: Cluster Node Number
+        visible: true
+        order: 2
+      - id: karmada-controller-manager-04
+        metric_name: cluster_cpu_allocatable_number
+        chart_type: gauge
+        title: Cluster Cpu Allocatable Number
+        visible: true
+        order: 3
+      - id: karmada-controller-manager-05
+        metric_name: cluster_cpu_allocated_number
+        chart_type: gauge
+        title: Cluster Cpu Allocated Number
+        visible: true
+        order: 4
+      - id: karmada-controller-manager-06
+        metric_name: cluster_memory_allocatable_bytes
+        chart_type: area
+        title: Cluster Memory Allocatable Bytes
+        visible: true
+        order: 5
+      - id: karmada-controller-manager-07
+        metric_name: cluster_memory_allocated_bytes
+        chart_type: area
+        title: Cluster Memory Allocated Bytes
+        visible: true
+        order: 6
+      - id: karmada-controller-manager-08
+        metric_name: cluster_pod_allocatable_number
+        chart_type: gauge
+        title: Cluster Pod Allocatable Number
+        visible: true
+        order: 7
+      - id: karmada-controller-manager-09
+        metric_name: cluster_pod_allocated_number
+        chart_type: gauge
+        title: Cluster Pod Allocated Number
+        visible: true
+        order: 8
+      - id: karmada-controller-manager-10
+        metric_name: cluster_sync_status_duration_seconds
+        chart_type: bar
+        title: Cluster Sync Status Duration Seconds
+        visible: true
+        order: 9
+      - id: karmada-controller-manager-11
+        metric_name: policy_apply_attempts_total
+        chart_type: line
+        title: Policy Apply Attempts Total
+        visible: true
+        order: 10
+      - id: karmada-controller-manager-12
+        metric_name: resource_apply_policy_duration_seconds
+        chart_type: bar
+        title: Resource Apply Policy Duration Seconds
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-agent
+    panels:
+      - id: karmada-agent-01
+        metric_name: cluster_ready_state
+        chart_type: gauge
+        title: Cluster Ready State
+        visible: true
+        order: 0
+      - id: karmada-agent-02
+        metric_name: cluster_ready_node_number
+        chart_type: gauge
+        title: Cluster Ready Node Number
+        visible: true
+        order: 1
+      - id: karmada-agent-03
+        metric_name: cluster_node_number
+        chart_type: gauge
+        title: Cluster Node Number
+        visible: true
+        order: 2
+      - id: karmada-agent-04
+        metric_name: cluster_cpu_allocatable_number
+        chart_type: gauge
+        title: Cluster Cpu Allocatable Number
+        visible: true
+        order: 3
+      - id: karmada-agent-05
+        metric_name: cluster_cpu_allocated_number
+        chart_type: gauge
+        title: Cluster Cpu Allocated Number
+        visible: true
+        order: 4
+      - id: karmada-agent-06
+        metric_name: cluster_memory_allocatable_bytes
+        chart_type: area
+        title: Cluster Memory Allocatable Bytes
+        visible: true
+        order: 5
+      - id: karmada-agent-07
+        metric_name: cluster_memory_allocated_bytes
+        chart_type: area
+        title: Cluster Memory Allocated Bytes
+        visible: true
+        order: 6
+      - id: karmada-agent-08
+        metric_name: cluster_pod_allocatable_number
+        chart_type: gauge
+        title: Cluster Pod Allocatable Number
+        visible: true
+        order: 7
+      - id: karmada-agent-09
+        metric_name: cluster_pod_allocated_number
+        chart_type: gauge
+        title: Cluster Pod Allocated Number
+        visible: true
+        order: 8
+      - id: karmada-agent-10
+        metric_name: cluster_sync_status_duration_seconds
+        chart_type: bar
+        title: Cluster Sync Status Duration Seconds
+        visible: true
+        order: 9
+      - id: karmada-agent-11
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 10
+  - version: 1
+    component: karmada-aggregated-apiserver
+    panels:
+      - id: karmada-aggregated-apiserver-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-aggregated-apiserver-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-aggregated-apiserver-03
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 2
+      - id: karmada-aggregated-apiserver-04
+        metric_name: apiserver_longrunning_requests
+        chart_type: gauge
+        title: Apiserver Longrunning Requests
+        visible: true
+        order: 3
+      - id: karmada-aggregated-apiserver-05
+        metric_name: apiserver_request_sli_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Sli Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-aggregated-apiserver-06
+        metric_name: apiserver_response_sizes
+        chart_type: bar
+        title: Apiserver Response Sizes
+        visible: true
+        order: 5
+      - id: karmada-aggregated-apiserver-07
+        metric_name: apiserver_storage_objects
+        chart_type: gauge
+        title: Apiserver Storage Objects
+        visible: true
+        order: 6
+      - id: karmada-aggregated-apiserver-08
+        metric_name: apiserver_storage_size_bytes
+        chart_type: area
+        title: Apiserver Storage Size Bytes
+        visible: true
+        order: 7
+      - id: karmada-aggregated-apiserver-09
+        metric_name: apiserver_storage_db_total_size_in_bytes
+        chart_type: area
+        title: Apiserver Storage Db Total Size In Bytes
+        visible: true
+        order: 8
+      - id: karmada-aggregated-apiserver-10
+        metric_name: apiserver_tls_handshake_errors_total
+        chart_type: line
+        title: Apiserver Tls Handshake Errors Total
+        visible: true
+        order: 9
+      - id: karmada-aggregated-apiserver-11
+        metric_name: apiserver_delegated_authz_request_total
+        chart_type: line
+        title: Apiserver Delegated Authz Request Total
+        visible: true
+        order: 10
+      - id: karmada-aggregated-apiserver-12
+        metric_name: apiserver_delegated_authz_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Delegated Authz Request Duration Seconds
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-apiserver
+    panels:
+      - id: karmada-apiserver-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-apiserver-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-apiserver-03
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 2
+      - id: karmada-apiserver-04
+        metric_name: apiserver_current_inqueue_requests
+        chart_type: gauge
+        title: Apiserver Current Inqueue Requests
+        visible: true
+        order: 3
+      - id: karmada-apiserver-05
+        metric_name: apiserver_longrunning_requests
+        chart_type: gauge
+        title: Apiserver Longrunning Requests
+        visible: true
+        order: 4
+      - id: karmada-apiserver-06
+        metric_name: apiserver_flowcontrol_current_executing_requests
+        chart_type: gauge
+        title: Apiserver Flowcontrol Current Executing Requests
+        visible: true
+        order: 5
+      - id: karmada-apiserver-07
+        metric_name: apiserver_flowcontrol_current_inqueue_requests
+        chart_type: gauge
+        title: Apiserver Flowcontrol Current Inqueue Requests
+        visible: true
+        order: 6
+      - id: karmada-apiserver-08
+        metric_name: apiserver_flowcontrol_request_wait_duration_seconds
+        chart_type: bar
+        title: Apiserver Flowcontrol Request Wait Duration Seconds
+        visible: true
+        order: 7
+      - id: karmada-apiserver-09
+        metric_name: apiserver_admission_controller_admission_duration_seconds
+        chart_type: bar
+        title: Apiserver Admission Controller Admission Duration Seconds
+        visible: true
+        order: 8
+      - id: karmada-apiserver-10
+        metric_name: apiserver_storage_objects
+        chart_type: gauge
+        title: Apiserver Storage Objects
+        visible: true
+        order: 9
+      - id: karmada-apiserver-11
+        metric_name: apiserver_storage_size_bytes
+        chart_type: area
+        title: Apiserver Storage Size Bytes
+        visible: true
+        order: 10
+      - id: karmada-apiserver-12
+        metric_name: apiserver_tls_handshake_errors_total
+        chart_type: line
+        title: Apiserver Tls Handshake Errors Total
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-descheduler
+    panels:
+      - id: karmada-descheduler-01
+        metric_name: leader_election_master_status
+        chart_type: gauge
+        title: Leader Election Master Status
+        visible: true
+        order: 0
+      - id: karmada-descheduler-02
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 1
+      - id: karmada-descheduler-03
+        metric_name: workqueue_adds_total
+        chart_type: line
+        title: Workqueue Adds Total
+        visible: true
+        order: 2
+      - id: karmada-descheduler-04
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 3
+      - id: karmada-descheduler-05
+        metric_name: workqueue_queue_duration_seconds
+        chart_type: bar
+        title: Workqueue Queue Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-descheduler-06
+        metric_name: workqueue_work_duration_seconds
+        chart_type: bar
+        title: Workqueue Work Duration Seconds
+        visible: true
+        order: 5
+      - id: karmada-descheduler-07
+        metric_name: workqueue_longest_running_processor_seconds
+        chart_type: gauge
+        title: Workqueue Longest Running Processor Seconds
+        visible: true
+        order: 6
+      - id: karmada-descheduler-08
+        metric_name: workqueue_unfinished_work_seconds
+        chart_type: gauge
+        title: Workqueue Unfinished Work Seconds
+        visible: true
+        order: 7
+  - version: 1
+    component: karmada-kube-controller-manager
+    panels:
+      - id: karmada-kube-controller-manager-01
+        metric_name: node_collector_update_all_nodes_health_duration_seconds
+        chart_type: bar
+        title: Node Collector Update All Nodes Health Duration Seconds
+        visible: true
+        order: 0
+      - id: karmada-kube-controller-manager-02
+        metric_name: node_collector_update_node_health_duration_seconds
+        chart_type: bar
+        title: Node Collector Update Node Health Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-kube-controller-manager-03
+        metric_name: garbagecollector_controller_resources_sync_error_total
+        chart_type: line
+        title: Garbagecollector Controller Resources Sync Error Total
+        visible: true
+        order: 2
+      - id: karmada-kube-controller-manager-04
+        metric_name: ttl_after_finished_controller_job_deletion_duration_seconds
+        chart_type: bar
+        title: Ttl After Finished Controller Job Deletion Duration Seconds
+        visible: true
+        order: 3
+      - id: karmada-kube-controller-manager-05
+        metric_name: leader_election_master_status
+        chart_type: gauge
+        title: Leader Election Master Status
+        visible: true
+        order: 4
+      - id: karmada-kube-controller-manager-06
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 5
+      - id: karmada-kube-controller-manager-07
+        metric_name: workqueue_adds_total
+        chart_type: line
+        title: Workqueue Adds Total
+        visible: true
+        order: 6
+      - id: karmada-kube-controller-manager-08
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 7
+      - id: karmada-kube-controller-manager-09
+        metric_name: workqueue_longest_running_processor_seconds
+        chart_type: gauge
+        title: Workqueue Longest Running Processor Seconds
+        visible: true
+        order: 8
+      - id: karmada-kube-controller-manager-10
+        metric_name: workqueue_unfinished_work_seconds
+        chart_type: gauge
+        title: Workqueue Unfinished Work Seconds
+        visible: true
+        order: 9
+  - version: 1
+    component: karmada-metrics-adapter
+    panels:
+      - id: karmada-metrics-adapter-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-metrics-adapter-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-metrics-adapter-03
+        metric_name: apiserver_request_sli_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Sli Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-metrics-adapter-04
+        metric_name: apiserver_request_slo_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Slo Duration Seconds
+        visible: true
+        order: 3
+      - id: karmada-metrics-adapter-05
+        metric_name: apiserver_request_filter_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Filter Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-metrics-adapter-06
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 5
+      - id: karmada-metrics-adapter-07
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 6
+      - id: karmada-metrics-adapter-08
+        metric_name: workqueue_adds_total
+        chart_type: line
+        title: Workqueue Adds Total
+        visible: true
+        order: 7
+      - id: karmada-metrics-adapter-09
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 8
+  - version: 1
+    component: karmada-scheduler-estimator-member1
+    panels:
+      - id: karmada-scheduler-estimator-member1-01
+        metric_name: karmada_scheduler_estimator_estimating_request_total
+        chart_type: line
+        title: Karmada Scheduler Estimator Estimating Request Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-estimator-member1-02
+        metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-scheduler-estimator-member1-03
+        metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-estimator-member1-04
+        metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+        visible: true
+        order: 3
+  - version: 1
+    component: karmada-scheduler-estimator-member2
+    panels:
+      - id: karmada-scheduler-estimator-member2-01
+        metric_name: karmada_scheduler_estimator_estimating_request_total
+        chart_type: line
+        title: Karmada Scheduler Estimator Estimating Request Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-estimator-member2-02
+        metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-scheduler-estimator-member2-03
+        metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-estimator-member2-04
+        metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+        visible: true
+        order: 3
+  - version: 1
+    component: karmada-scheduler-estimator-member3
+    panels:
+      - id: karmada-scheduler-estimator-member3-01
+        metric_name: karmada_scheduler_estimator_estimating_request_total
+        chart_type: line
+        title: Karmada Scheduler Estimator Estimating Request Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-estimator-member3-02
+        metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-scheduler-estimator-member3-03
+        metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-estimator-member3-04
+        metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+        visible: true
+        order: 3
+  - version: 1
+    component: karmada-search
+    panels:
+      - id: karmada-search-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-search-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-search-03
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 2
+      - id: karmada-search-04
+        metric_name: apiserver_longrunning_requests
+        chart_type: gauge
+        title: Apiserver Longrunning Requests
+        visible: true
+        order: 3
+      - id: karmada-search-05
+        metric_name: apiserver_request_sli_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Sli Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-search-06
+        metric_name: apiserver_request_slo_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Slo Duration Seconds
+        visible: true
+        order: 5
+      - id: karmada-search-07
+        metric_name: apiserver_request_filter_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Filter Duration Seconds
+        visible: true
+        order: 6
+      - id: karmada-search-08
+        metric_name: apiserver_storage_objects
+        chart_type: gauge
+        title: Apiserver Storage Objects
+        visible: true
+        order: 7
+      - id: karmada-search-09
+        metric_name: apiserver_storage_size_bytes
+        chart_type: area
+        title: Apiserver Storage Size Bytes
+        visible: true
+        order: 8
+      - id: karmada-search-10
+        metric_name: etcd_request_duration_seconds
+        chart_type: bar
+        title: Etcd Request Duration Seconds
+        visible: true
+        order: 9
+      - id: karmada-search-11
+        metric_name: etcd_requests_total
+        chart_type: line
+        title: Etcd Requests Total
+        visible: true
+        order: 10
+      - id: karmada-search-12
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-webhook
+    panels:
+      - id: karmada-webhook-01
+        metric_name: controller_runtime_webhook_requests_total
+        chart_type: line
+        title: Controller Runtime Webhook Requests Total
+        visible: true
+        order: 0
+      - id: karmada-webhook-02
+        metric_name: controller_runtime_webhook_latency_seconds
+        chart_type: bar
+        title: Controller Runtime Webhook Latency Seconds
+        visible: true
+        order: 1
+      - id: karmada-webhook-03
+        metric_name: controller_runtime_webhook_requests_in_flight
+        chart_type: gauge
+        title: Controller Runtime Webhook Requests In Flight
+        visible: true
+        order: 2
+      - id: karmada-webhook-04
+        metric_name: controller_runtime_webhook_panics_total
+        chart_type: line
+        title: Controller Runtime Webhook Panics Total
+        visible: true
+        order: 3
+      - id: karmada-webhook-05
+        metric_name: controller_runtime_conversion_webhook_panics_total
+        chart_type: line
+        title: Controller Runtime Conversion Webhook Panics Total
+        visible: true
+        order: 4
 menu_configs:
   - path: /overview
     enable: true
@@ -9,6 +727,9 @@ menu_configs:
   - path: /topology
     enable: true
     sidebar_key: TOPOLOGY
+  - path: /metrics
+    enable: true
+    sidebar_key: METRICS
   - path: /multicloud-resource-manage
     enable: true
     sidebar_key: MULTICLOUD-RESOURCE-MANAGE

--- a/artifacts/overlays/nodeport-mode/dashboard-config.yaml
+++ b/artifacts/overlays/nodeport-mode/dashboard-config.yaml
@@ -2,6 +2,724 @@ docker_registries: []
 chart_registries: []
 # path_prefix: '/karmada'
 path_prefix: ''
+metrics_dashboards:
+  - version: 1
+    component: karmada-scheduler
+    panels:
+      - id: karmada-scheduler-01
+        metric_name: karmada_scheduler_schedule_attempts_total
+        chart_type: line
+        title: Karmada Scheduler Schedule Attempts Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-02
+        metric_name: karmada_scheduler_queue_incoming_bindings_total
+        chart_type: line
+        title: Karmada Scheduler Queue Incoming Bindings Total
+        visible: true
+        order: 1
+      - id: karmada-scheduler-03
+        metric_name: karmada_scheduler_e2e_scheduling_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler E2e Scheduling Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-04
+        metric_name: karmada_scheduler_scheduling_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Scheduling Algorithm Duration Seconds
+        visible: true
+        order: 3
+      - id: karmada-scheduler-05
+        metric_name: karmada_scheduler_framework_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Framework Extension Point Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-scheduler-06
+        metric_name: karmada_scheduler_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Plugin Execution Duration Seconds
+        visible: true
+        order: 5
+      - id: karmada-scheduler-07
+        metric_name: leader_election_master_status
+        chart_type: gauge
+        title: Leader Election Master Status
+        visible: true
+        order: 6
+      - id: karmada-scheduler-08
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 7
+      - id: karmada-scheduler-09
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 8
+      - id: karmada-scheduler-10
+        metric_name: workqueue_longest_running_processor_seconds
+        chart_type: gauge
+        title: Workqueue Longest Running Processor Seconds
+        visible: true
+        order: 9
+  - version: 1
+    component: karmada-controller-manager
+    panels:
+      - id: karmada-controller-manager-01
+        metric_name: cluster_ready_state
+        chart_type: gauge
+        title: Cluster Ready State
+        visible: true
+        order: 0
+      - id: karmada-controller-manager-02
+        metric_name: cluster_ready_node_number
+        chart_type: gauge
+        title: Cluster Ready Node Number
+        visible: true
+        order: 1
+      - id: karmada-controller-manager-03
+        metric_name: cluster_node_number
+        chart_type: gauge
+        title: Cluster Node Number
+        visible: true
+        order: 2
+      - id: karmada-controller-manager-04
+        metric_name: cluster_cpu_allocatable_number
+        chart_type: gauge
+        title: Cluster Cpu Allocatable Number
+        visible: true
+        order: 3
+      - id: karmada-controller-manager-05
+        metric_name: cluster_cpu_allocated_number
+        chart_type: gauge
+        title: Cluster Cpu Allocated Number
+        visible: true
+        order: 4
+      - id: karmada-controller-manager-06
+        metric_name: cluster_memory_allocatable_bytes
+        chart_type: area
+        title: Cluster Memory Allocatable Bytes
+        visible: true
+        order: 5
+      - id: karmada-controller-manager-07
+        metric_name: cluster_memory_allocated_bytes
+        chart_type: area
+        title: Cluster Memory Allocated Bytes
+        visible: true
+        order: 6
+      - id: karmada-controller-manager-08
+        metric_name: cluster_pod_allocatable_number
+        chart_type: gauge
+        title: Cluster Pod Allocatable Number
+        visible: true
+        order: 7
+      - id: karmada-controller-manager-09
+        metric_name: cluster_pod_allocated_number
+        chart_type: gauge
+        title: Cluster Pod Allocated Number
+        visible: true
+        order: 8
+      - id: karmada-controller-manager-10
+        metric_name: cluster_sync_status_duration_seconds
+        chart_type: bar
+        title: Cluster Sync Status Duration Seconds
+        visible: true
+        order: 9
+      - id: karmada-controller-manager-11
+        metric_name: policy_apply_attempts_total
+        chart_type: line
+        title: Policy Apply Attempts Total
+        visible: true
+        order: 10
+      - id: karmada-controller-manager-12
+        metric_name: resource_apply_policy_duration_seconds
+        chart_type: bar
+        title: Resource Apply Policy Duration Seconds
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-agent
+    panels:
+      - id: karmada-agent-01
+        metric_name: cluster_ready_state
+        chart_type: gauge
+        title: Cluster Ready State
+        visible: true
+        order: 0
+      - id: karmada-agent-02
+        metric_name: cluster_ready_node_number
+        chart_type: gauge
+        title: Cluster Ready Node Number
+        visible: true
+        order: 1
+      - id: karmada-agent-03
+        metric_name: cluster_node_number
+        chart_type: gauge
+        title: Cluster Node Number
+        visible: true
+        order: 2
+      - id: karmada-agent-04
+        metric_name: cluster_cpu_allocatable_number
+        chart_type: gauge
+        title: Cluster Cpu Allocatable Number
+        visible: true
+        order: 3
+      - id: karmada-agent-05
+        metric_name: cluster_cpu_allocated_number
+        chart_type: gauge
+        title: Cluster Cpu Allocated Number
+        visible: true
+        order: 4
+      - id: karmada-agent-06
+        metric_name: cluster_memory_allocatable_bytes
+        chart_type: area
+        title: Cluster Memory Allocatable Bytes
+        visible: true
+        order: 5
+      - id: karmada-agent-07
+        metric_name: cluster_memory_allocated_bytes
+        chart_type: area
+        title: Cluster Memory Allocated Bytes
+        visible: true
+        order: 6
+      - id: karmada-agent-08
+        metric_name: cluster_pod_allocatable_number
+        chart_type: gauge
+        title: Cluster Pod Allocatable Number
+        visible: true
+        order: 7
+      - id: karmada-agent-09
+        metric_name: cluster_pod_allocated_number
+        chart_type: gauge
+        title: Cluster Pod Allocated Number
+        visible: true
+        order: 8
+      - id: karmada-agent-10
+        metric_name: cluster_sync_status_duration_seconds
+        chart_type: bar
+        title: Cluster Sync Status Duration Seconds
+        visible: true
+        order: 9
+      - id: karmada-agent-11
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 10
+  - version: 1
+    component: karmada-aggregated-apiserver
+    panels:
+      - id: karmada-aggregated-apiserver-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-aggregated-apiserver-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-aggregated-apiserver-03
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 2
+      - id: karmada-aggregated-apiserver-04
+        metric_name: apiserver_longrunning_requests
+        chart_type: gauge
+        title: Apiserver Longrunning Requests
+        visible: true
+        order: 3
+      - id: karmada-aggregated-apiserver-05
+        metric_name: apiserver_request_sli_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Sli Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-aggregated-apiserver-06
+        metric_name: apiserver_response_sizes
+        chart_type: bar
+        title: Apiserver Response Sizes
+        visible: true
+        order: 5
+      - id: karmada-aggregated-apiserver-07
+        metric_name: apiserver_storage_objects
+        chart_type: gauge
+        title: Apiserver Storage Objects
+        visible: true
+        order: 6
+      - id: karmada-aggregated-apiserver-08
+        metric_name: apiserver_storage_size_bytes
+        chart_type: area
+        title: Apiserver Storage Size Bytes
+        visible: true
+        order: 7
+      - id: karmada-aggregated-apiserver-09
+        metric_name: apiserver_storage_db_total_size_in_bytes
+        chart_type: area
+        title: Apiserver Storage Db Total Size In Bytes
+        visible: true
+        order: 8
+      - id: karmada-aggregated-apiserver-10
+        metric_name: apiserver_tls_handshake_errors_total
+        chart_type: line
+        title: Apiserver Tls Handshake Errors Total
+        visible: true
+        order: 9
+      - id: karmada-aggregated-apiserver-11
+        metric_name: apiserver_delegated_authz_request_total
+        chart_type: line
+        title: Apiserver Delegated Authz Request Total
+        visible: true
+        order: 10
+      - id: karmada-aggregated-apiserver-12
+        metric_name: apiserver_delegated_authz_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Delegated Authz Request Duration Seconds
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-apiserver
+    panels:
+      - id: karmada-apiserver-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-apiserver-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-apiserver-03
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 2
+      - id: karmada-apiserver-04
+        metric_name: apiserver_current_inqueue_requests
+        chart_type: gauge
+        title: Apiserver Current Inqueue Requests
+        visible: true
+        order: 3
+      - id: karmada-apiserver-05
+        metric_name: apiserver_longrunning_requests
+        chart_type: gauge
+        title: Apiserver Longrunning Requests
+        visible: true
+        order: 4
+      - id: karmada-apiserver-06
+        metric_name: apiserver_flowcontrol_current_executing_requests
+        chart_type: gauge
+        title: Apiserver Flowcontrol Current Executing Requests
+        visible: true
+        order: 5
+      - id: karmada-apiserver-07
+        metric_name: apiserver_flowcontrol_current_inqueue_requests
+        chart_type: gauge
+        title: Apiserver Flowcontrol Current Inqueue Requests
+        visible: true
+        order: 6
+      - id: karmada-apiserver-08
+        metric_name: apiserver_flowcontrol_request_wait_duration_seconds
+        chart_type: bar
+        title: Apiserver Flowcontrol Request Wait Duration Seconds
+        visible: true
+        order: 7
+      - id: karmada-apiserver-09
+        metric_name: apiserver_admission_controller_admission_duration_seconds
+        chart_type: bar
+        title: Apiserver Admission Controller Admission Duration Seconds
+        visible: true
+        order: 8
+      - id: karmada-apiserver-10
+        metric_name: apiserver_storage_objects
+        chart_type: gauge
+        title: Apiserver Storage Objects
+        visible: true
+        order: 9
+      - id: karmada-apiserver-11
+        metric_name: apiserver_storage_size_bytes
+        chart_type: area
+        title: Apiserver Storage Size Bytes
+        visible: true
+        order: 10
+      - id: karmada-apiserver-12
+        metric_name: apiserver_tls_handshake_errors_total
+        chart_type: line
+        title: Apiserver Tls Handshake Errors Total
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-descheduler
+    panels:
+      - id: karmada-descheduler-01
+        metric_name: leader_election_master_status
+        chart_type: gauge
+        title: Leader Election Master Status
+        visible: true
+        order: 0
+      - id: karmada-descheduler-02
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 1
+      - id: karmada-descheduler-03
+        metric_name: workqueue_adds_total
+        chart_type: line
+        title: Workqueue Adds Total
+        visible: true
+        order: 2
+      - id: karmada-descheduler-04
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 3
+      - id: karmada-descheduler-05
+        metric_name: workqueue_queue_duration_seconds
+        chart_type: bar
+        title: Workqueue Queue Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-descheduler-06
+        metric_name: workqueue_work_duration_seconds
+        chart_type: bar
+        title: Workqueue Work Duration Seconds
+        visible: true
+        order: 5
+      - id: karmada-descheduler-07
+        metric_name: workqueue_longest_running_processor_seconds
+        chart_type: gauge
+        title: Workqueue Longest Running Processor Seconds
+        visible: true
+        order: 6
+      - id: karmada-descheduler-08
+        metric_name: workqueue_unfinished_work_seconds
+        chart_type: gauge
+        title: Workqueue Unfinished Work Seconds
+        visible: true
+        order: 7
+  - version: 1
+    component: karmada-kube-controller-manager
+    panels:
+      - id: karmada-kube-controller-manager-01
+        metric_name: node_collector_update_all_nodes_health_duration_seconds
+        chart_type: bar
+        title: Node Collector Update All Nodes Health Duration Seconds
+        visible: true
+        order: 0
+      - id: karmada-kube-controller-manager-02
+        metric_name: node_collector_update_node_health_duration_seconds
+        chart_type: bar
+        title: Node Collector Update Node Health Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-kube-controller-manager-03
+        metric_name: garbagecollector_controller_resources_sync_error_total
+        chart_type: line
+        title: Garbagecollector Controller Resources Sync Error Total
+        visible: true
+        order: 2
+      - id: karmada-kube-controller-manager-04
+        metric_name: ttl_after_finished_controller_job_deletion_duration_seconds
+        chart_type: bar
+        title: Ttl After Finished Controller Job Deletion Duration Seconds
+        visible: true
+        order: 3
+      - id: karmada-kube-controller-manager-05
+        metric_name: leader_election_master_status
+        chart_type: gauge
+        title: Leader Election Master Status
+        visible: true
+        order: 4
+      - id: karmada-kube-controller-manager-06
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 5
+      - id: karmada-kube-controller-manager-07
+        metric_name: workqueue_adds_total
+        chart_type: line
+        title: Workqueue Adds Total
+        visible: true
+        order: 6
+      - id: karmada-kube-controller-manager-08
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 7
+      - id: karmada-kube-controller-manager-09
+        metric_name: workqueue_longest_running_processor_seconds
+        chart_type: gauge
+        title: Workqueue Longest Running Processor Seconds
+        visible: true
+        order: 8
+      - id: karmada-kube-controller-manager-10
+        metric_name: workqueue_unfinished_work_seconds
+        chart_type: gauge
+        title: Workqueue Unfinished Work Seconds
+        visible: true
+        order: 9
+  - version: 1
+    component: karmada-metrics-adapter
+    panels:
+      - id: karmada-metrics-adapter-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-metrics-adapter-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-metrics-adapter-03
+        metric_name: apiserver_request_sli_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Sli Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-metrics-adapter-04
+        metric_name: apiserver_request_slo_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Slo Duration Seconds
+        visible: true
+        order: 3
+      - id: karmada-metrics-adapter-05
+        metric_name: apiserver_request_filter_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Filter Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-metrics-adapter-06
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 5
+      - id: karmada-metrics-adapter-07
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 6
+      - id: karmada-metrics-adapter-08
+        metric_name: workqueue_adds_total
+        chart_type: line
+        title: Workqueue Adds Total
+        visible: true
+        order: 7
+      - id: karmada-metrics-adapter-09
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 8
+  - version: 1
+    component: karmada-scheduler-estimator-member1
+    panels:
+      - id: karmada-scheduler-estimator-member1-01
+        metric_name: karmada_scheduler_estimator_estimating_request_total
+        chart_type: line
+        title: Karmada Scheduler Estimator Estimating Request Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-estimator-member1-02
+        metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-scheduler-estimator-member1-03
+        metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-estimator-member1-04
+        metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+        visible: true
+        order: 3
+  - version: 1
+    component: karmada-scheduler-estimator-member2
+    panels:
+      - id: karmada-scheduler-estimator-member2-01
+        metric_name: karmada_scheduler_estimator_estimating_request_total
+        chart_type: line
+        title: Karmada Scheduler Estimator Estimating Request Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-estimator-member2-02
+        metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-scheduler-estimator-member2-03
+        metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-estimator-member2-04
+        metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+        visible: true
+        order: 3
+  - version: 1
+    component: karmada-scheduler-estimator-member3
+    panels:
+      - id: karmada-scheduler-estimator-member3-01
+        metric_name: karmada_scheduler_estimator_estimating_request_total
+        chart_type: line
+        title: Karmada Scheduler Estimator Estimating Request Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-estimator-member3-02
+        metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-scheduler-estimator-member3-03
+        metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-estimator-member3-04
+        metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+        visible: true
+        order: 3
+  - version: 1
+    component: karmada-search
+    panels:
+      - id: karmada-search-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-search-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-search-03
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 2
+      - id: karmada-search-04
+        metric_name: apiserver_longrunning_requests
+        chart_type: gauge
+        title: Apiserver Longrunning Requests
+        visible: true
+        order: 3
+      - id: karmada-search-05
+        metric_name: apiserver_request_sli_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Sli Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-search-06
+        metric_name: apiserver_request_slo_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Slo Duration Seconds
+        visible: true
+        order: 5
+      - id: karmada-search-07
+        metric_name: apiserver_request_filter_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Filter Duration Seconds
+        visible: true
+        order: 6
+      - id: karmada-search-08
+        metric_name: apiserver_storage_objects
+        chart_type: gauge
+        title: Apiserver Storage Objects
+        visible: true
+        order: 7
+      - id: karmada-search-09
+        metric_name: apiserver_storage_size_bytes
+        chart_type: area
+        title: Apiserver Storage Size Bytes
+        visible: true
+        order: 8
+      - id: karmada-search-10
+        metric_name: etcd_request_duration_seconds
+        chart_type: bar
+        title: Etcd Request Duration Seconds
+        visible: true
+        order: 9
+      - id: karmada-search-11
+        metric_name: etcd_requests_total
+        chart_type: line
+        title: Etcd Requests Total
+        visible: true
+        order: 10
+      - id: karmada-search-12
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-webhook
+    panels:
+      - id: karmada-webhook-01
+        metric_name: controller_runtime_webhook_requests_total
+        chart_type: line
+        title: Controller Runtime Webhook Requests Total
+        visible: true
+        order: 0
+      - id: karmada-webhook-02
+        metric_name: controller_runtime_webhook_latency_seconds
+        chart_type: bar
+        title: Controller Runtime Webhook Latency Seconds
+        visible: true
+        order: 1
+      - id: karmada-webhook-03
+        metric_name: controller_runtime_webhook_requests_in_flight
+        chart_type: gauge
+        title: Controller Runtime Webhook Requests In Flight
+        visible: true
+        order: 2
+      - id: karmada-webhook-04
+        metric_name: controller_runtime_webhook_panics_total
+        chart_type: line
+        title: Controller Runtime Webhook Panics Total
+        visible: true
+        order: 3
+      - id: karmada-webhook-05
+        metric_name: controller_runtime_conversion_webhook_panics_total
+        chart_type: line
+        title: Controller Runtime Conversion Webhook Panics Total
+        visible: true
+        order: 4
 menu_configs:
   - path: /overview
     enable: true
@@ -9,6 +727,9 @@ menu_configs:
   - path: /topology
     enable: true
     sidebar_key: TOPOLOGY
+  - path: /metrics
+    enable: true
+    sidebar_key: METRICS
   - path: /multicloud-resource-manage
     enable: true
     sidebar_key: MULTICLOUD-RESOURCE-MANAGE

--- a/charts/karmada-dashboard/templates/_helpers.tpl
+++ b/charts/karmada-dashboard/templates/_helpers.tpl
@@ -119,5 +119,25 @@ app: {{ include "karmada-dashboard.name" . }}-kubernetes-dashboard-api
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "karmada-dashboard.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.api.image .Values.web.image .Values.kubernetes_dashboard_api.image) "global" .Values.global) }}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.api.image .Values.web.image .Values.kubernetes_dashboard_api.image .Values.metrics_scraper.image) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper metrics-scraper image name
+*/}}
+{{- define "karmada-dashboard.metrics-scraper.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.metrics_scraper.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+metrics-scraper labels
+*/}}
+{{- define "karmada-dashboard.metrics-scraper.labels" -}}
+{{ include "karmada-dashboard.labels" . }}
+app: {{ include "karmada-dashboard.name" . }}-metrics-scraper
+{{- if .Values.metrics_scraper.labels }}
+{{- range $key, $value := .Values.metrics_scraper.labels }}
+{{ $key }}: {{ $value }}
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/charts/karmada-dashboard/templates/karmada-dashboard-configmap.yaml
+++ b/charts/karmada-dashboard/templates/karmada-dashboard-configmap.yaml
@@ -14,6 +14,9 @@ data:
       - path: /topology
         enable: true
         sidebar_key: TOPOLOGY
+      - path: /metrics
+        enable: true
+        sidebar_key: METRICS
       - path: /multicloud-resource-manage
         enable: true
         sidebar_key: MULTICLOUD-RESOURCE-MANAGE
@@ -88,6 +91,10 @@ data:
   prod.yaml: |-
     docker_registries: [ ]
     chart_registries: [ ]
+{{ with .Values.dashboardConfig.metricsDashboards }}
+    metrics_dashboards:
+{{ toYaml . | nindent 6 }}
+{{ end }}
     menu_configs:
       - path: /overview
         enable: true
@@ -95,6 +102,9 @@ data:
       - path: /topology
         enable: true
         sidebar_key: TOPOLOGY
+      - path: /metrics
+        enable: true
+        sidebar_key: METRICS
       - path: /multicloud-resource-manage
         enable: true
         sidebar_key: MULTICLOUD-RESOURCE-MANAGE

--- a/charts/karmada-dashboard/templates/karmada-dashboard-metrics-scraper-service.yaml
+++ b/charts/karmada-dashboard/templates/karmada-dashboard-metrics-scraper-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "karmada-dashboard.name" . }}-metrics-scraper
+  namespace: {{ include "karmada-dashboard.namespace" . }}
+  labels:
+    {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.metrics_scraper.service.type }}
+  ports:
+    - port: {{ .Values.metrics_scraper.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 4 }}

--- a/charts/karmada-dashboard/templates/karmada-dashboard-metrics-scraper.yaml
+++ b/charts/karmada-dashboard/templates/karmada-dashboard-metrics-scraper.yaml
@@ -1,0 +1,108 @@
+{{- $name := include "karmada-dashboard.name" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}-metrics-scraper
+  namespace: {{ include "karmada-dashboard.namespace" . }}
+  labels:
+    {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 6 }}
+  replicas: {{ .Values.metrics_scraper.replicaCount }}
+  {{- with .Values.metrics_scraper.strategy }}
+  strategy:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      {{- with .Values.metrics_scraper.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 8 }}
+        {{- with .Values.metrics_scraper.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: karmada-dashboard
+      {{- include "karmada-dashboard.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.metrics_scraper.podSecurityContext | nindent 8 }}
+      containers:
+        - name: metrics-scraper
+          securityContext:
+            {{- toYaml .Values.metrics_scraper.securityContext | nindent 12 }}
+          image: {{ template "karmada-dashboard.metrics-scraper.image" . }}
+          imagePullPolicy: {{ .Values.metrics_scraper.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.metrics_scraper.service.port }}
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 15
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 8000
+              scheme: HTTP
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 15
+          resources:
+            {{- toYaml .Values.metrics_scraper.resources | nindent 12 }}
+          volumeMounts:
+            - name: kubeconfig-secret
+              subPath: kubeconfig
+              mountPath: /etc/kubeconfig
+          command:
+            - karmada-dashboard-metrics-scraper
+            - --karmada-kubeconfig=/etc/kubeconfig
+            - --karmada-context={{ .Values.metrics_scraper.kubeconfigContext }}
+            - --kubeconfig=/etc/kubeconfig
+            - --context={{ .Values.metrics_scraper.kubeconfigContext }}
+            - --insecure-bind-address=0.0.0.0
+            - --bind-address=0.0.0.0
+      volumes:
+        - name: kubeconfig-secret
+          secret:
+            secretName: {{ .Values.metrics_scraper.kubeconfigName }}
+      {{- with .Values.metrics_scraper.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics_scraper.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics_scraper.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+{{ if .Values.metrics_scraper.podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}-metrics-scraper
+  namespace: {{ include "karmada-dashboard.namespace" . }}
+  labels:
+    {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 6 }}
+  {{ toYaml .Values.metrics_scraper.podDisruptionBudget | nindent 2 }}
+{{- end -}}

--- a/charts/karmada-dashboard/values.yaml
+++ b/charts/karmada-dashboard/values.yaml
@@ -27,6 +27,728 @@ karmadaDashboardImagePullPolicy: &karmadaDashboardImagePullPolicy IfNotPresent
 
 podDisruptionBudget: &podDisruptionBudget { }
 
+## Default component dashboard layouts persisted in karmada-dashboard-configmap.
+## @param dashboardConfig.metricsDashboards metrics panels displayed for each Karmada component
+dashboardConfig:
+  metricsDashboards:
+    - version: 1
+      component: karmada-scheduler
+      panels:
+        - id: karmada-scheduler-01
+          metric_name: karmada_scheduler_schedule_attempts_total
+          chart_type: line
+          title: Karmada Scheduler Schedule Attempts Total
+          visible: true
+          order: 0
+        - id: karmada-scheduler-02
+          metric_name: karmada_scheduler_queue_incoming_bindings_total
+          chart_type: line
+          title: Karmada Scheduler Queue Incoming Bindings Total
+          visible: true
+          order: 1
+        - id: karmada-scheduler-03
+          metric_name: karmada_scheduler_e2e_scheduling_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler E2e Scheduling Duration Seconds
+          visible: true
+          order: 2
+        - id: karmada-scheduler-04
+          metric_name: karmada_scheduler_scheduling_algorithm_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Scheduling Algorithm Duration Seconds
+          visible: true
+          order: 3
+        - id: karmada-scheduler-05
+          metric_name: karmada_scheduler_framework_extension_point_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Framework Extension Point Duration Seconds
+          visible: true
+          order: 4
+        - id: karmada-scheduler-06
+          metric_name: karmada_scheduler_plugin_execution_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Plugin Execution Duration Seconds
+          visible: true
+          order: 5
+        - id: karmada-scheduler-07
+          metric_name: leader_election_master_status
+          chart_type: gauge
+          title: Leader Election Master Status
+          visible: true
+          order: 6
+        - id: karmada-scheduler-08
+          metric_name: workqueue_depth
+          chart_type: gauge
+          title: Workqueue Depth
+          visible: true
+          order: 7
+        - id: karmada-scheduler-09
+          metric_name: workqueue_retries_total
+          chart_type: line
+          title: Workqueue Retries Total
+          visible: true
+          order: 8
+        - id: karmada-scheduler-10
+          metric_name: workqueue_longest_running_processor_seconds
+          chart_type: gauge
+          title: Workqueue Longest Running Processor Seconds
+          visible: true
+          order: 9
+    - version: 1
+      component: karmada-controller-manager
+      panels:
+        - id: karmada-controller-manager-01
+          metric_name: cluster_ready_state
+          chart_type: gauge
+          title: Cluster Ready State
+          visible: true
+          order: 0
+        - id: karmada-controller-manager-02
+          metric_name: cluster_ready_node_number
+          chart_type: gauge
+          title: Cluster Ready Node Number
+          visible: true
+          order: 1
+        - id: karmada-controller-manager-03
+          metric_name: cluster_node_number
+          chart_type: gauge
+          title: Cluster Node Number
+          visible: true
+          order: 2
+        - id: karmada-controller-manager-04
+          metric_name: cluster_cpu_allocatable_number
+          chart_type: gauge
+          title: Cluster Cpu Allocatable Number
+          visible: true
+          order: 3
+        - id: karmada-controller-manager-05
+          metric_name: cluster_cpu_allocated_number
+          chart_type: gauge
+          title: Cluster Cpu Allocated Number
+          visible: true
+          order: 4
+        - id: karmada-controller-manager-06
+          metric_name: cluster_memory_allocatable_bytes
+          chart_type: area
+          title: Cluster Memory Allocatable Bytes
+          visible: true
+          order: 5
+        - id: karmada-controller-manager-07
+          metric_name: cluster_memory_allocated_bytes
+          chart_type: area
+          title: Cluster Memory Allocated Bytes
+          visible: true
+          order: 6
+        - id: karmada-controller-manager-08
+          metric_name: cluster_pod_allocatable_number
+          chart_type: gauge
+          title: Cluster Pod Allocatable Number
+          visible: true
+          order: 7
+        - id: karmada-controller-manager-09
+          metric_name: cluster_pod_allocated_number
+          chart_type: gauge
+          title: Cluster Pod Allocated Number
+          visible: true
+          order: 8
+        - id: karmada-controller-manager-10
+          metric_name: cluster_sync_status_duration_seconds
+          chart_type: bar
+          title: Cluster Sync Status Duration Seconds
+          visible: true
+          order: 9
+        - id: karmada-controller-manager-11
+          metric_name: policy_apply_attempts_total
+          chart_type: line
+          title: Policy Apply Attempts Total
+          visible: true
+          order: 10
+        - id: karmada-controller-manager-12
+          metric_name: resource_apply_policy_duration_seconds
+          chart_type: bar
+          title: Resource Apply Policy Duration Seconds
+          visible: true
+          order: 11
+    - version: 1
+      component: karmada-agent
+      panels:
+        - id: karmada-agent-01
+          metric_name: cluster_ready_state
+          chart_type: gauge
+          title: Cluster Ready State
+          visible: true
+          order: 0
+        - id: karmada-agent-02
+          metric_name: cluster_ready_node_number
+          chart_type: gauge
+          title: Cluster Ready Node Number
+          visible: true
+          order: 1
+        - id: karmada-agent-03
+          metric_name: cluster_node_number
+          chart_type: gauge
+          title: Cluster Node Number
+          visible: true
+          order: 2
+        - id: karmada-agent-04
+          metric_name: cluster_cpu_allocatable_number
+          chart_type: gauge
+          title: Cluster Cpu Allocatable Number
+          visible: true
+          order: 3
+        - id: karmada-agent-05
+          metric_name: cluster_cpu_allocated_number
+          chart_type: gauge
+          title: Cluster Cpu Allocated Number
+          visible: true
+          order: 4
+        - id: karmada-agent-06
+          metric_name: cluster_memory_allocatable_bytes
+          chart_type: area
+          title: Cluster Memory Allocatable Bytes
+          visible: true
+          order: 5
+        - id: karmada-agent-07
+          metric_name: cluster_memory_allocated_bytes
+          chart_type: area
+          title: Cluster Memory Allocated Bytes
+          visible: true
+          order: 6
+        - id: karmada-agent-08
+          metric_name: cluster_pod_allocatable_number
+          chart_type: gauge
+          title: Cluster Pod Allocatable Number
+          visible: true
+          order: 7
+        - id: karmada-agent-09
+          metric_name: cluster_pod_allocated_number
+          chart_type: gauge
+          title: Cluster Pod Allocated Number
+          visible: true
+          order: 8
+        - id: karmada-agent-10
+          metric_name: cluster_sync_status_duration_seconds
+          chart_type: bar
+          title: Cluster Sync Status Duration Seconds
+          visible: true
+          order: 9
+        - id: karmada-agent-11
+          metric_name: workqueue_depth
+          chart_type: gauge
+          title: Workqueue Depth
+          visible: true
+          order: 10
+    - version: 1
+      component: karmada-aggregated-apiserver
+      panels:
+        - id: karmada-aggregated-apiserver-01
+          metric_name: apiserver_request_total
+          chart_type: line
+          title: Apiserver Request Total
+          visible: true
+          order: 0
+        - id: karmada-aggregated-apiserver-02
+          metric_name: apiserver_request_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-aggregated-apiserver-03
+          metric_name: apiserver_current_inflight_requests
+          chart_type: gauge
+          title: Apiserver Current Inflight Requests
+          visible: true
+          order: 2
+        - id: karmada-aggregated-apiserver-04
+          metric_name: apiserver_longrunning_requests
+          chart_type: gauge
+          title: Apiserver Longrunning Requests
+          visible: true
+          order: 3
+        - id: karmada-aggregated-apiserver-05
+          metric_name: apiserver_request_sli_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Sli Duration Seconds
+          visible: true
+          order: 4
+        - id: karmada-aggregated-apiserver-06
+          metric_name: apiserver_response_sizes
+          chart_type: bar
+          title: Apiserver Response Sizes
+          visible: true
+          order: 5
+        - id: karmada-aggregated-apiserver-07
+          metric_name: apiserver_storage_objects
+          chart_type: gauge
+          title: Apiserver Storage Objects
+          visible: true
+          order: 6
+        - id: karmada-aggregated-apiserver-08
+          metric_name: apiserver_storage_size_bytes
+          chart_type: area
+          title: Apiserver Storage Size Bytes
+          visible: true
+          order: 7
+        - id: karmada-aggregated-apiserver-09
+          metric_name: apiserver_storage_db_total_size_in_bytes
+          chart_type: area
+          title: Apiserver Storage Db Total Size In Bytes
+          visible: true
+          order: 8
+        - id: karmada-aggregated-apiserver-10
+          metric_name: apiserver_tls_handshake_errors_total
+          chart_type: line
+          title: Apiserver Tls Handshake Errors Total
+          visible: true
+          order: 9
+        - id: karmada-aggregated-apiserver-11
+          metric_name: apiserver_delegated_authz_request_total
+          chart_type: line
+          title: Apiserver Delegated Authz Request Total
+          visible: true
+          order: 10
+        - id: karmada-aggregated-apiserver-12
+          metric_name: apiserver_delegated_authz_request_duration_seconds
+          chart_type: bar
+          title: Apiserver Delegated Authz Request Duration Seconds
+          visible: true
+          order: 11
+    - version: 1
+      component: karmada-apiserver
+      panels:
+        - id: karmada-apiserver-01
+          metric_name: apiserver_request_total
+          chart_type: line
+          title: Apiserver Request Total
+          visible: true
+          order: 0
+        - id: karmada-apiserver-02
+          metric_name: apiserver_request_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-apiserver-03
+          metric_name: apiserver_current_inflight_requests
+          chart_type: gauge
+          title: Apiserver Current Inflight Requests
+          visible: true
+          order: 2
+        - id: karmada-apiserver-04
+          metric_name: apiserver_current_inqueue_requests
+          chart_type: gauge
+          title: Apiserver Current Inqueue Requests
+          visible: true
+          order: 3
+        - id: karmada-apiserver-05
+          metric_name: apiserver_longrunning_requests
+          chart_type: gauge
+          title: Apiserver Longrunning Requests
+          visible: true
+          order: 4
+        - id: karmada-apiserver-06
+          metric_name: apiserver_flowcontrol_current_executing_requests
+          chart_type: gauge
+          title: Apiserver Flowcontrol Current Executing Requests
+          visible: true
+          order: 5
+        - id: karmada-apiserver-07
+          metric_name: apiserver_flowcontrol_current_inqueue_requests
+          chart_type: gauge
+          title: Apiserver Flowcontrol Current Inqueue Requests
+          visible: true
+          order: 6
+        - id: karmada-apiserver-08
+          metric_name: apiserver_flowcontrol_request_wait_duration_seconds
+          chart_type: bar
+          title: Apiserver Flowcontrol Request Wait Duration Seconds
+          visible: true
+          order: 7
+        - id: karmada-apiserver-09
+          metric_name: apiserver_admission_controller_admission_duration_seconds
+          chart_type: bar
+          title: Apiserver Admission Controller Admission Duration Seconds
+          visible: true
+          order: 8
+        - id: karmada-apiserver-10
+          metric_name: apiserver_storage_objects
+          chart_type: gauge
+          title: Apiserver Storage Objects
+          visible: true
+          order: 9
+        - id: karmada-apiserver-11
+          metric_name: apiserver_storage_size_bytes
+          chart_type: area
+          title: Apiserver Storage Size Bytes
+          visible: true
+          order: 10
+        - id: karmada-apiserver-12
+          metric_name: apiserver_tls_handshake_errors_total
+          chart_type: line
+          title: Apiserver Tls Handshake Errors Total
+          visible: true
+          order: 11
+    - version: 1
+      component: karmada-descheduler
+      panels:
+        - id: karmada-descheduler-01
+          metric_name: leader_election_master_status
+          chart_type: gauge
+          title: Leader Election Master Status
+          visible: true
+          order: 0
+        - id: karmada-descheduler-02
+          metric_name: workqueue_depth
+          chart_type: gauge
+          title: Workqueue Depth
+          visible: true
+          order: 1
+        - id: karmada-descheduler-03
+          metric_name: workqueue_adds_total
+          chart_type: line
+          title: Workqueue Adds Total
+          visible: true
+          order: 2
+        - id: karmada-descheduler-04
+          metric_name: workqueue_retries_total
+          chart_type: line
+          title: Workqueue Retries Total
+          visible: true
+          order: 3
+        - id: karmada-descheduler-05
+          metric_name: workqueue_queue_duration_seconds
+          chart_type: bar
+          title: Workqueue Queue Duration Seconds
+          visible: true
+          order: 4
+        - id: karmada-descheduler-06
+          metric_name: workqueue_work_duration_seconds
+          chart_type: bar
+          title: Workqueue Work Duration Seconds
+          visible: true
+          order: 5
+        - id: karmada-descheduler-07
+          metric_name: workqueue_longest_running_processor_seconds
+          chart_type: gauge
+          title: Workqueue Longest Running Processor Seconds
+          visible: true
+          order: 6
+        - id: karmada-descheduler-08
+          metric_name: workqueue_unfinished_work_seconds
+          chart_type: gauge
+          title: Workqueue Unfinished Work Seconds
+          visible: true
+          order: 7
+    - version: 1
+      component: karmada-kube-controller-manager
+      panels:
+        - id: karmada-kube-controller-manager-01
+          metric_name: node_collector_update_all_nodes_health_duration_seconds
+          chart_type: bar
+          title: Node Collector Update All Nodes Health Duration Seconds
+          visible: true
+          order: 0
+        - id: karmada-kube-controller-manager-02
+          metric_name: node_collector_update_node_health_duration_seconds
+          chart_type: bar
+          title: Node Collector Update Node Health Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-kube-controller-manager-03
+          metric_name: garbagecollector_controller_resources_sync_error_total
+          chart_type: line
+          title: Garbagecollector Controller Resources Sync Error Total
+          visible: true
+          order: 2
+        - id: karmada-kube-controller-manager-04
+          metric_name: ttl_after_finished_controller_job_deletion_duration_seconds
+          chart_type: bar
+          title: Ttl After Finished Controller Job Deletion Duration Seconds
+          visible: true
+          order: 3
+        - id: karmada-kube-controller-manager-05
+          metric_name: leader_election_master_status
+          chart_type: gauge
+          title: Leader Election Master Status
+          visible: true
+          order: 4
+        - id: karmada-kube-controller-manager-06
+          metric_name: workqueue_depth
+          chart_type: gauge
+          title: Workqueue Depth
+          visible: true
+          order: 5
+        - id: karmada-kube-controller-manager-07
+          metric_name: workqueue_adds_total
+          chart_type: line
+          title: Workqueue Adds Total
+          visible: true
+          order: 6
+        - id: karmada-kube-controller-manager-08
+          metric_name: workqueue_retries_total
+          chart_type: line
+          title: Workqueue Retries Total
+          visible: true
+          order: 7
+        - id: karmada-kube-controller-manager-09
+          metric_name: workqueue_longest_running_processor_seconds
+          chart_type: gauge
+          title: Workqueue Longest Running Processor Seconds
+          visible: true
+          order: 8
+        - id: karmada-kube-controller-manager-10
+          metric_name: workqueue_unfinished_work_seconds
+          chart_type: gauge
+          title: Workqueue Unfinished Work Seconds
+          visible: true
+          order: 9
+    - version: 1
+      component: karmada-metrics-adapter
+      panels:
+        - id: karmada-metrics-adapter-01
+          metric_name: apiserver_request_total
+          chart_type: line
+          title: Apiserver Request Total
+          visible: true
+          order: 0
+        - id: karmada-metrics-adapter-02
+          metric_name: apiserver_request_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-metrics-adapter-03
+          metric_name: apiserver_request_sli_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Sli Duration Seconds
+          visible: true
+          order: 2
+        - id: karmada-metrics-adapter-04
+          metric_name: apiserver_request_slo_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Slo Duration Seconds
+          visible: true
+          order: 3
+        - id: karmada-metrics-adapter-05
+          metric_name: apiserver_request_filter_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Filter Duration Seconds
+          visible: true
+          order: 4
+        - id: karmada-metrics-adapter-06
+          metric_name: apiserver_current_inflight_requests
+          chart_type: gauge
+          title: Apiserver Current Inflight Requests
+          visible: true
+          order: 5
+        - id: karmada-metrics-adapter-07
+          metric_name: workqueue_depth
+          chart_type: gauge
+          title: Workqueue Depth
+          visible: true
+          order: 6
+        - id: karmada-metrics-adapter-08
+          metric_name: workqueue_adds_total
+          chart_type: line
+          title: Workqueue Adds Total
+          visible: true
+          order: 7
+        - id: karmada-metrics-adapter-09
+          metric_name: workqueue_retries_total
+          chart_type: line
+          title: Workqueue Retries Total
+          visible: true
+          order: 8
+    - version: 1
+      component: karmada-scheduler-estimator-member1
+      panels:
+        - id: karmada-scheduler-estimator-member1-01
+          metric_name: karmada_scheduler_estimator_estimating_request_total
+          chart_type: line
+          title: Karmada Scheduler Estimator Estimating Request Total
+          visible: true
+          order: 0
+        - id: karmada-scheduler-estimator-member1-02
+          metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-scheduler-estimator-member1-03
+          metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+          visible: true
+          order: 2
+        - id: karmada-scheduler-estimator-member1-04
+          metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+          visible: true
+          order: 3
+    - version: 1
+      component: karmada-scheduler-estimator-member2
+      panels:
+        - id: karmada-scheduler-estimator-member2-01
+          metric_name: karmada_scheduler_estimator_estimating_request_total
+          chart_type: line
+          title: Karmada Scheduler Estimator Estimating Request Total
+          visible: true
+          order: 0
+        - id: karmada-scheduler-estimator-member2-02
+          metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-scheduler-estimator-member2-03
+          metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+          visible: true
+          order: 2
+        - id: karmada-scheduler-estimator-member2-04
+          metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+          visible: true
+          order: 3
+    - version: 1
+      component: karmada-scheduler-estimator-member3
+      panels:
+        - id: karmada-scheduler-estimator-member3-01
+          metric_name: karmada_scheduler_estimator_estimating_request_total
+          chart_type: line
+          title: Karmada Scheduler Estimator Estimating Request Total
+          visible: true
+          order: 0
+        - id: karmada-scheduler-estimator-member3-02
+          metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-scheduler-estimator-member3-03
+          metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+          visible: true
+          order: 2
+        - id: karmada-scheduler-estimator-member3-04
+          metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+          visible: true
+          order: 3
+    - version: 1
+      component: karmada-search
+      panels:
+        - id: karmada-search-01
+          metric_name: apiserver_request_total
+          chart_type: line
+          title: Apiserver Request Total
+          visible: true
+          order: 0
+        - id: karmada-search-02
+          metric_name: apiserver_request_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-search-03
+          metric_name: apiserver_current_inflight_requests
+          chart_type: gauge
+          title: Apiserver Current Inflight Requests
+          visible: true
+          order: 2
+        - id: karmada-search-04
+          metric_name: apiserver_longrunning_requests
+          chart_type: gauge
+          title: Apiserver Longrunning Requests
+          visible: true
+          order: 3
+        - id: karmada-search-05
+          metric_name: apiserver_request_sli_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Sli Duration Seconds
+          visible: true
+          order: 4
+        - id: karmada-search-06
+          metric_name: apiserver_request_slo_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Slo Duration Seconds
+          visible: true
+          order: 5
+        - id: karmada-search-07
+          metric_name: apiserver_request_filter_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Filter Duration Seconds
+          visible: true
+          order: 6
+        - id: karmada-search-08
+          metric_name: apiserver_storage_objects
+          chart_type: gauge
+          title: Apiserver Storage Objects
+          visible: true
+          order: 7
+        - id: karmada-search-09
+          metric_name: apiserver_storage_size_bytes
+          chart_type: area
+          title: Apiserver Storage Size Bytes
+          visible: true
+          order: 8
+        - id: karmada-search-10
+          metric_name: etcd_request_duration_seconds
+          chart_type: bar
+          title: Etcd Request Duration Seconds
+          visible: true
+          order: 9
+        - id: karmada-search-11
+          metric_name: etcd_requests_total
+          chart_type: line
+          title: Etcd Requests Total
+          visible: true
+          order: 10
+        - id: karmada-search-12
+          metric_name: workqueue_depth
+          chart_type: gauge
+          title: Workqueue Depth
+          visible: true
+          order: 11
+    - version: 1
+      component: karmada-webhook
+      panels:
+        - id: karmada-webhook-01
+          metric_name: controller_runtime_webhook_requests_total
+          chart_type: line
+          title: Controller Runtime Webhook Requests Total
+          visible: true
+          order: 0
+        - id: karmada-webhook-02
+          metric_name: controller_runtime_webhook_latency_seconds
+          chart_type: bar
+          title: Controller Runtime Webhook Latency Seconds
+          visible: true
+          order: 1
+        - id: karmada-webhook-03
+          metric_name: controller_runtime_webhook_requests_in_flight
+          chart_type: gauge
+          title: Controller Runtime Webhook Requests In Flight
+          visible: true
+          order: 2
+        - id: karmada-webhook-04
+          metric_name: controller_runtime_webhook_panics_total
+          chart_type: line
+          title: Controller Runtime Webhook Panics Total
+          visible: true
+          order: 3
+        - id: karmada-webhook-05
+          metric_name: controller_runtime_conversion_webhook_panics_total
+          chart_type: line
+          title: Controller Runtime Conversion Webhook Panics Total
+          visible: true
+          order: 4
+
 ingress:
   enabled: false
   className: ""
@@ -241,6 +963,75 @@ kubernetes_dashboard_api:
     #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  service:
+    type: ClusterIP
+    port: 8000
+
+metrics_scraper:
+  ## @param metrics_scraper.labels labels of the metrics-scraper deployment
+  labels: {}
+  replicaCount: 1
+  ## @param metrics_scraper.podAnnotations annotations of the metrics-scraper pods
+  podAnnotations: { }
+  ## @param metrics_scraper.podLabels labels of the metrics-scraper pods
+  podLabels: { }
+  ## @param metrics_scraper.image.registry metrics-scraper image registry
+  ## @param metrics_scraper.image.repository metrics-scraper image repository
+  ## @param metrics_scraper.image.tag karmada metrics-scraper image tag (immutable tags are recommended)
+  ## @param metrics_scraper.image.pullPolicy metrics-scraper image pull policy
+  ## @param metrics_scraper.image.pullSecrets Specify docker-registry secret names as an array
+  ##
+  image:
+    registry: docker.io
+    repository: karmada/karmada-dashboard-metrics-scraper
+    tag: *karmadaDashboardImageVersion
+    pullPolicy: *karmadaDashboardImagePullPolicy
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: [ ]
+  ## @param metrics_scraper.resources resource quota of the metrics-scraper
+  resources: { }
+    # If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  ## @param metrics_scraper.nodeSelector node selector of the metrics-scraper
+  nodeSelector: { }
+  ## @param metrics_scraper.affinity affinity of the metrics-scraper
+  affinity: { }
+  ## @param metrics_scraper.tolerations tolerations of the metrics-scraper
+  tolerations: [ ]
+  # - key: node-role.kubernetes.io/master
+  #   operator: Exists
+  ## @param metrics_scraper.strategy strategy of the metrics-scraper
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 50%
+  ## @param metrics_scraper.kubeconfigName secret name of the Karmada kubeconfig
+  kubeconfigName: karmada-kubeconfig
+  ## @param metrics_scraper.kubeconfigContext context name used in the Karmada kubeconfig
+  kubeconfigContext: karmada-apiserver
+  ## @param metrics_scraper.podDisruptionBudget
+  podDisruptionBudget: *podDisruptionBudget
+  podSecurityContext: { }
+  # fsGroup: 2000
+  securityContext: { }
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
   service:

--- a/cmd/metrics-scraper/app/db/consts.go
+++ b/cmd/metrics-scraper/app/db/consts.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package db
 
+import "strings"
+
 const (
 	// Namespace is the namespace of karmada.
 	Namespace = "karmada-system"
@@ -27,8 +29,112 @@ const (
 	KarmadaSchedulerEstimator = "karmada-scheduler-estimator"
 	// KarmadaControllerManager is the name of karmada controller manager.
 	KarmadaControllerManager = "karmada-controller-manager"
-	// SchedulerPort is the port of karmada scheduler.
-	SchedulerPort = "10351"
-	// ControllerManagerPort is the port of karmada controller manager.
-	ControllerManagerPort = "8080"
+	// KarmadaAggregatedAPIServer is the name of karmada aggregated apiserver.
+	KarmadaAggregatedAPIServer = "karmada-aggregated-apiserver"
+	// KarmadaAPIServer is the name of karmada apiserver.
+	KarmadaAPIServer = "karmada-apiserver"
+	// KarmadaDescheduler is the name of karmada descheduler.
+	KarmadaDescheduler = "karmada-descheduler"
+	// KarmadaKubeControllerManager is the name of karmada kube controller manager.
+	KarmadaKubeControllerManager = "karmada-kube-controller-manager"
+	// KarmadaMetricsAdapter is the name of karmada metrics adapter.
+	KarmadaMetricsAdapter = "karmada-metrics-adapter"
+	// KarmadaSearch is the name of karmada search.
+	KarmadaSearch = "karmada-search"
+	// KarmadaWebhook is the name of karmada webhook.
+	KarmadaWebhook = "karmada-webhook"
+
+	// DefaultMetricsPort is used by Karmada components that expose a dedicated
+	// controller-runtime metrics listener.
+	DefaultMetricsPort = "8080"
 )
+
+// ComponentConfig holds the scrape configuration for a single Karmada component.
+type ComponentConfig struct {
+	// Name is the component name used by the dashboard and metrics database.
+	Name string
+	// LabelSelector selects the component pods in the host cluster.
+	LabelSelector string
+	// Port is the metrics port.
+	Port string
+	// Scheme is "http" or "https".
+	Scheme string
+	// MetricsPath is the path to the metrics endpoint (default "/metrics").
+	MetricsPath string
+	// ServerName is used to verify a secure component's serving certificate
+	// while connecting directly to its pod IP.
+	ServerName string
+	// InsecureSkipVerify is reserved for components such as the upstream
+	// kube-controller-manager that generate an ephemeral self-signed serving
+	// certificate which cannot be validated with the Karmada CA.
+	InsecureSkipVerify bool
+}
+
+// AllComponents returns the full list of scrapeable Karmada control-plane components.
+func AllComponents() []ComponentConfig {
+	return []ComponentConfig{
+		{Name: KarmadaScheduler, LabelSelector: "app=" + KarmadaScheduler, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+		{Name: KarmadaControllerManager, LabelSelector: "app=" + KarmadaControllerManager, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+		{Name: KarmadaAgent, LabelSelector: "app=" + KarmadaAgent, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+		{Name: KarmadaSchedulerEstimator, LabelSelector: "app=" + KarmadaSchedulerEstimator, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+		{Name: KarmadaAggregatedAPIServer, LabelSelector: "app=" + KarmadaAggregatedAPIServer, Port: "443", Scheme: "https", MetricsPath: "/metrics", ServerName: serviceServerName(KarmadaAggregatedAPIServer)},
+		{Name: KarmadaAPIServer, LabelSelector: "app=" + KarmadaAPIServer, Port: "5443", Scheme: "https", MetricsPath: "/metrics", ServerName: serviceServerName(KarmadaAPIServer)},
+		{Name: KarmadaDescheduler, LabelSelector: "app=" + KarmadaDescheduler, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+		// kube-controller-manager generates an ephemeral self-signed serving
+		// certificate for 127.0.0.1 even when it binds to all interfaces.
+		{Name: KarmadaKubeControllerManager, LabelSelector: "app=kube-controller-manager", Port: "10257", Scheme: "https", MetricsPath: "/metrics", InsecureSkipVerify: true},
+		{Name: KarmadaMetricsAdapter, LabelSelector: "app=" + KarmadaMetricsAdapter, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+		{Name: KarmadaSearch, LabelSelector: "app=" + KarmadaSearch, Port: "443", Scheme: "https", MetricsPath: "/metrics", ServerName: serviceServerName(KarmadaSearch)},
+		{Name: KarmadaWebhook, LabelSelector: "app=" + KarmadaWebhook, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+	}
+}
+
+func serviceServerName(component string) string {
+	return component + "." + Namespace + ".svc"
+}
+
+// GetComponentConfig returns the ComponentConfig for the given app name, or nil if not found.
+func GetComponentConfig(appName string) *ComponentConfig {
+	for _, c := range AllComponents() {
+		if c.Name == appName {
+			return &c
+		}
+		if c.Name == KarmadaSchedulerEstimator && strings.HasPrefix(appName, KarmadaSchedulerEstimator+"-") {
+			c.Name = appName
+			c.LabelSelector = "app=" + appName
+			return &c
+		}
+	}
+	return nil
+}
+
+// MetricTier defines storage priority for metrics.
+type MetricTier int
+
+const (
+	// TierHigh - always stored at full resolution (process_*, workqueue_*, go_goroutines, go_threads).
+	TierHigh MetricTier = iota
+	// TierMedium - stored every scrape but without histogram buckets.
+	TierMedium
+	// TierLow - sampled every 3rd scrape (rest_client_*, etcd_*, apiserver_*).
+	TierLow
+)
+
+// GetMetricTier returns the storage tier for a metric based on its name prefix.
+func GetMetricTier(metricName string) MetricTier {
+	// High priority: core operational metrics
+	highPrefixes := []string{"process_", "workqueue_", "go_goroutines", "go_threads", "go_memstats_"}
+	for _, p := range highPrefixes {
+		if strings.HasPrefix(metricName, p) {
+			return TierHigh
+		}
+	}
+	// Low priority: verbose client/etcd/apiserver metrics
+	lowPrefixes := []string{"rest_client_", "etcd_", "apiserver_request_", "reflector_"}
+	for _, p := range lowPrefixes {
+		if strings.HasPrefix(metricName, p) {
+			return TierLow
+		}
+	}
+	return TierMedium
+}

--- a/cmd/metrics-scraper/app/db/consts_test.go
+++ b/cmd/metrics-scraper/app/db/consts_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package db
+
+import "testing"
+
+func TestComponentScrapeConfigs(t *testing.T) {
+	tests := []struct {
+		name       string
+		port       string
+		scheme     string
+		selector   string
+		serverName string
+		insecure   bool
+	}{
+		{KarmadaScheduler, "8080", "http", "app=karmada-scheduler", "", false},
+		{KarmadaDescheduler, "8080", "http", "app=karmada-descheduler", "", false},
+		{KarmadaWebhook, "8080", "http", "app=karmada-webhook", "", false},
+		{KarmadaAggregatedAPIServer, "443", "https", "app=karmada-aggregated-apiserver", "karmada-aggregated-apiserver.karmada-system.svc", false},
+		{KarmadaAPIServer, "5443", "https", "app=karmada-apiserver", "karmada-apiserver.karmada-system.svc", false},
+		{KarmadaSearch, "443", "https", "app=karmada-search", "karmada-search.karmada-system.svc", false},
+		{KarmadaKubeControllerManager, "10257", "https", "app=kube-controller-manager", "", true},
+		{KarmadaSchedulerEstimator + "-member1", "8080", "http", "app=karmada-scheduler-estimator-member1", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := GetComponentConfig(tt.name)
+			if cfg == nil {
+				t.Fatalf("GetComponentConfig(%q) returned nil", tt.name)
+			}
+			if cfg.Port != tt.port || cfg.Scheme != tt.scheme || cfg.LabelSelector != tt.selector || cfg.ServerName != tt.serverName || cfg.InsecureSkipVerify != tt.insecure {
+				t.Fatalf("GetComponentConfig(%q) = %#v, want port=%q scheme=%q selector=%q serverName=%q insecure=%t", tt.name, cfg, tt.port, tt.scheme, tt.selector, tt.serverName, tt.insecure)
+			}
+		})
+	}
+}
+
+func TestGetComponentConfigRejectsUnknownComponent(t *testing.T) {
+	if cfg := GetComponentConfig("not-a-karmada-component"); cfg != nil {
+		t.Fatalf("expected nil config, got %#v", cfg)
+	}
+}

--- a/cmd/metrics-scraper/app/db/models.go
+++ b/cmd/metrics-scraper/app/db/models.go
@@ -19,6 +19,7 @@ package db
 // PodInfo is the pod info.
 type PodInfo struct {
 	Name string `json:"name"`
+	IP   string `json:"ip"`
 }
 
 // Metric is the metric info.

--- a/cmd/metrics-scraper/app/metricsscraper.go
+++ b/cmd/metrics-scraper/app/metricsscraper.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
 	"github.com/spf13/cobra"
@@ -88,7 +89,11 @@ func run(ctx context.Context, opts *options.Options) error {
 	)
 	ensureAPIServerConnectionOrDie()
 	serve(opts)
-	go scrape.InitDatabase()
+	scrapeInterval := opts.ScrapeInterval
+	if scrapeInterval <= 0 {
+		scrapeInterval = 10 * time.Second
+	}
+	go scrape.InitDatabase(scrapeInterval)
 
 	config.InitDashboardConfig(client.InClusterClient(), ctx.Done())
 	<-ctx.Done()
@@ -126,7 +131,12 @@ func init() {
 	r := router.V1()
 	r.GET("/metrics", metrics.GetMetrics)
 	r.GET("/metrics/:app_name", metrics.GetMetrics)
+	r.GET("/metrics/:app_name/visualization", metrics.GetVisualization)
+	r.GET("/metrics/:app_name/explore", metrics.GetMetricExplore)
+	r.GET("/metrics/:app_name/pods", metrics.GetComponentPods)
 	r.GET("/metrics/:app_name/:pod_name", metrics.QueryMetrics)
+	r.GET("/metrics-config", metrics.GetDashboardConfig)
+	r.PUT("/metrics-config", metrics.SaveDashboardConfig)
 }
 
 // http://localhost:8000/api/v1/metrics/karmada-scheduler?type=metricsdetails  //from sqlite details bar

--- a/cmd/metrics-scraper/app/options/options.go
+++ b/cmd/metrics-scraper/app/options/options.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"net"
+	"time"
 
 	"github.com/spf13/pflag"
 )
@@ -35,6 +36,7 @@ type Options struct {
 	KarmadaContext                string
 	SkipKarmadaApiserverTLSVerify bool
 	Namespace                     string
+	ScrapeInterval                time.Duration
 	DisableCSRFProtection         bool
 	OpenAPIEnabled                bool
 }
@@ -60,6 +62,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.KarmadaContext, "karmada-context", "", "The name of the karmada-kubeconfig context to use.")
 	fs.BoolVar(&o.SkipKarmadaApiserverTLSVerify, "skip-karmada-apiserver-tls-verify", false, "enable if connection with remote Karmada API server should skip TLS verify")
 	fs.StringVar(&o.Namespace, "namespace", "karmada-dashboard", "Namespace to use when accessing Dashboard specific resources, i.e. configmap")
+	fs.DurationVar(&o.ScrapeInterval, "scrape-interval", 10*time.Second, "Interval between metrics scrape cycles, e.g. 5s, 30s, 1m")
 	fs.BoolVar(&o.DisableCSRFProtection, "disable-csrf-protection", false, "allows disabling CSRF protection")
 	fs.BoolVar(&o.OpenAPIEnabled, "openapi-enabled", false, "enables OpenAPI v2 endpoint under '/apidocs.json'")
 }

--- a/cmd/metrics-scraper/app/routes/metrics/config.go
+++ b/cmd/metrics-scraper/app/routes/metrics/config.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/karmada-io/dashboard/pkg/client"
+	"github.com/karmada-io/dashboard/pkg/config"
+)
+
+// GetDashboardConfig returns the persisted metrics dashboards for every component.
+func GetDashboardConfig(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"dashboards": config.GetMetricsDashboards(),
+	})
+}
+
+// SaveDashboardConfig persists (upserts) the metrics dashboard for a single
+// component into the dashboard ConfigMap so it is shared across browsers.
+func SaveDashboardConfig(c *gin.Context) {
+	var body struct {
+		Dashboard config.MetricsDashboard `json:"dashboard"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body: " + err.Error()})
+		return
+	}
+	if strings.TrimSpace(body.Dashboard.Component) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "dashboard.component is required"})
+		return
+	}
+
+	if err := config.UpsertMetricsDashboard(client.InClusterClient(), body.Dashboard); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to persist config: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"dashboards": config.GetMetricsDashboards(),
+	})
+}

--- a/cmd/metrics-scraper/app/routes/metrics/explore.go
+++ b/cmd/metrics-scraper/app/routes/metrics/explore.go
@@ -1,0 +1,452 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const defaultExploreAggregation = "sum"
+
+// LabelFilter defines a label matcher for metric exploration.
+type LabelFilter struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// ExploreMeta is metadata for metric exploration responses.
+type ExploreMeta struct {
+	Metric      string        `json:"metric"`
+	Aggregation string        `json:"aggregation"`
+	Labels      []LabelFilter `json:"labels"`
+	Window      string        `json:"window"`
+	PodMode     string        `json:"podMode"`
+	GeneratedAt string        `json:"generatedAt"`
+}
+
+// ExploreResponse is the API contract for metric exploration.
+type ExploreResponse struct {
+	Meta            ExploreMeta         `json:"meta"`
+	Timeseries      []Point             `json:"timeseries"`
+	AvailableLabels map[string][]string `json:"availableLabels"`
+}
+
+type exploreBucket struct {
+	Sum      float64
+	Count    int64
+	Max      float64
+	Min      float64
+	HasValue bool
+}
+
+func (b *exploreBucket) merge(sum float64, count int64, max, min float64) {
+	b.Sum += sum
+	b.Count += count
+	if !b.HasValue || max > b.Max {
+		b.Max = max
+	}
+	if !b.HasValue || min < b.Min {
+		b.Min = min
+	}
+	b.HasValue = true
+}
+
+// GetMetricExplore returns a single metric series with configurable aggregation and label filtering.
+func GetMetricExplore(c *gin.Context) {
+	appName := c.Param("app_name")
+	metricName := strings.TrimSpace(c.Query("metric"))
+	if metricName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "metric is required"})
+		return
+	}
+
+	aggregation, err := parseExploreAggregation(c.Query("aggregation"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	labels, err := parseLabelFilters(c.Query("labels"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	window, err := parseWindow(c.Query("window"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	podMode := c.DefaultQuery("pod", defaultPodMode)
+	dbConn, err := getDBFunc(appName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open metrics database"})
+		return
+	}
+
+	podTables, err := listPodTables(dbConn)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to list %s pod tables", appName)})
+		return
+	}
+	if len(podTables) == 0 {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": fmt.Sprintf("no %s metrics data found", appName)})
+		return
+	}
+
+	selectedTables, err := selectPodTables(podTables, podMode)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	measure, err := determineExploreMeasure(dbConn, selectedTables, metricName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to resolve metric metadata: %v", err)})
+		return
+	}
+
+	availableLabels, err := queryAvailableLabels(dbConn, selectedTables, metricName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to query metric labels: %v", err)})
+		return
+	}
+
+	cutoff := time.Now().Add(-window)
+	points, err := queryMetricExploreSeries(dbConn, selectedTables, metricName, measure, aggregation, labels, cutoff)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to query metric timeseries: %v", err)})
+		return
+	}
+	if points == nil {
+		points = []Point{}
+	}
+
+	c.JSON(http.StatusOK, ExploreResponse{
+		Meta: ExploreMeta{
+			Metric:      metricName,
+			Aggregation: aggregation,
+			Labels:      labels,
+			Window:      window.String(),
+			PodMode:     podMode,
+			GeneratedAt: time.Now().Format(time.RFC3339),
+		},
+		Timeseries:      points,
+		AvailableLabels: availableLabels,
+	})
+}
+
+func parseExploreAggregation(raw string) (string, error) {
+	if raw == "" {
+		return defaultExploreAggregation, nil
+	}
+
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch value {
+	case "sum", "avg", "max", "min", "rate":
+		return value, nil
+	default:
+		return "", fmt.Errorf("invalid aggregation %q, expected one of sum, avg, max, min, rate", raw)
+	}
+}
+
+func parseLabelFilters(raw string) ([]LabelFilter, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+
+	var filters []LabelFilter
+	if err := json.Unmarshal([]byte(raw), &filters); err != nil {
+		return nil, fmt.Errorf("invalid labels, expected JSON array of {key,value}: %w", err)
+	}
+
+	for _, filter := range filters {
+		if strings.TrimSpace(filter.Key) == "" {
+			return nil, fmt.Errorf("invalid labels, key must not be empty")
+		}
+	}
+	return filters, nil
+}
+
+func determineExploreMeasure(dbConn *sql.DB, podTables []string, metricName string) (string, error) {
+	for _, table := range podTables {
+		metadataQuery := fmt.Sprintf(`
+			SELECT COALESCE(type, '')
+			FROM %s_metadata
+			WHERE name = ?
+			LIMIT 1
+		`, table)
+
+		var metricType string
+		err := dbConn.QueryRow(metadataQuery, metricName).Scan(&metricType)
+		switch {
+		case err == nil:
+			return primaryMeasureForType(normalizePrometheusType(metricType)), nil
+		case err == sql.ErrNoRows:
+			continue
+		case strings.Contains(err.Error(), "no such table"):
+			continue
+		default:
+			return "", err
+		}
+	}
+
+	measurePriority := []string{"total", "current_value", "sum", "count"}
+	measureSet := map[string]struct{}{}
+	for _, table := range podTables {
+		measureQuery := fmt.Sprintf(`
+			SELECT DISTINCT v.measure
+			FROM %s m
+			INNER JOIN %s_values v ON m.id = v.metric_id
+			WHERE m.name = ?
+		`, table, table)
+		rows, err := dbConn.Query(measureQuery, metricName)
+		if err != nil {
+			return "", err
+		}
+		for rows.Next() {
+			var measure string
+			if scanErr := rows.Scan(&measure); scanErr != nil {
+				rows.Close()
+				return "", scanErr
+			}
+			measureSet[measure] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return "", err
+		}
+		rows.Close()
+	}
+
+	for _, measure := range measurePriority {
+		if _, ok := measureSet[measure]; ok {
+			return measure, nil
+		}
+	}
+	return primaryMeasureForType("gauge"), nil
+}
+
+func queryAvailableLabels(dbConn *sql.DB, podTables []string, metricName string) (map[string][]string, error) {
+	labelSet := make(map[string]map[string]struct{})
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+
+	for _, table := range podTables {
+		wg.Add(1)
+		go func(table string) {
+			defer wg.Done()
+
+			query := fmt.Sprintf(`
+				SELECT DISTINCT ls.key, ls.value
+				FROM %s m
+				INNER JOIN %s_values v ON m.id = v.metric_id
+				INNER JOIN %s_labels l ON v.id = l.value_id
+				INNER JOIN %s_label_strings ls ON l.label_string_id = ls.id
+				WHERE m.name = ?
+			`, table, table, table, table)
+			rows, err := dbConn.Query(query, metricName)
+			if err != nil {
+				if strings.Contains(err.Error(), "no such table") {
+					return
+				}
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+			defer rows.Close()
+
+			local := make(map[string]map[string]struct{})
+			for rows.Next() {
+				var key, value string
+				if scanErr := rows.Scan(&key, &value); scanErr != nil {
+					errOnce.Do(func() { firstErr = scanErr })
+					return
+				}
+				if _, ok := local[key]; !ok {
+					local[key] = make(map[string]struct{})
+				}
+				local[key][value] = struct{}{}
+			}
+			if err := rows.Err(); err != nil {
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+
+			mu.Lock()
+			for key, values := range local {
+				if _, ok := labelSet[key]; !ok {
+					labelSet[key] = make(map[string]struct{})
+				}
+				for value := range values {
+					labelSet[key][value] = struct{}{}
+				}
+			}
+			mu.Unlock()
+		}(table)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	result := make(map[string][]string, len(labelSet))
+	for key, values := range labelSet {
+		result[key] = mapKeys(values)
+	}
+	return result, nil
+}
+
+func queryMetricExploreSeries(dbConn *sql.DB, podTables []string, metricName, measure, aggregation string, labels []LabelFilter, cutoff time.Time) ([]Point, error) {
+	buckets := make(map[time.Time]*exploreBucket)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+
+	for _, table := range podTables {
+		wg.Add(1)
+		go func(table string) {
+			defer wg.Done()
+
+			query, args := buildExploreSeriesQuery(table, metricName, measure, labels, cutoff)
+			rows, err := dbConn.Query(query, args...)
+			if err != nil {
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+			defer rows.Close()
+
+			localBuckets := make(map[time.Time]*exploreBucket)
+			for rows.Next() {
+				var currentTimeRaw string
+				var sum, max, min float64
+				var count int64
+				if scanErr := rows.Scan(&currentTimeRaw, &sum, &count, &max, &min); scanErr != nil {
+					errOnce.Do(func() { firstErr = scanErr })
+					return
+				}
+
+				currentTime, parseErr := parseCurrentTime(currentTimeRaw)
+				if parseErr != nil {
+					continue
+				}
+				normalized := currentTime.UTC().Truncate(time.Second)
+				bucket, ok := localBuckets[normalized]
+				if !ok {
+					bucket = &exploreBucket{}
+					localBuckets[normalized] = bucket
+				}
+				bucket.merge(sum, count, max, min)
+			}
+			if err := rows.Err(); err != nil {
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+
+			mu.Lock()
+			for ts, localBucket := range localBuckets {
+				bucket, ok := buckets[ts]
+				if !ok {
+					bucket = &exploreBucket{}
+					buckets[ts] = bucket
+				}
+				bucket.merge(localBucket.Sum, localBucket.Count, localBucket.Max, localBucket.Min)
+			}
+			mu.Unlock()
+		}(table)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	values := make(map[time.Time]float64, len(buckets))
+	for ts, bucket := range buckets {
+		if !bucket.HasValue {
+			continue
+		}
+		switch aggregation {
+		case "avg":
+			if bucket.Count > 0 {
+				values[ts] = bucket.Sum / float64(bucket.Count)
+			}
+		case "max":
+			values[ts] = bucket.Max
+		case "min":
+			values[ts] = bucket.Min
+		default:
+			values[ts] = bucket.Sum
+		}
+	}
+
+	points := mapToPoints(values)
+	if aggregation == "rate" {
+		return counterRate(points), nil
+	}
+	return points, nil
+}
+
+func buildExploreSeriesQuery(table, metricName, measure string, labels []LabelFilter, cutoff time.Time) (string, []any) {
+	query := fmt.Sprintf(`
+		SELECT m.currentTime, SUM(v.value), COUNT(v.value), MAX(v.value), MIN(v.value)
+		FROM %s m
+		INNER JOIN %s_values v ON m.id = v.metric_id
+		WHERE m.name = ? AND v.measure = ? AND m.currentTime >= ?
+	`, table, table)
+	args := []any{metricName, measure, cutoff.Format(time.RFC3339)}
+
+	for _, filter := range labels {
+		query += fmt.Sprintf(`
+			AND EXISTS (
+				SELECT 1
+				FROM %s_labels l
+				INNER JOIN %s_label_strings ls ON l.label_string_id = ls.id
+				WHERE l.value_id = v.id AND ls.key = ? AND ls.value = ?
+			)
+		`, table, table)
+		args = append(args, filter.Key, filter.Value)
+	}
+
+	query += `
+		GROUP BY m.currentTime
+		ORDER BY m.currentTime ASC
+	`
+	return query, args
+}
+
+func mapKeys(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/cmd/metrics-scraper/app/routes/metrics/handler.go
+++ b/cmd/metrics-scraper/app/routes/metrics/handler.go
@@ -18,13 +18,12 @@ package metrics
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/scrape"
 )
-
-var requests = make(chan scrape.SaveRequest)
 
 // GetMetrics returns the metrics for the given app name
 func GetMetrics(c *gin.Context) {
@@ -50,14 +49,24 @@ func GetMetrics(c *gin.Context) {
 		return
 	}
 
-	allMetrics, errors, err := scrape.FetchMetrics(c.Request.Context(), appName, requests)
+	// Pass nil for the save channel; live metrics are persisted by background goroutines only.
+	allMetrics, errors, err := scrape.FetchMetrics(c.Request.Context(), appName, nil)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"errors": errors, "error": err.Error()})
+		status := http.StatusBadGateway
+		if strings.Contains(strings.ToLower(err.Error()), "no pods found") {
+			status = http.StatusServiceUnavailable
+		}
+		c.JSON(status, gin.H{"errors": errors, "error": err.Error()})
 		return
 	}
 	if len(allMetrics) > 0 {
 		c.JSON(http.StatusOK, allMetrics)
 	} else {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "No metrics data found", "errors": errors})
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "No metrics data found", "errors": errors})
 	}
+}
+
+// GetVisualization returns visualization-oriented time series for the given app.
+func GetVisualization(c *gin.Context) {
+	GetSchedulerVisualization(c)
 }

--- a/cmd/metrics-scraper/app/routes/metrics/handlerqueries.go
+++ b/cmd/metrics-scraper/app/routes/metrics/handlerqueries.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +30,9 @@ import (
 
 	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/scrape"
 )
+
+// validTableNameRe ensures a table name contains only safe identifier characters.
+var validTableNameRe = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 // MetricInfo represents the information about a metric.
 type MetricInfo struct {
@@ -44,6 +49,11 @@ func QueryMetrics(c *gin.Context) {
 
 	sanitizedAppName := strings.ReplaceAll(appName, "-", "_")
 	sanitizedPodName := strings.ReplaceAll(podName, "-", "_")
+
+	if !validTableNameRe.MatchString(sanitizedPodName) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid pod_name"})
+		return
+	}
 
 	db, err := scrape.GetDB(sanitizedAppName)
 	if err != nil {
@@ -71,6 +81,18 @@ func QueryMetrics(c *gin.Context) {
 	case "metricsdetails":
 		queryMetricDetails(c, appName)
 	}
+}
+
+type sqlQueryer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}
+
+func queryWithMetadataFallback(q sqlQueryer, metadataTableName, preferredQuery, fallbackQuery string, args ...any) (*sql.Rows, error) {
+	rows, err := q.Query(preferredQuery, args...)
+	if err != nil && strings.Contains(err.Error(), "no such table: "+metadataTableName) {
+		return q.Query(fallbackQuery, args...)
+	}
+	return rows, err
 }
 
 func queryMetricNames(c *gin.Context, tx *sql.Tx, sanitizedPodName string) {
@@ -101,18 +123,24 @@ func queryMetricDetailsByName(c *gin.Context, tx *sql.Tx, sanitizedPodName, metr
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Metric name required for details"})
 		return
 	}
-	query := `
+	// Single query with JOIN to avoid N+1 queries for labels
+	query := fmt.Sprintf(`
             SELECT 
                 m.currentTime, 
                 m.name, 
                 v.value, 
                 v.measure, 
-                v.id
-            FROM ? m
-            INNER JOIN ? v ON m.id = v.metric_id
+                v.id,
+                COALESCE(ls.key, '') AS label_key,
+                COALESCE(ls.value, '') AS label_value
+            FROM %s m
+            INNER JOIN %s_values v ON m.id = v.metric_id
+            LEFT JOIN %s_labels l ON v.id = l.value_id
+            LEFT JOIN %s_label_strings ls ON l.label_string_id = ls.id
             WHERE m.name = ?
-        `
-	rows, err := tx.Query(query, sanitizedPodName, fmt.Sprintf("%s_values", sanitizedPodName), metricName)
+            ORDER BY m.currentTime, v.id
+        `, sanitizedPodName, sanitizedPodName, sanitizedPodName, sanitizedPodName)
+	rows, err := tx.Query(query, metricName)
 	if err != nil {
 		log.Printf("Error querying metric details: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to query metric details"})
@@ -132,54 +160,47 @@ func queryMetricDetailsByName(c *gin.Context, tx *sql.Tx, sanitizedPodName, metr
 	}
 
 	detailsMap := make(map[string]MetricDetails)
+	// Track values by (timeKey, valueID) to accumulate labels
+	type valueKey struct {
+		timeKey string
+		valueID int
+	}
+	valueLabels := make(map[valueKey]map[string]string)
+	valueIndex := make(map[valueKey]*MetricValue)
 
 	for rows.Next() {
 		var currentTime time.Time
-		var name, value, measure string
+		var name, measure, labelKey, labelValue string
+		var numericValue float64
 		var valueID int
-		if err := rows.Scan(&currentTime, &name, &value, &measure, &valueID); err != nil {
+		if err := rows.Scan(&currentTime, &name, &numericValue, &measure, &valueID, &labelKey, &labelValue); err != nil {
 			log.Printf("Error scanning metric details: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to scan metric details"})
 			return
 		}
 
-		labelsQuery := "SELECT key, value FROM ? WHERE value_id = ?"
-		labelsRows, err := tx.Query(labelsQuery, fmt.Sprintf("%s_labels", sanitizedPodName), valueID)
-		if err != nil {
-			log.Printf("Error querying labels: %v", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to query labels"})
-			return
-		}
-		defer labelsRows.Close()
-
-		labels := make(map[string]string)
-		for labelsRows.Next() {
-			var labelKey, labelValue string
-			if err := labelsRows.Scan(&labelKey, &labelValue); err != nil {
-				log.Printf("Error scanning labels: %v", err)
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to scan labels"})
-				return
-			}
-			labels[labelKey] = labelValue
-		}
-
 		timeKey := currentTime.Format(time.RFC3339)
+		vk := valueKey{timeKey: timeKey, valueID: valueID}
 
-		detail, exists := detailsMap[timeKey]
-		if !exists {
-			detail = MetricDetails{
-				Name:   name,
-				Values: []MetricValue{},
+		if _, exists := valueIndex[vk]; !exists {
+			detail, detailExists := detailsMap[timeKey]
+			if !detailExists {
+				detail = MetricDetails{
+					Name:   name,
+					Values: []MetricValue{},
+				}
 			}
+			labels := make(map[string]string)
+			mv := MetricValue{Value: strconv.FormatFloat(numericValue, 'f', -1, 64), Measure: measure, Labels: labels}
+			detail.Values = append(detail.Values, mv)
+			detailsMap[timeKey] = detail
+			valueLabels[vk] = labels
+			valueIndex[vk] = &detailsMap[timeKey].Values[len(detailsMap[timeKey].Values)-1]
 		}
 
-		detail.Values = append(detail.Values, MetricValue{
-			Value:   value,
-			Measure: measure,
-			Labels:  labels,
-		})
-
-		detailsMap[timeKey] = detail
+		if labelKey != "" {
+			valueLabels[vk][labelKey] = labelValue
+		}
 	}
 
 	c.JSON(http.StatusOK, gin.H{"details": detailsMap})
@@ -187,13 +208,13 @@ func queryMetricDetailsByName(c *gin.Context, tx *sql.Tx, sanitizedPodName, metr
 
 func queryMetricDetails(c *gin.Context, appName string) {
 	// Handle metricsdetails query type
-	db, err := sql.Open("sqlite", strings.ReplaceAll(appName, "-", "_")+".db")
+	sanitizedName := strings.ReplaceAll(appName, "-", "_")
+	db, err := scrape.GetDB(sanitizedName)
 	if err != nil {
 		log.Printf("Error opening database: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to open database"})
 		return
 	}
-	defer db.Close()
 
 	// Get all relevant tables
 	rows, err := db.Query(`
@@ -202,6 +223,8 @@ func queryMetricDetails(c *gin.Context, appName string) {
 			WHERE type='table' 
 			AND name NOT LIKE '%_values' 
 			AND name NOT LIKE '%_labels' 
+			AND name NOT LIKE '%_label_strings'
+			AND name NOT LIKE '%_metadata'
 			AND name NOT LIKE '%_time_load'
 			AND name != 'sqlite_sequence'
 		`)
@@ -223,16 +246,22 @@ func queryMetricDetails(c *gin.Context, appName string) {
 		}
 
 		// Get metrics for this pod
-		metricRows, err := db.Query(fmt.Sprintf(`
+		metadataQuery := fmt.Sprintf(`
+				SELECT DISTINCT m.name, COALESCE(md.help, ''), COALESCE(md.type, '')
+				FROM %s m
+				LEFT JOIN %s_metadata md ON m.name = md.name
+				GROUP BY m.name
+			`, tableName, tableName)
+		fallbackQuery := fmt.Sprintf(`
 				SELECT DISTINCT name, help, type 
 				FROM %s 
 				GROUP BY name
-			`, tableName))
+			`, tableName)
+		metricRows, err := queryWithMetadataFallback(db, fmt.Sprintf("%s_metadata", tableName), metadataQuery, fallbackQuery)
 		if err != nil {
 			log.Printf("Error querying metrics for table %s: %v", tableName, err)
 			continue
 		}
-		defer metricRows.Close()
 
 		podMetrics := make(map[string]MetricInfo)
 
@@ -249,6 +278,7 @@ func queryMetricDetails(c *gin.Context, appName string) {
 				Type: metricType,
 			}
 		}
+		metricRows.Close()
 
 		result[tableName] = podMetrics
 	}

--- a/cmd/metrics-scraper/app/routes/metrics/pods.go
+++ b/cmd/metrics-scraper/app/routes/metrics/pods.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/db"
+	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/scrape"
+)
+
+type componentPodsResponse struct {
+	AppName  string   `json:"appName"`
+	Pods     []string `json:"pods"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+var discoverComponentPods = scrape.DiscoverComponentPods
+
+// GetComponentPods returns the live Kubernetes pods selected for a component.
+func GetComponentPods(c *gin.Context) {
+	appName := c.Param("app_name")
+	if db.GetComponentConfig(appName) == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported metrics component"})
+		return
+	}
+
+	pods, warnings, err := discoverComponentPods(c.Request.Context(), appName)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{
+			"error":    err.Error(),
+			"pods":     pods,
+			"warnings": warnings,
+		})
+		return
+	}
+	if pods == nil {
+		pods = []string{}
+	}
+	c.JSON(http.StatusOK, componentPodsResponse{
+		AppName:  appName,
+		Pods:     pods,
+		Warnings: warnings,
+	})
+}

--- a/cmd/metrics-scraper/app/routes/metrics/pods_test.go
+++ b/cmd/metrics-scraper/app/routes/metrics/pods_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestGetComponentPodsSuccess(t *testing.T) {
+	original := discoverComponentPods
+	defer func() { discoverComponentPods = original }()
+	discoverComponentPods = func(_ context.Context, appName string) ([]string, []string, error) {
+		if appName != "karmada-aggregated-apiserver" {
+			t.Fatalf("unexpected app name %q", appName)
+		}
+		return []string{"aggregated-0", "aggregated-1"}, nil, nil
+	}
+
+	c, w := newVisualizationContext("/api/v1/metrics/karmada-aggregated-apiserver/pods")
+	c.Params = gin.Params{{Key: "app_name", Value: "karmada-aggregated-apiserver"}}
+	GetComponentPods(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var response componentPodsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Pods) != 2 {
+		t.Fatalf("expected 2 pods, got %#v", response.Pods)
+	}
+}
+
+func TestGetComponentPodsDiscoveryFailure(t *testing.T) {
+	original := discoverComponentPods
+	defer func() { discoverComponentPods = original }()
+	discoverComponentPods = func(_ context.Context, _ string) ([]string, []string, error) {
+		return nil, []string{"list failed"}, errors.New("discovery failed")
+	}
+
+	c, w := newVisualizationContext("/api/v1/metrics/karmada-aggregated-apiserver/pods")
+	c.Params = gin.Params{{Key: "app_name", Value: "karmada-aggregated-apiserver"}}
+	GetComponentPods(c)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/cmd/metrics-scraper/app/routes/metrics/visualization.go
+++ b/cmd/metrics-scraper/app/routes/metrics/visualization.go
@@ -1,0 +1,916 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"database/sql"
+	"fmt"
+	"math"
+	"net/http"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/scrape"
+)
+
+const (
+	defaultVisualizationWindow = 15 * time.Minute
+	maxVisualizationWindow     = 6 * time.Hour
+	defaultPodMode             = "all"
+)
+
+var (
+	getDBFunc        = scrape.GetDB
+	triggerScrapeNow = scrape.TriggerScrapeNow
+)
+
+// Point is a single point in a time series.
+type Point struct {
+	Timestamp string  `json:"timestamp"`
+	Value     float64 `json:"value"`
+}
+
+// metricMeta holds discovered metric metadata from the database.
+type metricMeta struct {
+	name    string
+	help    string
+	mtype   string // gauge, counter, histogram, summary
+	measure string // primary measure for aggregation
+}
+
+// VisualizationMeta is metadata for visualization responses.
+type VisualizationMeta struct {
+	AppName           string `json:"appName"`
+	Window            string `json:"window"`
+	PodMode           string `json:"podMode"`
+	SampleIntervalSec int    `json:"sampleIntervalSec"`
+	GeneratedAt       string `json:"generatedAt"`
+}
+
+// VisualizationMetricInfo describes an available metric and its suggested chart type|.
+type VisualizationMetricInfo struct {
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	SuggestedChart string `json:"suggestedChart"`
+}
+
+// MetricCatalogItem provides full metadata about a metric for frontend rendering.
+type MetricCatalogItem struct {
+	Name           string `json:"name"`
+	Help           string `json:"help"`
+	PrometheusType string `json:"prometheusType"`
+	SuggestedChart string `json:"suggestedChart"`
+	Group          string `json:"group"`
+}
+
+// SchedulerVisualizationResponse is the API contract for scheduler metric charts.
+type SchedulerVisualizationResponse struct {
+	Meta             VisualizationMeta         `json:"meta"`
+	Timeseries       map[string][]Point        `json:"timeseries"`
+	Pods             []string                  `json:"pods"`
+	Warnings         []string                  `json:"warnings,omitempty"`
+	AvailableMetrics []VisualizationMetricInfo `json:"availableMetrics,omitempty"`
+	MetricsCatalog   []MetricCatalogItem       `json:"metricsCatalog,omitempty"`
+}
+
+// GetSchedulerVisualization returns chart-oriented scheduler time series from metrics-scraper DB.
+func GetSchedulerVisualization(c *gin.Context) {
+	appName := c.Param("app_name")
+	if appName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "app_name is required"})
+		return
+	}
+
+	window, err := parseWindow(c.Query("window"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	podMode := c.DefaultQuery("pod", defaultPodMode)
+	refresh, err := parseRefresh(c.Query("refresh"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var warnings []string
+	if refresh {
+		scrapeErrors, scrapeErr := triggerScrapeNow(c.Request.Context(), appName)
+		if scrapeErr != nil {
+			c.JSON(http.StatusBadGateway, gin.H{
+				"error":   scrapeErr.Error(),
+				"errors":  scrapeErrors,
+				"message": fmt.Sprintf("failed to refresh %s metrics before visualization query", appName),
+			})
+			return
+		}
+		warnings = append(warnings, scrapeErrors...)
+	}
+
+	dbConn, err := getDBFunc(appName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open metrics database"})
+		return
+	}
+
+	podTables, err := listPodTables(dbConn)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to list %s pod tables", appName)})
+		return
+	}
+	if len(podTables) == 0 {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": fmt.Sprintf("no %s metrics data found", appName)})
+		return
+	}
+
+	selectedTables, err := selectPodTables(podTables, podMode)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	metricsFilter := c.Query("metrics")
+	var requestedMetrics []string
+	if metricsFilter != "" {
+		for _, m := range strings.Split(metricsFilter, ",") {
+			m = strings.TrimSpace(m)
+			if m != "" {
+				requestedMetrics = append(requestedMetrics, m)
+			}
+		}
+	}
+
+	cutoff := time.Now().Add(-window)
+	series, catalog, err := buildDynamicVisualization(dbConn, selectedTables, cutoff, window, requestedMetrics)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to build visualization: %v", err)})
+		return
+	}
+
+	if !hasAnySeriesData(series) {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": fmt.Sprintf("no %s visualization data available in requested window", appName),
+			"pods":  desanitizePods(selectedTables),
+		})
+		return
+	}
+
+	resp := SchedulerVisualizationResponse{
+		Meta: VisualizationMeta{
+			AppName:           appName,
+			Window:            window.String(),
+			PodMode:           podMode,
+			SampleIntervalSec: detectSampleInterval(series),
+			GeneratedAt:       time.Now().Format(time.RFC3339),
+		},
+		Timeseries:       series,
+		Pods:             desanitizePods(selectedTables),
+		Warnings:         warnings,
+		AvailableMetrics: buildAvailableMetrics(series),
+		MetricsCatalog:   catalog,
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+func buildAvailableMetrics(series map[string][]Point) []VisualizationMetricInfo {
+	metricChartMapping := map[string]VisualizationMetricInfo{
+		"workqueueDepth":             {Name: "workqueueDepth", Type: "gauge", SuggestedChart: "bar"},
+		"workqueueAddsRate":          {Name: "workqueueAddsRate", Type: "counter_rate", SuggestedChart: "line"},
+		"workqueueRetriesRate":       {Name: "workqueueRetriesRate", Type: "counter_rate", SuggestedChart: "line"},
+		"workqueueQueueDurationAvg":  {Name: "workqueueQueueDurationAvg", Type: "histogram_avg", SuggestedChart: "area"},
+		"workqueueWorkDurationAvg":   {Name: "workqueueWorkDurationAvg", Type: "histogram_avg", SuggestedChart: "area"},
+		"processResidentMemoryBytes": {Name: "processResidentMemoryBytes", Type: "gauge", SuggestedChart: "gauge"},
+		"processCPUSecondsRate":      {Name: "processCPUSecondsRate", Type: "counter_rate", SuggestedChart: "line"},
+	}
+
+	var available []VisualizationMetricInfo
+	for key, points := range series {
+		if len(points) == 0 {
+			continue
+		}
+		if info, ok := metricChartMapping[key]; ok {
+			available = append(available, info)
+		} else {
+			// Unknown metrics default to line chart
+			available = append(available, VisualizationMetricInfo{Name: key, Type: "unknown", SuggestedChart: "line"})
+		}
+	}
+	return available
+}
+
+func parseWindow(windowRaw string) (time.Duration, error) {
+	if windowRaw == "" {
+		return defaultVisualizationWindow, nil
+	}
+
+	window, err := time.ParseDuration(windowRaw)
+	if err != nil || window <= 0 {
+		return 0, fmt.Errorf("invalid window %q, expected a positive Go duration such as 15m", windowRaw)
+	}
+	if window > maxVisualizationWindow {
+		return 0, fmt.Errorf("invalid window %q, maximum supported window is %s", windowRaw, maxVisualizationWindow)
+	}
+	return window, nil
+}
+
+func parseRefresh(refreshRaw string) (bool, error) {
+	if refreshRaw == "" {
+		return false, nil
+	}
+	value, err := strconv.ParseBool(refreshRaw)
+	if err != nil {
+		return false, fmt.Errorf("invalid refresh %q, expected true or false", refreshRaw)
+	}
+	return value, nil
+}
+
+func listPodTables(dbConn *sql.DB) ([]string, error) {
+	rows, err := dbConn.Query(`
+		SELECT name
+		FROM sqlite_master
+		WHERE type='table'
+		AND name NOT LIKE '%_values'
+		AND name NOT LIKE '%_labels'
+		AND name NOT LIKE '%_label_strings'
+		AND name NOT LIKE '%_metadata'
+		AND name NOT LIKE '%_time_load'
+		AND name NOT LIKE '%_aggregates'
+		AND name != 'sqlite_sequence'
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		if scanErr := rows.Scan(&name); scanErr != nil {
+			return nil, scanErr
+		}
+		tables = append(tables, name)
+	}
+
+	slices.Sort(tables)
+	return tables, nil
+}
+
+func selectPodTables(tables []string, podMode string) ([]string, error) {
+	if podMode == "" || podMode == defaultPodMode {
+		return tables, nil
+	}
+
+	target := strings.ReplaceAll(podMode, "-", "_")
+	for _, table := range tables {
+		if table == target {
+			return []string{table}, nil
+		}
+	}
+	return nil, fmt.Errorf("pod %q not found in metrics data", podMode)
+}
+
+func buildComponentVisualization(dbConn *sql.DB, podTables []string, cutoff time.Time) (map[string][]Point, error) {
+	type metricAccumulator struct {
+		mu   sync.Mutex
+		data map[time.Time]float64
+	}
+
+	workqueueDepth := &metricAccumulator{data: map[time.Time]float64{}}
+	workqueueAdds := &metricAccumulator{data: map[time.Time]float64{}}
+	workqueueRetries := &metricAccumulator{data: map[time.Time]float64{}}
+	queueDurationSum := &metricAccumulator{data: map[time.Time]float64{}}
+	queueDurationCount := &metricAccumulator{data: map[time.Time]float64{}}
+	workDurationSum := &metricAccumulator{data: map[time.Time]float64{}}
+	workDurationCount := &metricAccumulator{data: map[time.Time]float64{}}
+	processResidentMemory := &metricAccumulator{data: map[time.Time]float64{}}
+	processCPUTotal := &metricAccumulator{data: map[time.Time]float64{}}
+
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+
+	for _, table := range podTables {
+		wg.Add(1)
+		go func(table string) {
+			defer wg.Done()
+
+			type metricSpec struct {
+				name    string
+				measure string
+				acc     *metricAccumulator
+			}
+			specs := []metricSpec{
+				{"workqueue_depth", "current_value", workqueueDepth},
+				{"workqueue_adds_total", "total", workqueueAdds},
+				{"workqueue_retries_total", "total", workqueueRetries},
+				{"workqueue_queue_duration_seconds", "sum", queueDurationSum},
+				{"workqueue_queue_duration_seconds", "count", queueDurationCount},
+				{"workqueue_work_duration_seconds", "sum", workDurationSum},
+				{"workqueue_work_duration_seconds", "count", workDurationCount},
+				{"process_resident_memory_bytes", "current_value", processResidentMemory},
+				{"process_cpu_seconds_total", "total", processCPUTotal},
+			}
+
+			for _, spec := range specs {
+				localMap := map[time.Time]float64{}
+				if err := accumulateMetric(dbConn, table, spec.name, spec.measure, cutoff, localMap); err != nil {
+					errOnce.Do(func() { firstErr = err })
+					return
+				}
+				spec.acc.mu.Lock()
+				for t, v := range localMap {
+					spec.acc.data[t] += v
+				}
+				spec.acc.mu.Unlock()
+			}
+		}(table)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	result := map[string][]Point{
+		"workqueueDepth":       mapToPoints(workqueueDepth.data),
+		"workqueueAddsRate":    counterRate(mapToPoints(workqueueAdds.data)),
+		"workqueueRetriesRate": counterRate(mapToPoints(workqueueRetries.data)),
+		"workqueueQueueDurationAvg": histogramAverage(
+			mapToPoints(queueDurationSum.data),
+			mapToPoints(queueDurationCount.data),
+		),
+		"workqueueWorkDurationAvg": histogramAverage(
+			mapToPoints(workDurationSum.data),
+			mapToPoints(workDurationCount.data),
+		),
+		"processResidentMemoryBytes": mapToPoints(processResidentMemory.data),
+		"processCPUSecondsRate":      counterRate(mapToPoints(processCPUTotal.data)),
+	}
+
+	return result, nil
+}
+
+// buildDynamicVisualization discovers all metrics from DB dynamically, classifies them by type,
+// and builds timeseries for each metric. Returns series and a catalog of all discovered metrics.
+func buildDynamicVisualization(dbConn *sql.DB, podTables []string, cutoff time.Time, window time.Duration, requestedMetrics []string) (map[string][]Point, []MetricCatalogItem, error) {
+	if len(podTables) == 0 {
+		return nil, nil, nil
+	}
+
+	resolution := ""
+	useAggregates := false
+	if window > 5*time.Minute && window <= 1*time.Hour {
+		resolution = "1m"
+		useAggregates = true
+	} else if window > 1*time.Hour {
+		resolution = "5m"
+		useAggregates = true
+	}
+
+	// Step 1: discover all distinct metric names and their types from the DB.
+	// Prefer metadata tables so discovery still works when raw samples have aged out.
+	discoveredMetrics := map[string]*metricMeta{}
+	var discoveryMu sync.Mutex
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+
+	for _, table := range podTables {
+		wg.Add(1)
+		go func(table string) {
+			defer wg.Done()
+			query := fmt.Sprintf(`
+				SELECT md.name, COALESCE(md.type, ''), COALESCE(md.help, '')
+				FROM %s_metadata md
+				WHERE ? IS NOT NULL
+			`, table)
+			fallbackQuery := fmt.Sprintf(`
+				SELECT DISTINCT m.name, '', ''
+				FROM %s m
+				WHERE m.currentTime >= ?
+			`, table)
+			rows, err := queryWithMetadataFallback(dbConn, fmt.Sprintf("%s_metadata", table), query, fallbackQuery, cutoff.Format(time.RFC3339))
+			if err != nil {
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+			defer rows.Close()
+
+			for rows.Next() {
+				var name, mtype, help string
+				if err := rows.Scan(&name, &mtype, &help); err != nil {
+					continue
+				}
+				discoveryMu.Lock()
+				if _, exists := discoveredMetrics[name]; !exists {
+					discoveredMetrics[name] = &metricMeta{name: name, help: help, mtype: normalizePrometheusType(mtype)}
+				}
+				discoveryMu.Unlock()
+			}
+		}(table)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, nil, firstErr
+	}
+
+	if len(discoveredMetrics) == 0 {
+		return nil, nil, nil
+	}
+
+	if len(requestedMetrics) > 0 {
+		requestedSet := make(map[string]bool, len(requestedMetrics))
+		for _, m := range requestedMetrics {
+			requestedSet[m] = true
+		}
+		for name := range discoveredMetrics {
+			if !requestedSet[name] {
+				delete(discoveredMetrics, name)
+			}
+		}
+	}
+
+	if len(discoveredMetrics) == 0 {
+		return nil, nil, nil
+	}
+
+	for _, meta := range discoveredMetrics {
+		meta.measure = primaryMeasureForType(meta.mtype)
+	}
+
+	type metricAccumulator struct {
+		mu   sync.Mutex
+		data map[time.Time]float64
+	}
+	type histAcc struct {
+		sum   *metricAccumulator
+		count *metricAccumulator
+	}
+
+	gaugeAccs := map[string]*metricAccumulator{}
+	counterAccs := map[string]*metricAccumulator{}
+	histAccs := map[string]*histAcc{}
+
+	for name, meta := range discoveredMetrics {
+		switch meta.mtype {
+		case "gauge":
+			gaugeAccs[name] = &metricAccumulator{data: map[time.Time]float64{}}
+		case "counter":
+			counterAccs[name] = &metricAccumulator{data: map[time.Time]float64{}}
+		case "histogram", "summary":
+			histAccs[name] = &histAcc{
+				sum:   &metricAccumulator{data: map[time.Time]float64{}},
+				count: &metricAccumulator{data: map[time.Time]float64{}},
+			}
+		}
+	}
+
+	accumulate := func(localMap map[time.Time]float64, table, name, measure string) error {
+		if useAggregates {
+			if err := accumulateFromAggregates(dbConn, table, name, measure, resolution, cutoff, localMap); err != nil {
+				return err
+			}
+			// Fallback to raw data if aggregates are empty (not yet populated)
+			if len(localMap) == 0 {
+				return accumulateMetric(dbConn, table, name, measure, cutoff, localMap)
+			}
+			return nil
+		}
+		return accumulateMetric(dbConn, table, name, measure, cutoff, localMap)
+	}
+
+	// Limit concurrency to match SQLite MaxOpenConns (4)
+	maxWorkers := len(podTables)
+	if maxWorkers > 4 {
+		maxWorkers = 4
+	}
+	sem := make(chan struct{}, maxWorkers)
+
+	for _, table := range podTables {
+		wg.Add(1)
+		sem <- struct{}{} // Acquire semaphore slot
+		go func(table string) {
+			defer wg.Done()
+			defer func() { <-sem }() // Release semaphore slot
+			for name, meta := range discoveredMetrics {
+				switch meta.mtype {
+				case "gauge":
+					acc := gaugeAccs[name]
+					localMap := map[time.Time]float64{}
+					if err := accumulate(localMap, table, name, "current_value"); err != nil {
+						errOnce.Do(func() { firstErr = err })
+						return
+					}
+					acc.mu.Lock()
+					for t, v := range localMap {
+						acc.data[t] += v
+					}
+					acc.mu.Unlock()
+
+				case "counter":
+					acc := counterAccs[name]
+					localMap := map[time.Time]float64{}
+					if err := accumulate(localMap, table, name, "total"); err != nil {
+						errOnce.Do(func() { firstErr = err })
+						return
+					}
+					acc.mu.Lock()
+					for t, v := range localMap {
+						acc.data[t] += v
+					}
+					acc.mu.Unlock()
+
+				case "histogram", "summary":
+					ha := histAccs[name]
+					localSum := map[time.Time]float64{}
+					localCount := map[time.Time]float64{}
+					if err := accumulate(localSum, table, name, "sum"); err != nil {
+						errOnce.Do(func() { firstErr = err })
+						return
+					}
+					if err := accumulate(localCount, table, name, "count"); err != nil {
+						errOnce.Do(func() { firstErr = err })
+						return
+					}
+					ha.sum.mu.Lock()
+					for t, v := range localSum {
+						ha.sum.data[t] += v
+					}
+					ha.sum.mu.Unlock()
+					ha.count.mu.Lock()
+					for t, v := range localCount {
+						ha.count.data[t] += v
+					}
+					ha.count.mu.Unlock()
+				}
+			}
+		}(table)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, nil, firstErr
+	}
+
+	result := map[string][]Point{}
+	for name := range gaugeAccs {
+		points := mapToPoints(gaugeAccs[name].data)
+		if len(points) > 0 {
+			result[name] = points
+		}
+	}
+	for name := range counterAccs {
+		points := counterRate(mapToPoints(counterAccs[name].data))
+		if len(points) > 0 {
+			result[name] = points
+		}
+	}
+	for name := range histAccs {
+		ha := histAccs[name]
+		points := histogramAverage(mapToPoints(ha.sum.data), mapToPoints(ha.count.data))
+		if len(points) > 0 {
+			result[name] = points
+		}
+	}
+
+	catalog := buildMetricsCatalog(discoveredMetrics, result)
+	return result, catalog, nil
+}
+
+func normalizePrometheusType(mtype string) string {
+	mtype = strings.ToLower(strings.TrimSpace(mtype))
+	switch mtype {
+	case "gauge", "counter", "histogram", "summary":
+		return mtype
+	case "untyped":
+		return "gauge"
+	default:
+		return "gauge"
+	}
+}
+
+func primaryMeasureForType(mtype string) string {
+	switch mtype {
+	case "gauge":
+		return "current_value"
+	case "counter":
+		return "total"
+	case "histogram", "summary":
+		return "sum"
+	default:
+		return "current_value"
+	}
+}
+
+func suggestedChartForType(mtype string, metricName string) string {
+	switch mtype {
+	case "gauge":
+		if strings.Contains(metricName, "_bytes") || strings.Contains(metricName, "memory") {
+			return "area"
+		}
+		return "gauge"
+	case "counter":
+		return "line"
+	case "histogram":
+		return "bar"
+	case "summary":
+		return "line"
+	default:
+		return "line"
+	}
+}
+
+func extractMetricGroup(name string) string {
+	// Extract the first meaningful prefix (e.g. "workqueue" from "workqueue_depth")
+	parts := strings.Split(name, "_")
+	if len(parts) >= 2 {
+		// Use first two parts for common prefixes
+		prefix := parts[0]
+		// Known multi-word prefixes
+		multiWordPrefixes := []string{"go", "process", "rest", "workqueue", "leader", "scheduler", "controller"}
+		for _, mp := range multiWordPrefixes {
+			if prefix == mp {
+				return mp
+			}
+		}
+		if len(parts) >= 3 {
+			return parts[0] + "_" + parts[1]
+		}
+		return prefix
+	}
+	return name
+}
+
+func buildMetricsCatalog(metrics map[string]*metricMeta, series map[string][]Point) []MetricCatalogItem {
+	catalog := make([]MetricCatalogItem, 0, len(metrics))
+	for name, meta := range metrics {
+		if _, hasSeries := series[name]; !hasSeries {
+			continue
+		}
+		catalog = append(catalog, MetricCatalogItem{
+			Name:           name,
+			Help:           meta.help,
+			PrometheusType: meta.mtype,
+			SuggestedChart: suggestedChartForType(meta.mtype, name),
+			Group:          extractMetricGroup(name),
+		})
+	}
+	sort.Slice(catalog, func(i, j int) bool {
+		if catalog[i].PrometheusType != catalog[j].PrometheusType {
+			return catalog[i].PrometheusType < catalog[j].PrometheusType
+		}
+		if catalog[i].Group != catalog[j].Group {
+			return catalog[i].Group < catalog[j].Group
+		}
+		return catalog[i].Name < catalog[j].Name
+	})
+	return catalog
+}
+
+func accumulateMetric(dbConn *sql.DB, podTable, metricName, measure string, cutoff time.Time, aggregate map[time.Time]float64) error {
+	query := fmt.Sprintf(`
+		SELECT m.currentTime, SUM(v.value)
+		FROM %s m
+		INNER JOIN %s_values v ON m.id = v.metric_id
+		WHERE m.name = ? AND v.measure = ? AND m.currentTime >= ?
+		GROUP BY m.currentTime
+		ORDER BY m.currentTime ASC
+	`, podTable, podTable)
+
+	rows, err := dbConn.Query(query, metricName, measure, cutoff.Format(time.RFC3339))
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var currentTimeRaw string
+		var total float64
+		if scanErr := rows.Scan(&currentTimeRaw, &total); scanErr != nil {
+			return scanErr
+		}
+
+		currentTime, parseErr := parseCurrentTime(currentTimeRaw)
+		if parseErr != nil {
+			continue
+		}
+
+		normalized := currentTime.UTC().Truncate(time.Second)
+		aggregate[normalized] += total
+	}
+
+	return rows.Err()
+}
+
+func accumulateFromAggregates(dbConn *sql.DB, podTable, metricName, measure, resolution string, cutoff time.Time, aggregate map[time.Time]float64) error {
+	query := fmt.Sprintf(`
+		SELECT bucket_time, avg_value
+		FROM %s_aggregates
+		WHERE name = ? AND measure = ? AND resolution = ? AND bucket_time >= ?
+		ORDER BY bucket_time ASC
+	`, podTable)
+
+	rows, err := dbConn.Query(query, metricName, measure, resolution, cutoff.Format(time.RFC3339))
+	if err != nil {
+		if strings.Contains(err.Error(), "no such table") {
+			return nil
+		}
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var bucketTimeRaw string
+		var avg float64
+		if err := rows.Scan(&bucketTimeRaw, &avg); err != nil {
+			return err
+		}
+		t, err := parseCurrentTime(bucketTimeRaw)
+		if err != nil {
+			continue
+		}
+		normalized := t.UTC().Truncate(time.Second)
+		aggregate[normalized] += avg
+	}
+	return rows.Err()
+}
+
+func parseCurrentTime(raw string) (time.Time, error) {
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02 15:04:05",
+	}
+	for _, layout := range layouts {
+		if ts, err := time.Parse(layout, raw); err == nil {
+			return ts, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid time format: %s", raw)
+}
+
+func mapToPoints(values map[time.Time]float64) []Point {
+	if len(values) == 0 {
+		return nil
+	}
+
+	timestamps := make([]time.Time, 0, len(values))
+	for ts := range values {
+		timestamps = append(timestamps, ts)
+	}
+	sort.Slice(timestamps, func(i, j int) bool {
+		return timestamps[i].Before(timestamps[j])
+	})
+
+	points := make([]Point, 0, len(timestamps))
+	for _, ts := range timestamps {
+		value := values[ts]
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			continue
+		}
+		points = append(points, Point{
+			Timestamp: ts.Format(time.RFC3339),
+			Value:     value,
+		})
+	}
+	return points
+}
+
+func counterRate(cumulative []Point) []Point {
+	if len(cumulative) == 0 {
+		return nil
+	}
+
+	rates := make([]Point, 0, len(cumulative))
+	rates = append(rates, Point{Timestamp: cumulative[0].Timestamp, Value: 0})
+	for i := 1; i < len(cumulative); i++ {
+		now, nowErr := time.Parse(time.RFC3339, cumulative[i].Timestamp)
+		prev, prevErr := time.Parse(time.RFC3339, cumulative[i-1].Timestamp)
+		if nowErr != nil || prevErr != nil {
+			rates = append(rates, Point{Timestamp: cumulative[i].Timestamp, Value: 0})
+			continue
+		}
+
+		deltaSeconds := now.Sub(prev).Seconds()
+		if deltaSeconds <= 0 {
+			rates = append(rates, Point{Timestamp: cumulative[i].Timestamp, Value: 0})
+			continue
+		}
+
+		delta := cumulative[i].Value - cumulative[i-1].Value
+		if delta < 0 {
+			delta = 0
+		}
+
+		rates = append(rates, Point{
+			Timestamp: cumulative[i].Timestamp,
+			Value:     delta / deltaSeconds,
+		})
+	}
+	return rates
+}
+
+func histogramAverage(sumSeries, countSeries []Point) []Point {
+	if len(sumSeries) == 0 || len(countSeries) == 0 {
+		return nil
+	}
+
+	sumMap := make(map[string]float64, len(sumSeries))
+	countMap := make(map[string]float64, len(countSeries))
+	for _, p := range sumSeries {
+		sumMap[p.Timestamp] = p.Value
+	}
+	for _, p := range countSeries {
+		countMap[p.Timestamp] = p.Value
+	}
+
+	var timestamps []string
+	for ts := range sumMap {
+		if _, ok := countMap[ts]; ok {
+			timestamps = append(timestamps, ts)
+		}
+	}
+	sort.Strings(timestamps)
+	if len(timestamps) == 0 {
+		return nil
+	}
+
+	result := make([]Point, 0, len(timestamps))
+	result = append(result, Point{Timestamp: timestamps[0], Value: 0})
+	for i := 1; i < len(timestamps); i++ {
+		prev := timestamps[i-1]
+		curr := timestamps[i]
+		sumDelta := sumMap[curr] - sumMap[prev]
+		countDelta := countMap[curr] - countMap[prev]
+		avg := 0.0
+		if sumDelta >= 0 && countDelta > 0 {
+			avg = sumDelta / countDelta
+		}
+		result = append(result, Point{Timestamp: curr, Value: avg})
+	}
+
+	return result
+}
+
+func hasAnySeriesData(timeseries map[string][]Point) bool {
+	for _, points := range timeseries {
+		if len(points) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func detectSampleInterval(timeseries map[string][]Point) int {
+	for _, points := range timeseries {
+		if len(points) < 2 {
+			continue
+		}
+
+		prev, err := time.Parse(time.RFC3339, points[0].Timestamp)
+		if err != nil {
+			continue
+		}
+		for i := 1; i < len(points); i++ {
+			curr, parseErr := time.Parse(time.RFC3339, points[i].Timestamp)
+			if parseErr != nil {
+				continue
+			}
+			interval := int(curr.Sub(prev).Seconds())
+			if interval > 0 {
+				return interval
+			}
+			prev = curr
+		}
+	}
+
+	return 0
+}
+
+func desanitizePods(tables []string) []string {
+	pods := make([]string, 0, len(tables))
+	for _, table := range tables {
+		pods = append(pods, strings.ReplaceAll(table, "_", "-"))
+	}
+	return pods
+}

--- a/cmd/metrics-scraper/app/routes/metrics/visualization_test.go
+++ b/cmd/metrics-scraper/app/routes/metrics/visualization_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/glebarez/sqlite"
+)
+
+func TestCounterRateHandlesReset(t *testing.T) {
+	points := []Point{
+		{Timestamp: "2026-01-01T00:00:00Z", Value: 10},
+		{Timestamp: "2026-01-01T00:00:10Z", Value: 16},
+		{Timestamp: "2026-01-01T00:00:20Z", Value: 3}, // counter reset
+	}
+
+	got := counterRate(points)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 points, got %d", len(got))
+	}
+	if got[1].Value != 0.6 {
+		t.Fatalf("expected second point rate 0.6, got %f", got[1].Value)
+	}
+	if got[2].Value != 0 {
+		t.Fatalf("expected reset point rate 0, got %f", got[2].Value)
+	}
+}
+
+func TestHistogramAverageUsesDelta(t *testing.T) {
+	sum := []Point{
+		{Timestamp: "2026-01-01T00:00:00Z", Value: 10},
+		{Timestamp: "2026-01-01T00:00:10Z", Value: 16},
+	}
+	count := []Point{
+		{Timestamp: "2026-01-01T00:00:00Z", Value: 2},
+		{Timestamp: "2026-01-01T00:00:10Z", Value: 4},
+	}
+
+	got := histogramAverage(sum, count)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 points, got %d", len(got))
+	}
+	if got[1].Value != 3 {
+		t.Fatalf("expected delta average 3, got %f", got[1].Value)
+	}
+}
+
+func TestGetSchedulerVisualizationInvalidApp(t *testing.T) {
+	origGetDB := getDBFunc
+	defer func() { getDBFunc = origGetDB }()
+	dbConn := mustOpenSQLite(t)
+	getDBFunc = func(_ string) (*sql.DB, error) {
+		return dbConn, nil
+	}
+
+	c, w := newVisualizationContext("/api/v1/metrics/unknown-component/visualization")
+	c.Params = gin.Params{{Key: "app_name", Value: "unknown-component"}}
+
+	GetSchedulerVisualization(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestGetSchedulerVisualizationNoData(t *testing.T) {
+	origGetDB := getDBFunc
+	origTrigger := triggerScrapeNow
+	defer func() {
+		getDBFunc = origGetDB
+		triggerScrapeNow = origTrigger
+	}()
+
+	dbConn := mustOpenSQLite(t)
+	getDBFunc = func(_ string) (*sql.DB, error) { return dbConn, nil }
+	triggerScrapeNow = func(_ context.Context, _ string) ([]string, error) { return nil, nil }
+
+	c, w := newVisualizationContext("/api/v1/metrics/karmada-scheduler/visualization?window=15m")
+	c.Params = gin.Params{{Key: "app_name", Value: "karmada-scheduler"}}
+
+	GetSchedulerVisualization(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestGetSchedulerVisualizationSuccess(t *testing.T) {
+	origGetDB := getDBFunc
+	origTrigger := triggerScrapeNow
+	defer func() {
+		getDBFunc = origGetDB
+		triggerScrapeNow = origTrigger
+	}()
+
+	dbConn := mustOpenSQLite(t)
+	createTestMetricTables(t, dbConn, "karmada_scheduler_testpod")
+
+	now := time.Now().Truncate(time.Second)
+	t1 := now.Add(-20 * time.Second).Format(time.RFC3339)
+	t2 := now.Add(-10 * time.Second).Format(time.RFC3339)
+	insertMetricSample(t, dbConn, "karmada_scheduler_testpod", t1, "workqueue_depth", "current_value", 4)
+	insertMetricSample(t, dbConn, "karmada_scheduler_testpod", t2, "workqueue_depth", "current_value", 6)
+	insertMetricSample(t, dbConn, "karmada_scheduler_testpod", t1, "workqueue_adds_total", "total", 10)
+	insertMetricSample(t, dbConn, "karmada_scheduler_testpod", t2, "workqueue_adds_total", "total", 30)
+
+	getDBFunc = func(_ string) (*sql.DB, error) { return dbConn, nil }
+	triggerScrapeNow = func(_ context.Context, _ string) ([]string, error) { return nil, nil }
+
+	c, w := newVisualizationContext("/api/v1/metrics/karmada-scheduler/visualization?window=15m")
+	c.Params = gin.Params{{Key: "app_name", Value: "karmada-scheduler"}}
+
+	GetSchedulerVisualization(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp SchedulerVisualizationResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response json: %v", err)
+	}
+	if len(resp.Timeseries["workqueue_depth"]) == 0 {
+		t.Fatalf("expected workqueue_depth points")
+	}
+	if len(resp.Timeseries["workqueue_adds_total"]) == 0 {
+		t.Fatalf("expected workqueue_adds_total points")
+	}
+}
+
+func newVisualizationContext(url string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	c.Request = req
+	return c, w
+}
+
+func mustOpenSQLite(t *testing.T) *sql.DB {
+	t.Helper()
+	dbConn, err := sql.Open("sqlite", "file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	dbConn.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		_ = dbConn.Close()
+	})
+	return dbConn
+}
+
+func createTestMetricTables(t *testing.T, dbConn *sql.DB, table string) {
+	t.Helper()
+	sqls := []string{
+		"CREATE TABLE IF NOT EXISTS " + table + " (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, currentTime DATETIME)",
+		"CREATE TABLE IF NOT EXISTS " + table + "_metadata (name TEXT PRIMARY KEY, help TEXT, type TEXT)",
+		"CREATE TABLE IF NOT EXISTS " + table + "_values (id INTEGER PRIMARY KEY AUTOINCREMENT, metric_id INTEGER, value TEXT, measure TEXT)",
+	}
+	for _, stmt := range sqls {
+		if _, err := dbConn.Exec(stmt); err != nil {
+			t.Fatalf("failed to create test table: %v", err)
+		}
+	}
+}
+
+func insertMetricSample(t *testing.T, dbConn *sql.DB, table, ts, metric, measure string, value float64) {
+	t.Helper()
+	metricType := "GAUGE"
+	if measure == "total" {
+		metricType = "COUNTER"
+	}
+	if _, err := dbConn.Exec(
+		"INSERT OR IGNORE INTO "+table+"_metadata (name, help, type) VALUES (?, ?, ?)",
+		metric, "", metricType,
+	); err != nil {
+		t.Fatalf("failed to insert metric metadata: %v", err)
+	}
+	result, err := dbConn.Exec(
+		"INSERT INTO "+table+" (name, currentTime) VALUES (?, ?)",
+		metric, ts,
+	)
+	if err != nil {
+		t.Fatalf("failed to insert metric row: %v", err)
+	}
+	metricID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("failed to get metric id: %v", err)
+	}
+	if _, err = dbConn.Exec(
+		"INSERT INTO "+table+"_values (metric_id, value, measure) VALUES (?, ?, ?)",
+		metricID, value, measure,
+	); err != nil {
+		t.Fatalf("failed to insert metric value: %v", err)
+	}
+}

--- a/cmd/metrics-scraper/app/scrape/aggregation.go
+++ b/cmd/metrics-scraper/app/scrape/aggregation.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scrape
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"time"
+)
+
+// StartAggregationWorkers starts background goroutines that periodically
+// downsample raw metrics into 1-min and 5-min aggregate buckets.
+func StartAggregationWorkers() {
+	go func() {
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			runAggregation("1m", 1*time.Minute)
+		}
+	}()
+
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			runAggregation("5m", 5*time.Minute)
+		}
+	}()
+}
+
+func runAggregation(resolution string, bucketDuration time.Duration) {
+	dbMapLock.RLock()
+	dbs := make(map[string]*sql.DB, len(dbMap))
+	for name, d := range dbMap {
+		dbs[name] = d
+	}
+	dbMapLock.RUnlock()
+
+	for appName, db := range dbs {
+		tables, err := getTablesForApp(db)
+		if err != nil {
+			log.Printf("Aggregation: error getting tables for %s: %v", appName, err)
+			continue
+		}
+		for _, table := range tables {
+			if err := aggregateTable(db, table, resolution, bucketDuration); err != nil {
+				log.Printf("Aggregation: error for table %s resolution %s: %v", table, resolution, err)
+			}
+		}
+	}
+}
+
+func getTablesForApp(db *sql.DB) ([]string, error) {
+	rows, err := db.Query("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE '%_values' AND name NOT LIKE '%_labels' AND name NOT LIKE '%_label_strings' AND name NOT LIKE '%_time_load' AND name NOT LIKE '%_metadata' AND name NOT LIKE '%_aggregates' AND name != 'app_sync' AND name != 'sqlite_sequence'")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			continue
+		}
+		tables = append(tables, name)
+	}
+	return tables, rows.Err()
+}
+
+func aggregateTable(db *sql.DB, table, resolution string, bucketDuration time.Duration) error {
+	now := time.Now().UTC()
+	bucketEnd := now.Truncate(bucketDuration)
+	bucketStart := bucketEnd.Add(-bucketDuration)
+
+	query := fmt.Sprintf(`
+		SELECT m.name, v.measure, AVG(v.value), MAX(v.value), MIN(v.value), COUNT(v.value)
+		FROM %s m
+		INNER JOIN %s_values v ON m.id = v.metric_id
+		WHERE m.currentTime >= ? AND m.currentTime < ?
+		  AND v.measure IN ('current_value', 'total', 'sum', 'count')
+		GROUP BY m.name, v.measure
+	`, table, table)
+
+	rows, err := db.Query(query, bucketStart.Format(time.RFC3339), bucketEnd.Format(time.RFC3339))
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	if _, err := db.Exec(fmt.Sprintf(createAggregatesTableSQL, table)); err != nil {
+		return err
+	}
+	if _, err := db.Exec(fmt.Sprintf(createAggregatesIndexSQL, table, table)); err != nil {
+		return err
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	bucketTimeStr := bucketStart.Format(time.RFC3339)
+	for rows.Next() {
+		var name, measure string
+		var avg, max, min float64
+		var count int
+		if err := rows.Scan(&name, &measure, &avg, &max, &min, &count); err != nil {
+			continue
+		}
+		if _, err = tx.Exec(fmt.Sprintf(insertAggregateSQL, table), name, measure, bucketTimeStr, resolution, avg, max, min, count); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	var retentionCutoff time.Time
+	switch resolution {
+	case "1m":
+		retentionCutoff = now.Add(-1 * time.Hour)
+	case "5m":
+		retentionCutoff = now.Add(-6 * time.Hour)
+	default:
+		retentionCutoff = now
+	}
+	if _, err = tx.Exec(fmt.Sprintf(deleteOldAggregatesSQL, table), resolution, retentionCutoff.Format(time.RFC3339)); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}

--- a/cmd/metrics-scraper/app/scrape/consts.go
+++ b/cmd/metrics-scraper/app/scrape/consts.go
@@ -21,17 +21,21 @@ const (
         CREATE TABLE IF NOT EXISTS %s (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT,
-            help TEXT,
-            type TEXT,
             currentTime DATETIME
         )
     `
+
+	createMetadataTableSQL = `CREATE TABLE IF NOT EXISTS %s_metadata (
+        name TEXT PRIMARY KEY,
+        help TEXT,
+        type TEXT
+    )`
 
 	createValuesTableSQL = `
         CREATE TABLE IF NOT EXISTS %s_values (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             metric_id INTEGER,
-            value TEXT,
+            value REAL,
             measure TEXT,
             FOREIGN KEY (metric_id) REFERENCES %s(id)
         )
@@ -46,12 +50,6 @@ const (
 	insertTimeLoadSQL = `
         INSERT OR REPLACE INTO %s (time_entry) VALUES (?)
     `
-	// 900 is 15 minutes in seconds
-	getOldestTimeSQL = `
-        SELECT time_entry FROM %s
-        ORDER BY time_entry DESC
-        LIMIT 1 OFFSET 900  
-    `
 
 	deleteOldTimeSQL = `DELETE FROM %s WHERE time_entry <= ?`
 
@@ -59,19 +57,68 @@ const (
         DELETE FROM %s WHERE currentTime <= ?
     `
 
+	// Direct time-based deletion for values (avoids slow NOT IN subquery)
 	deleteAssociatedValuesSQL = `
-        DELETE FROM %s_values WHERE metric_id NOT IN (SELECT id FROM %s)
+        DELETE FROM %s_values WHERE metric_id IN (
+            SELECT id FROM %s WHERE currentTime <= ?
+        )
     `
 
-	insertMainSQL = `
-        INSERT INTO %s (name, help, type, currentTime) 
-        VALUES (?, ?, ?, ?)
+	// Direct time-based deletion for labels (avoids slow NOT IN subquery)
+	deleteAssociatedLabelsSQL = `
+        DELETE FROM %s_labels WHERE value_id IN (
+            SELECT v.id FROM %s_values v
+            INNER JOIN %s m ON v.metric_id = m.id
+            WHERE m.currentTime <= ?
+        )
     `
+
+	insertMetadataSQL = `INSERT OR IGNORE INTO %s_metadata (name, help, type) VALUES (?, ?, ?)`
+
+	insertMainSQL = `
+        INSERT INTO %s (name, currentTime)
+        VALUES (?, ?)
+    `
+	createLabelStringsTableSQL = `CREATE TABLE IF NOT EXISTS %s_label_strings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        key TEXT NOT NULL,
+        value TEXT NOT NULL,
+        UNIQUE(key, value)
+    )`
+
 	createLabelsTableSQL = `CREATE TABLE IF NOT EXISTS %s_labels (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         value_id INTEGER,
-        key TEXT,
-        value TEXT,
-        FOREIGN KEY(value_id) REFERENCES %s_values(id)
+        label_string_id INTEGER,
+        FOREIGN KEY(value_id) REFERENCES %s_values(id),
+        FOREIGN KEY(label_string_id) REFERENCES %s_label_strings(id)
     )`
+
+	// Index creation SQL for query performance
+	createMainIndexSQL = `CREATE INDEX IF NOT EXISTS idx_%s_name_time ON %s(name, currentTime)`
+
+	createValuesIndexSQL = `CREATE INDEX IF NOT EXISTS idx_%s_values_metric_id ON %s_values(metric_id)`
+
+	createLabelsIndexSQL = `CREATE INDEX IF NOT EXISTS idx_%s_labels_value_id ON %s_labels(value_id)`
+
+	createLabelStringsIndexSQL = `CREATE INDEX IF NOT EXISTS idx_%s_label_strings_kv ON %s_label_strings(key, value)`
+
+	createAggregatesTableSQL = `CREATE TABLE IF NOT EXISTS %s_aggregates (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL,
+		measure TEXT NOT NULL,
+		bucket_time DATETIME NOT NULL,
+		resolution TEXT NOT NULL,
+		avg_value REAL,
+		max_value REAL,
+		min_value REAL,
+		sample_count INTEGER DEFAULT 1,
+		UNIQUE(name, measure, bucket_time, resolution)
+	)`
+
+	createAggregatesIndexSQL = `CREATE INDEX IF NOT EXISTS idx_%s_aggregates_lookup ON %s_aggregates(name, measure, resolution, bucket_time)`
+
+	insertAggregateSQL = `INSERT OR REPLACE INTO %s_aggregates (name, measure, bucket_time, resolution, avg_value, max_value, min_value, sample_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+
+	deleteOldAggregatesSQL = `DELETE FROM %s_aggregates WHERE resolution = ? AND bucket_time <= ?`
 )

--- a/cmd/metrics-scraper/app/scrape/db.go
+++ b/cmd/metrics-scraper/app/scrape/db.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 )
 
 var (
@@ -53,10 +54,55 @@ func GetDB(appName string) (*sql.DB, error) {
 		return nil, err
 	}
 
-	// Set connection pool settings
-	db.SetMaxOpenConns(1) // Restrict to 1 connection to prevent lock conflicts
-	db.SetMaxIdleConns(1)
+	// Enable WAL mode for concurrent read/write
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to enable WAL mode: %w", err)
+	}
+	if _, err := db.Exec("PRAGMA synchronous=NORMAL"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to set synchronous mode: %w", err)
+	}
+	// Enable incremental auto-vacuum to reclaim space after deletes.
+	// This pragma only takes effect on new databases; for existing ones we must VACUUM.
+	if _, err := db.Exec("PRAGMA auto_vacuum=INCREMENTAL"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to set auto_vacuum: %w", err)
+	}
+	var vacuumMode int
+	if err := db.QueryRow("PRAGMA auto_vacuum").Scan(&vacuumMode); err == nil && vacuumMode == 0 {
+		// Database was created with NONE; apply change via full VACUUM
+		_, _ = db.Exec("VACUUM")
+	}
+
+	// WAL mode allows concurrent readers, increase max connections
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(2)
 
 	dbMap[sanitizedAppName] = db
 	return db, nil
+}
+
+// RunPeriodicMaintenance starts a background goroutine that periodically
+// runs incremental vacuum and WAL checkpoint on all open databases.
+func RunPeriodicMaintenance() {
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			dbMapLock.RLock()
+			dbs := make([]*sql.DB, 0, len(dbMap))
+			for _, d := range dbMap {
+				dbs = append(dbs, d)
+			}
+			dbMapLock.RUnlock()
+
+			for _, d := range dbs {
+				// Reclaim freed pages
+				_, _ = d.Exec("PRAGMA incremental_vacuum(200)")
+				// Checkpoint WAL to keep file size bounded
+				_, _ = d.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+			}
+		}
+	}()
 }

--- a/cmd/metrics-scraper/app/scrape/job.go
+++ b/cmd/metrics-scraper/app/scrape/job.go
@@ -20,15 +20,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclient "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/rest"
 
 	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/db"
 	"github.com/karmada-io/dashboard/pkg/client"
@@ -42,12 +46,48 @@ type SaveRequest struct {
 	result  chan error
 }
 
+const metricsRequestTimeout = 10 * time.Second
+
+// DiscoverComponentPods returns live Kubernetes pod names for a metrics
+// component without depending on the component's metrics database.
+func DiscoverComponentPods(ctx context.Context, appName string) ([]string, []string, error) {
+	if db.GetComponentConfig(appName) == nil {
+		return nil, nil, fmt.Errorf("unsupported metrics component %q", appName)
+	}
+
+	podsByCluster, warnings := getKarmadaPods(ctx, appName)
+	uniqueNames := make(map[string]struct{})
+	for _, pods := range podsByCluster {
+		for _, pod := range pods {
+			uniqueNames[pod.Name] = struct{}{}
+		}
+	}
+	podNames := make([]string, 0, len(uniqueNames))
+	for name := range uniqueNames {
+		podNames = append(podNames, name)
+	}
+	sort.Strings(podNames)
+
+	if len(podNames) == 0 && len(warnings) > 0 {
+		return podNames, warnings, fmt.Errorf("failed to discover %s pods", appName)
+	}
+	return podNames, warnings, nil
+}
+
 // FetchMetrics fetches metrics from all pods of the given app name
 func FetchMetrics(ctx context.Context, appName string, requests chan SaveRequest) (map[string]*db.ParsedData, []string, error) {
 	kubeClient := client.InClusterClient()
+	componentConfig := db.GetComponentConfig(appName)
+	if componentConfig == nil {
+		return nil, nil, fmt.Errorf("unsupported metrics component %q", appName)
+	}
 	podsMap, errors := getKarmadaPods(ctx, appName) // Pass context here
-	if len(podsMap) == 0 && len(errors) > 0 {
-		return nil, errors, fmt.Errorf("no pods found")
+	podCount := 0
+	for _, pods := range podsMap {
+		podCount += len(pods)
+	}
+	if podCount == 0 {
+		return nil, errors, fmt.Errorf("no pods found for component %q", appName)
 	}
 	allMetrics := make(map[string]*db.ParsedData)
 	var mu sync.Mutex
@@ -65,7 +105,7 @@ func FetchMetrics(ctx context.Context, appName string, requests chan SaveRequest
 				var jsonMetrics *db.ParsedData
 				var err error
 				if appName == db.KarmadaAgent {
-					jsonMetrics, err = getKarmadaAgentMetrics(ctx, pod.Name, clusterName, requests)
+					jsonMetrics, err = getKarmadaAgentMetrics(ctx, pod.Name, clusterName)
 					if err != nil {
 						mu.Lock()
 						errors = append(errors, err.Error())
@@ -73,20 +113,10 @@ func FetchMetrics(ctx context.Context, appName string, requests chan SaveRequest
 						return
 					}
 				} else {
-					port := db.SchedulerPort
-					if appName == db.KarmadaControllerManager {
-						port = db.ControllerManagerPort
-					}
-					metricsOutput, err := kubeClient.CoreV1().RESTClient().Get().
-						Namespace(db.Namespace).
-						Resource("pods").
-						SubResource("proxy").
-						Name(fmt.Sprintf("%s:%s", pod.Name, port)).
-						Suffix("metrics").
-						Do(ctx).Raw() // Use the context here
+					metricsOutput, err := getMetricsFromHostClusterPod(ctx, kubeClient, pod, componentConfig)
 					if err != nil {
 						mu.Lock()
-						errors = append(errors, err.Error())
+						errors = append(errors, fmt.Sprintf("pod %s: %v", pod.Name, err))
 						mu.Unlock()
 						return
 					}
@@ -97,17 +127,12 @@ func FetchMetrics(ctx context.Context, appName string, requests chan SaveRequest
 						mu.Unlock()
 						return
 					}
-					// Send save request without waiting
-					select {
-					case requests <- SaveRequest{
-						appName: appName,
-						podName: pod.Name,
-						data:    jsonMetrics,
-						result:  nil, // Not waiting for result
-					}:
-					case <-ctx.Done():
-						return
-					}
+				}
+				if err = persistMetrics(ctx, requests, appName, pod.Name, jsonMetrics); err != nil {
+					mu.Lock()
+					errors = append(errors, fmt.Sprintf("pod %s: failed to persist metrics: %v", pod.Name, err))
+					mu.Unlock()
+					return
 				}
 				mu.Lock()
 				allMetrics[pod.Name] = jsonMetrics
@@ -116,7 +141,126 @@ func FetchMetrics(ctx context.Context, appName string, requests chan SaveRequest
 		}
 	}
 	wg.Wait()
+	if len(allMetrics) == 0 && len(errors) > 0 {
+		return nil, errors, fmt.Errorf("failed to scrape metrics from all %s pods", appName)
+	}
 	return allMetrics, errors, nil
+}
+
+func persistMetrics(ctx context.Context, requests chan SaveRequest, appName, podName string, data *db.ParsedData) error {
+	if requests == nil {
+		return nil
+	}
+
+	result := make(chan error, 1)
+	select {
+	case requests <- SaveRequest{appName: appName, podName: podName, data: data, result: result}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	select {
+	case err := <-result:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func getMetricsFromHostClusterPod(ctx context.Context, kubeClient kubeclient.Interface, pod db.PodInfo, cfg *db.ComponentConfig) ([]byte, error) {
+	if cfg.Scheme == "https" {
+		karmadaConfig, _, err := client.GetKarmadaConfig()
+		if err != nil {
+			return nil, fmt.Errorf("get Karmada client config: %w", err)
+		}
+		return getAuthenticatedPodMetrics(ctx, karmadaConfig, pod, cfg)
+	}
+	return getMetricsFromHostClusterPodProxy(ctx, kubeClient, pod.Name, cfg.Port, cfg.MetricsPath)
+}
+
+func getMetricsFromHostClusterPodProxy(ctx context.Context, kubeClient kubeclient.Interface, podName, port, metricsPath string) ([]byte, error) {
+	path := strings.TrimPrefix(metricsPath, "/")
+	metricsOutput, err := kubeClient.CoreV1().RESTClient().Get().
+		Namespace(db.Namespace).
+		Resource("pods").
+		SubResource("proxy").
+		Name(fmt.Sprintf("%s:%s", podName, port)).
+		Suffix(path).
+		Do(ctx).Raw()
+	if err == nil {
+		return metricsOutput, nil
+	}
+
+	// Some apiservers may not reliably handle pod proxy with "<pod>:<port>".
+	// Fall back to "<pod>/proxy/metrics" before failing.
+	if isPodProxyPortLookupError(err) {
+		return kubeClient.CoreV1().RESTClient().Get().
+			Namespace(db.Namespace).
+			Resource("pods").
+			SubResource("proxy").
+			Name(podName).
+			Suffix(path).
+			Do(ctx).Raw()
+	}
+
+	return nil, err
+}
+
+func getAuthenticatedPodMetrics(ctx context.Context, karmadaConfig *rest.Config, pod db.PodInfo, cfg *db.ComponentConfig) ([]byte, error) {
+	if pod.IP == "" {
+		return nil, fmt.Errorf("pod has no IP address")
+	}
+
+	transportConfig := rest.CopyConfig(karmadaConfig)
+	transportConfig.TLSClientConfig.ServerName = cfg.ServerName
+	if cfg.InsecureSkipVerify {
+		// #nosec G402 -- upstream kube-controller-manager uses an ephemeral
+		// self-signed serving certificate; authentication still uses the Karmada
+		// client credentials and the connection is restricted to the selected pod.
+		transportConfig.TLSClientConfig.Insecure = true
+		transportConfig.TLSClientConfig.CAData = nil
+		transportConfig.TLSClientConfig.CAFile = ""
+		transportConfig.TLSClientConfig.ServerName = ""
+	}
+	httpClient, err := rest.HTTPClientFor(transportConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create authenticated metrics client: %w", err)
+	}
+	httpClient.Timeout = metricsRequestTimeout
+
+	endpoint := url.URL{
+		Scheme: cfg.Scheme,
+		Host:   net.JoinHostPort(pod.IP, cfg.Port),
+		Path:   cfg.MetricsPath,
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create metrics request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", endpoint.Redacted(), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("GET %s returned %s: %s", endpoint.Redacted(), resp.Status, strings.TrimSpace(string(body)))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read metrics response from %s: %w", endpoint.Redacted(), err)
+	}
+	return body, nil
+}
+
+func isPodProxyPortLookupError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "could not find the requested resource") ||
+		strings.Contains(msg, "not found")
 }
 
 func getKarmadaPods(ctx context.Context, appName string) (map[string][]db.PodInfo, []string) {
@@ -143,8 +287,13 @@ func getKarmadaPods(ctx context.Context, appName string) (map[string][]db.PodInf
 			}
 		}
 	} else {
+		cfg := db.GetComponentConfig(appName)
+		if cfg == nil {
+			errors = append(errors, fmt.Sprintf("unsupported metrics component %q", appName))
+			return podsMap, errors
+		}
 		pods, err := kubeClient.CoreV1().Pods(db.Namespace).List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app=%s", appName),
+			LabelSelector: cfg.LabelSelector,
 		})
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("failed to list pods: %v", err))
@@ -152,7 +301,7 @@ func getKarmadaPods(ctx context.Context, appName string) (map[string][]db.PodInf
 		}
 
 		for _, pod := range pods.Items {
-			podsMap[appName] = append(podsMap[appName], db.PodInfo{Name: pod.Name})
+			podsMap[appName] = append(podsMap[appName], db.PodInfo{Name: pod.Name, IP: pod.Status.PodIP})
 		}
 	}
 
@@ -162,28 +311,14 @@ func getKarmadaPods(ctx context.Context, appName string) (map[string][]db.PodInf
 func getClusterPods(ctx context.Context, cluster *v1alpha1.Cluster) ([]db.PodInfo, error) {
 	fmt.Printf("Getting pods for cluster: %s\n", cluster.Name)
 
-	kubeconfigPath := os.Getenv("KUBECONFIG")
-	if kubeconfigPath == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get user home directory: %v", err)
-		}
-		kubeconfigPath = filepath.Join(homeDir, ".kube", "karmada.config")
+	kubeClient := client.InClusterClientForMemberCluster(cluster.Name)
+	if kubeClient == nil {
+		return nil, fmt.Errorf("failed to create kubeclient for cluster %s", cluster.Name)
 	}
 
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build config for cluster %s: %v", cluster.Name, err)
-	}
-
-	config.Host = fmt.Sprintf("%s/apis/cluster.karmada.io/v1alpha1/clusters/%s/proxy", config.Host, cluster.Name)
-
-	kubeClient, err := kubeclient.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubeclient for cluster %s: %v", cluster.Name, err)
-	}
-
-	podList, err := kubeClient.CoreV1().Pods("karmada-system").List(ctx, metav1.ListOptions{})
+	podList, err := kubeClient.CoreV1().Pods("karmada-system").List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app=%s", db.KarmadaAgent),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods for cluster %s: %v", cluster.Name, err)
 	}
@@ -200,43 +335,14 @@ func getClusterPods(ctx context.Context, cluster *v1alpha1.Cluster) ([]db.PodInf
 	return podInfos, nil
 }
 
-func getKarmadaAgentMetrics(ctx context.Context, podName string, clusterName string, requests chan SaveRequest) (*db.ParsedData, error) {
-	kubeClient := client.InClusterKarmadaClient()
-	clusters, err := kubeClient.ClusterV1alpha1().Clusters().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list clusters: %v", err)
-	}
-
-	for _, cluster := range clusters.Items {
-		if strings.EqualFold(string(cluster.Spec.SyncMode), "Pull") {
-			clusterName = cluster.Name
-			break
-		}
-	}
-
+func getKarmadaAgentMetrics(ctx context.Context, podName string, clusterName string) (*db.ParsedData, error) {
 	if clusterName == "" {
-		return nil, fmt.Errorf("no cluster in 'Pull' mode found")
+		return nil, fmt.Errorf("cluster name is required for karmada-agent metrics")
 	}
 
-	kubeconfigPath := os.Getenv("KUBECONFIG")
-	if kubeconfigPath == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get user home directory: %v", err)
-		}
-		kubeconfigPath = filepath.Join(homeDir, ".kube", "karmada.config")
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build config for cluster %s: %v", clusterName, err)
-	}
-
-	config.Host = fmt.Sprintf("%s/apis/cluster.karmada.io/v1alpha1/clusters/%s/proxy", config.Host, clusterName)
-
-	restClient, err := kubeclient.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create REST client for cluster %s: %v", clusterName, err)
+	restClient := client.InClusterClientForMemberCluster(clusterName)
+	if restClient == nil {
+		return nil, fmt.Errorf("failed to create REST client for cluster %s", clusterName)
 	}
 
 	metricsOutput, err := restClient.CoreV1().RESTClient().Get().
@@ -264,18 +370,6 @@ func getKarmadaAgentMetrics(ctx context.Context, podName string, clusterName str
 			return nil, fmt.Errorf("failed to parse metrics to JSON: %v", err)
 		}
 		parsedData = parsedDataPtr
-	}
-
-	// Send save request to the database worker
-	select {
-	case requests <- SaveRequest{
-		appName: db.KarmadaAgent,
-		podName: podName,
-		data:    parsedData,
-		result:  nil, // Not waiting for result
-	}:
-	case <-ctx.Done():
-		return nil, ctx.Err()
 	}
 
 	return parsedData, nil

--- a/cmd/metrics-scraper/app/scrape/job_test.go
+++ b/cmd/metrics-scraper/app/scrape/job_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scrape
+
+import (
+	"bytes"
+	"context"
+	"encoding/pem"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/db"
+)
+
+func TestGetAuthenticatedPodMetricsUsesKarmadaCredentials(t *testing.T) {
+	const token = "metrics-reader-token"
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			http.Error(w, "missing Karmada credentials", http.StatusForbidden)
+			return
+		}
+		if r.URL.Path != "/custom-metrics" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte("# TYPE karmada_build_info gauge\nkarmada_build_info 1\n"))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	host, port, err := net.SplitHostPort(serverURL.Host)
+	if err != nil {
+		t.Fatalf("split test server address: %v", err)
+	}
+	certificate := server.Certificate()
+	caData := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw})
+
+	got, err := getAuthenticatedPodMetrics(
+		context.Background(),
+		&rest.Config{BearerToken: token, TLSClientConfig: rest.TLSClientConfig{CAData: caData}},
+		db.PodInfo{Name: "aggregated-apiserver-0", IP: host},
+		&db.ComponentConfig{Scheme: "https", Port: port, MetricsPath: "/custom-metrics"},
+	)
+	if err != nil {
+		t.Fatalf("getAuthenticatedPodMetrics returned error: %v", err)
+	}
+	if string(got) != "# TYPE karmada_build_info gauge\nkarmada_build_info 1\n" {
+		t.Fatalf("unexpected metrics body %q", got)
+	}
+}
+
+func TestGetAuthenticatedPodMetricsRequiresPodIP(t *testing.T) {
+	_, err := getAuthenticatedPodMetrics(
+		context.Background(),
+		&rest.Config{},
+		db.PodInfo{Name: "pending-pod"},
+		&db.ComponentConfig{Scheme: "https", Port: "443", MetricsPath: "/metrics"},
+	)
+	if err == nil {
+		t.Fatal("expected an error for a pod without an IP")
+	}
+}
+
+func TestParseFiniteMetricValue(t *testing.T) {
+	for _, raw := range []string{"NaN", "+Inf", "-Inf", "not-a-number"} {
+		if value, ok := parseFiniteMetricValue(raw); ok {
+			t.Fatalf("parseFiniteMetricValue(%q) = %v, true; want rejected", raw, value)
+		}
+	}
+	if value, ok := parseFiniteMetricValue(" 12.5 "); !ok || value != 12.5 {
+		t.Fatalf("parseFiniteMetricValue(valid) = %v, %t; want 12.5, true", value, ok)
+	}
+}
+
+func TestGetAuthenticatedPodMetricsIntegration(t *testing.T) {
+	podIP := os.Getenv("METRICS_INTEGRATION_POD_IP")
+	kubeconfig := os.Getenv("METRICS_INTEGRATION_KUBECONFIG")
+	if podIP == "" || kubeconfig == "" {
+		t.Skip("set METRICS_INTEGRATION_POD_IP and METRICS_INTEGRATION_KUBECONFIG to run")
+	}
+
+	karmadaConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("load Karmada kubeconfig: %v", err)
+	}
+	component := os.Getenv("METRICS_INTEGRATION_COMPONENT")
+	if component == "" {
+		component = db.KarmadaAggregatedAPIServer
+	}
+	cfg := db.GetComponentConfig(component)
+	if cfg == nil {
+		t.Fatalf("%s scrape config is missing", component)
+	}
+
+	metrics, err := getAuthenticatedPodMetrics(
+		context.Background(),
+		karmadaConfig,
+		db.PodInfo{Name: "integration-target", IP: podIP},
+		cfg,
+	)
+	if err != nil {
+		t.Fatalf("scrape %s: %v", component, err)
+	}
+	if !bytes.Contains(metrics, []byte("# HELP")) || !bytes.Contains(metrics, []byte("# TYPE")) {
+		t.Fatalf("response is not Prometheus metrics text (length %d)", len(metrics))
+	}
+	t.Logf("scraped %d bytes from %s", len(metrics), component)
+}

--- a/cmd/metrics-scraper/app/scrape/other.go
+++ b/cmd/metrics-scraper/app/scrape/other.go
@@ -21,24 +21,46 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	_ "github.com/glebarez/sqlite" // Import the SQLite driver
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 
 	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/db"
 )
 
-var dbMutex sync.Mutex
+var (
+	dbMutexMap      = make(map[string]*sync.Mutex)
+	dbMutexLock     sync.Mutex
+	scrapeCounter   uint64
+	scrapeCounterMu sync.Mutex
+)
+
+func getDBMutex(appName string) *sync.Mutex {
+	dbMutexLock.Lock()
+	defer dbMutexLock.Unlock()
+
+	if mu, ok := dbMutexMap[appName]; ok {
+		return mu
+	}
+
+	mu := &sync.Mutex{}
+	dbMutexMap[appName] = mu
+	return mu
+}
 
 func saveToDBWithConnection(db *sql.DB, appName, podName string, data *db.ParsedData) (err error) {
 	sanitizedPodName := strings.ReplaceAll(podName, "-", "_")
 	log.Printf("Saving data for app '%s', pod '%s' (sanitized: '%s')", appName, podName, sanitizedPodName)
 
-	dbMutex.Lock()
-	defer dbMutex.Unlock()
+	mu := getDBMutex(appName)
+	mu.Lock()
+	defer mu.Unlock()
 
 	tx, err := db.Begin()
 	if err != nil {
@@ -64,13 +86,41 @@ func saveToDBWithConnection(db *sql.DB, appName, podName string, data *db.Parsed
 		return err
 	}
 
+	if _, err = tx.Exec(fmt.Sprintf(createMetadataTableSQL, sanitizedPodName)); err != nil {
+		log.Printf("Error creating metadata table: %v", err)
+		return err
+	}
+
 	if _, err = tx.Exec(fmt.Sprintf(createValuesTableSQL, sanitizedPodName, sanitizedPodName)); err != nil {
 		log.Printf("Error creating values table: %v", err)
 		return err
 	}
 
-	if _, err = tx.Exec(fmt.Sprintf(createLabelsTableSQL, sanitizedPodName, sanitizedPodName)); err != nil {
+	if _, err = tx.Exec(fmt.Sprintf(createLabelStringsTableSQL, sanitizedPodName)); err != nil {
+		log.Printf("Error creating label_strings table: %v", err)
+		return err
+	}
+
+	if _, err = tx.Exec(fmt.Sprintf(createLabelsTableSQL, sanitizedPodName, sanitizedPodName, sanitizedPodName)); err != nil {
 		log.Printf("Error creating labels table: %v", err)
+		return err
+	}
+
+	// Create indexes for query performance
+	if _, err = tx.Exec(fmt.Sprintf(createMainIndexSQL, sanitizedPodName, sanitizedPodName)); err != nil {
+		log.Printf("Error creating main index: %v", err)
+		return err
+	}
+	if _, err = tx.Exec(fmt.Sprintf(createValuesIndexSQL, sanitizedPodName, sanitizedPodName)); err != nil {
+		log.Printf("Error creating values index: %v", err)
+		return err
+	}
+	if _, err = tx.Exec(fmt.Sprintf(createLabelsIndexSQL, sanitizedPodName, sanitizedPodName)); err != nil {
+		log.Printf("Error creating labels index: %v", err)
+		return err
+	}
+	if _, err = tx.Exec(fmt.Sprintf(createLabelStringsIndexSQL, sanitizedPodName, sanitizedPodName)); err != nil {
+		log.Printf("Error creating label_strings index: %v", err)
 		return err
 	}
 
@@ -96,54 +146,73 @@ func saveToDBWithConnection(db *sql.DB, appName, podName string, data *db.Parsed
 		return err
 	}
 
-	if err = tx.Commit(); err != nil {
-		log.Printf("Error committing transaction: %v", err)
-		return err
-	}
-
 	log.Println("Data inserted successfully")
 	return nil
 }
 
 func cleanupOldData(tx *sql.Tx, timeLoadTableName, sanitizedPodName string) error {
-	var oldestTime string
-	err := tx.QueryRow(fmt.Sprintf(getOldestTimeSQL, timeLoadTableName)).Scan(&oldestTime)
-	if err != nil && err != sql.ErrNoRows {
-		log.Printf("Error getting oldest time entry: %v", err)
+	// Use time-based TTL: delete everything older than 5 minutes
+	cutoffTime := time.Now().Add(-15 * time.Minute).Format(time.RFC3339)
+
+	result, err := tx.Exec(fmt.Sprintf(deleteOldTimeSQL, timeLoadTableName), cutoffTime)
+	if err != nil {
+		log.Printf("Error deleting old time entries: %v", err)
 		return err
 	}
-
-	if oldestTime != "" {
-		result, err := tx.Exec(fmt.Sprintf(deleteOldTimeSQL, timeLoadTableName), oldestTime)
-		if err != nil {
-			log.Printf("Error deleting old time entries: %v", err)
-			return err
-		}
-		rowsAffected, _ := result.RowsAffected()
+	rowsAffected, _ := result.RowsAffected()
+	if rowsAffected > 0 {
 		log.Printf("Deleted %d old time entries from %s", rowsAffected, timeLoadTableName)
 
-		result, err = tx.Exec(fmt.Sprintf(deleteAssociatedMetricsSQL, sanitizedPodName), oldestTime)
+		// Delete labels first (depends on values which depends on metrics)
+		result, err = tx.Exec(fmt.Sprintf(deleteAssociatedLabelsSQL, sanitizedPodName, sanitizedPodName, sanitizedPodName), cutoffTime)
 		if err != nil {
-			log.Printf("Error deleting associated metrics: %v", err)
+			log.Printf("Error deleting associated labels: %v", err)
 			return err
 		}
-		rowsAffected, _ = result.RowsAffected()
-		log.Printf("Deleted %d associated metrics from %s", rowsAffected, sanitizedPodName)
+		labelsAffected, _ := result.RowsAffected()
+		log.Printf("Deleted %d associated labels from %s_labels", labelsAffected, sanitizedPodName)
 
-		result, err = tx.Exec(fmt.Sprintf(deleteAssociatedValuesSQL, sanitizedPodName, sanitizedPodName))
+		// Delete values (depends on metrics)
+		result, err = tx.Exec(fmt.Sprintf(deleteAssociatedValuesSQL, sanitizedPodName, sanitizedPodName), cutoffTime)
 		if err != nil {
 			log.Printf("Error deleting associated values: %v", err)
 			return err
 		}
-		rowsAffected, _ = result.RowsAffected()
-		log.Printf("Deleted %d associated values from %s_values", rowsAffected, sanitizedPodName)
+		valuesAffected, _ := result.RowsAffected()
+		log.Printf("Deleted %d associated values from %s_values", valuesAffected, sanitizedPodName)
+
+		// Delete metrics last
+		result, err = tx.Exec(fmt.Sprintf(deleteAssociatedMetricsSQL, sanitizedPodName), cutoffTime)
+		if err != nil {
+			log.Printf("Error deleting associated metrics: %v", err)
+			return err
+		}
+		metricsAffected, _ := result.RowsAffected()
+		log.Printf("Deleted %d associated metrics from %s", metricsAffected, sanitizedPodName)
 	}
 	return nil
 }
 
 func insertMetricsData(tx *sql.Tx, data *db.ParsedData, sanitizedPodName string) error {
+	scrapeCounterMu.Lock()
+	scrapeCounter++
+	currentScrape := scrapeCounter
+	scrapeCounterMu.Unlock()
+
 	for metricName, metricData := range data.Metrics {
-		result, err := tx.Exec(fmt.Sprintf(insertMainSQL, sanitizedPodName), metricName, metricData.Help, metricData.Type, data.CurrentTime)
+		tier := db.GetMetricTier(metricName)
+
+		// Skip low-tier metrics on non-sampled scrapes (keep every 3rd)
+		if tier == db.TierLow && currentScrape%3 != 0 {
+			continue
+		}
+
+		if _, err := tx.Exec(fmt.Sprintf(insertMetadataSQL, sanitizedPodName), metricName, metricData.Help, metricData.Type); err != nil {
+			log.Printf("Error inserting metadata for metric %s: %v", metricName, err)
+			return err
+		}
+
+		result, err := tx.Exec(fmt.Sprintf(insertMainSQL, sanitizedPodName), metricName, data.CurrentTime)
 		if err != nil {
 			log.Printf("Error inserting data for metric %s: %v", metricName, err)
 			return err
@@ -156,7 +225,16 @@ func insertMetricsData(tx *sql.Tx, data *db.ParsedData, sanitizedPodName string)
 		}
 
 		for _, value := range metricData.Values {
-			valueIDResult, err := tx.Exec(fmt.Sprintf("INSERT INTO %s_values (metric_id, value, measure) VALUES (?, ?, ?)", sanitizedPodName), metricID, value.Value, value.Measure)
+			// Skip histogram bucket detail rows — keep only sum and count
+			if value.Measure == "cumulative_count" {
+				continue
+			}
+
+			numericValue, ok := parseFiniteMetricValue(value.Value)
+			if !ok {
+				continue
+			}
+			valueIDResult, err := tx.Exec(fmt.Sprintf("INSERT INTO %s_values (metric_id, value, measure) VALUES (?, ?, ?)", sanitizedPodName), metricID, numericValue, value.Measure)
 			if err != nil {
 				log.Printf("Error inserting value for metric %s: %v", metricName, err)
 				return err
@@ -168,15 +246,36 @@ func insertMetricsData(tx *sql.Tx, data *db.ParsedData, sanitizedPodName string)
 			}
 
 			for labelKey, labelValue := range value.Labels {
-				_, err = tx.Exec(fmt.Sprintf("INSERT INTO %s_labels (value_id, key, value) VALUES (?, ?, ?)", sanitizedPodName), valueID, labelKey, labelValue)
+				_, err = tx.Exec(fmt.Sprintf("INSERT OR IGNORE INTO %s_label_strings (key, value) VALUES (?, ?)", sanitizedPodName), labelKey, labelValue)
 				if err != nil {
-					log.Printf("Error inserting label for value of metric %s: %v", metricName, err)
+					log.Printf("Error interning label for metric %s: %v", metricName, err)
+					return err
+				}
+
+				var labelStringID int64
+				err = tx.QueryRow(fmt.Sprintf("SELECT id FROM %s_label_strings WHERE key = ? AND value = ?", sanitizedPodName), labelKey, labelValue).Scan(&labelStringID)
+				if err != nil {
+					log.Printf("Error getting interned label ID for metric %s: %v", metricName, err)
+					return err
+				}
+
+				_, err = tx.Exec(fmt.Sprintf("INSERT INTO %s_labels (value_id, label_string_id) VALUES (?, ?)", sanitizedPodName), valueID, labelStringID)
+				if err != nil {
+					log.Printf("Error inserting label ref for metric %s: %v", metricName, err)
 					return err
 				}
 			}
 		}
 	}
 	return nil
+}
+
+func parseFiniteMetricValue(raw string) (float64, bool) {
+	value, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, false
+	}
+	return value, true
 }
 
 func isJSON(data []byte) bool {
@@ -206,7 +305,7 @@ func startDatabaseWorker(requests chan SaveRequest) {
 }
 
 func parseMetricsToJSON(metricsOutput string) (*db.ParsedData, error) {
-	var parser expfmt.TextParser
+	parser := expfmt.NewTextParser(model.UTF8Validation)
 	metricFamilies, err := parser.TextToMetricFamilies(strings.NewReader(metricsOutput))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing metrics: %w", err)

--- a/cmd/metrics-scraper/app/scrape/scrape.go
+++ b/cmd/metrics-scraper/app/scrape/scrape.go
@@ -19,6 +19,7 @@ package scrape
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -31,17 +32,28 @@ import (
 )
 
 var (
-	requests chan SaveRequest
-	sqldb    *sql.DB
-	syncMap  sync.Map
+	requestsMap map[string]chan SaveRequest
+	sqldb       *sql.DB
+	syncMap     sync.Map
+	// scrapeInterval controls how frequently each app fetcher triggers a scrape cycle.
+	scrapeInterval = 10 * time.Second
 	// Add contexts and cancel functions for each app
 	appContexts    map[string]context.Context
 	appCancelFuncs map[string]context.CancelFunc
 	contextMutex   sync.Mutex
 )
 
+func getRequestsChannel(appName string) (chan SaveRequest, bool) {
+	if requestsMap == nil {
+		return nil, false
+	}
+
+	requests, ok := requestsMap[appName]
+	return requests, ok
+}
+
 func startAppMetricsFetcher(appName string) {
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(scrapeInterval)
 	defer ticker.Stop()
 
 	for {
@@ -66,15 +78,19 @@ func startAppMetricsFetcher(appName string) {
 
 			syncTrigger, ok := syncTriggerVal.(int)
 			if !ok || syncTrigger != 1 {
-				return
+				continue
 			}
 
-			go func(ctx context.Context) {
-				_, errors, err := FetchMetrics(ctx, appName, requests)
-				if err != nil {
-					log.Printf("Error fetching metrics for %s: %v, errors: %v\n", appName, err, errors)
-				}
-			}(ctx)
+			requests, ok := getRequestsChannel(appName)
+			if !ok {
+				log.Printf("Request channel not found for %s", appName)
+				continue
+			}
+
+			_, errors, err := FetchMetrics(ctx, appName, requests)
+			if err != nil {
+				log.Printf("Error fetching metrics for %s: %v, errors: %v\n", appName, err, errors)
+			}
 		}
 	}
 }
@@ -83,7 +99,7 @@ func startAppMetricsFetcher(appName string) {
 func CheckAppStatus(c *gin.Context) {
 	statusMap := make(map[string]bool)
 
-	// Get status for all registered apps
+	// Get status for all registered apps (same list as InitDatabase)
 	for _, app := range []string{
 		db.KarmadaScheduler,
 		db.KarmadaControllerManager,
@@ -91,6 +107,13 @@ func CheckAppStatus(c *gin.Context) {
 		db.KarmadaSchedulerEstimator + "-member1",
 		db.KarmadaSchedulerEstimator + "-member2",
 		db.KarmadaSchedulerEstimator + "-member3",
+		db.KarmadaAggregatedAPIServer,
+		db.KarmadaAPIServer,
+		db.KarmadaDescheduler,
+		db.KarmadaKubeControllerManager,
+		db.KarmadaMetricsAdapter,
+		db.KarmadaSearch,
+		db.KarmadaWebhook,
 	} {
 		syncValue, exists := syncMap.Load(app)
 		if !exists {
@@ -122,9 +145,11 @@ func HandleSyncOperation(c *gin.Context, appName string, syncValue int, queryTyp
 		// Cancel all existing contexts and create new ones if turning on
 		contextMutex.Lock()
 		for app := range appContexts {
-			currentSyncValue, _ := syncMap.Load(app)
-			if currentSyncValue == syncValue {
-				continue // Skip if already in the desired state
+			currentSyncValue, ok := syncMap.Load(app)
+			if ok {
+				if val, isInt := currentSyncValue.(int); isInt && val == syncValue {
+					continue // Skip if already in the desired state
+				}
 			}
 
 			if cancel, exists := appCancelFuncs[app]; exists {
@@ -150,11 +175,13 @@ func HandleSyncOperation(c *gin.Context, appName string, syncValue int, queryTyp
 		c.JSON(http.StatusOK, gin.H{"message": message})
 	} else {
 		// Update specific app
-		currentSyncValue, _ := syncMap.Load(appName)
-		if currentSyncValue == syncValue {
-			message := fmt.Sprintf("Sync is already %s for %s", queryType, appName)
-			c.JSON(http.StatusOK, gin.H{"message": message})
-			return
+		currentSyncValue, ok := syncMap.Load(appName)
+		if ok {
+			if val, isInt := currentSyncValue.(int); isInt && val == syncValue {
+				message := fmt.Sprintf("Sync is already %s for %s", queryType, appName)
+				c.JSON(http.StatusOK, gin.H{"message": message})
+				return
+			}
 		}
 
 		_, err := sqldb.Exec("UPDATE app_sync SET sync_trigger = ? WHERE app_name = ?", syncValue, appName)
@@ -190,7 +217,12 @@ func HandleSyncOperation(c *gin.Context, appName string, syncValue int, queryTyp
 }
 
 // InitDatabase initializes the database and starts the metrics fetchers.
-func InitDatabase() {
+func InitDatabase(interval time.Duration) {
+	if interval > 0 {
+		scrapeInterval = interval
+	}
+	log.Printf("Metrics scrape interval set to %s", scrapeInterval)
+
 	// Initialize contexts and cancel functions
 	appContexts = make(map[string]context.Context)
 	appCancelFuncs = make(map[string]context.CancelFunc)
@@ -202,6 +234,13 @@ func InitDatabase() {
 		db.KarmadaSchedulerEstimator + "-member1",
 		db.KarmadaSchedulerEstimator + "-member2",
 		db.KarmadaSchedulerEstimator + "-member3",
+		db.KarmadaAggregatedAPIServer,
+		db.KarmadaAPIServer,
+		db.KarmadaDescheduler,
+		db.KarmadaKubeControllerManager,
+		db.KarmadaMetricsAdapter,
+		db.KarmadaSearch,
+		db.KarmadaWebhook,
 	}
 
 	// Create database connection
@@ -239,11 +278,36 @@ func InitDatabase() {
 		syncMap.Store(appName, 1)
 	}
 
-	requests = make(chan SaveRequest, len(appNames))
-	go startDatabaseWorker(requests)
+	requestsMap = make(map[string]chan SaveRequest, len(appNames))
+	for _, appName := range appNames {
+		requests := make(chan SaveRequest, len(appNames))
+		requestsMap[appName] = requests
+		go startDatabaseWorker(requests)
+	}
 
 	// Start metrics fetchers with context
 	for _, app := range appNames {
 		go startAppMetricsFetcher(app)
 	}
+
+	// Start periodic database maintenance (vacuum + WAL checkpoint)
+	RunPeriodicMaintenance()
+
+	// Start aggregation workers for downsampling
+	StartAggregationWorkers()
+}
+
+// TriggerScrapeNow triggers an immediate scrape for a single app and stores the result.
+func TriggerScrapeNow(ctx context.Context, appName string) ([]string, error) {
+	requests, ok := getRequestsChannel(appName)
+	if !ok {
+		return nil, errors.New("metrics scraper is not initialized for app")
+	}
+
+	_, scrapeErrors, err := FetchMetrics(ctx, appName, requests)
+	if err != nil {
+		return scrapeErrors, err
+	}
+
+	return scrapeErrors, nil
 }

--- a/cmd/web/app/options/options.go
+++ b/cmd/web/app/options/options.go
@@ -34,6 +34,8 @@ type Options struct {
 	APIProxyEndpoint                    string
 	EnableKubernetesDashboardAPIProxy   bool
 	KubernetesDashboardAPIProxyEndpoint string
+	EnableMetricsScraperProxy           bool
+	MetricsScraperProxyEndpoint         string
 	DashboardConfigPath                 string
 }
 
@@ -57,5 +59,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.APIProxyEndpoint, "api-proxy-endpoint", "http://karmada-dashboard-api.karmada-system.svc.cluster.local:8000", "karmada-dashboard-api endpoint")
 	fs.BoolVar(&o.EnableKubernetesDashboardAPIProxy, "enable-kubernetes-dashboard-api-proxy", true, "whether enable proxy to kubernetes-dashboard-api, if set true, all requests with /clusterapi prefix will be proxied to kubernetes-dashboard-api.karmada-system.svc.cluster.local")
 	fs.StringVar(&o.KubernetesDashboardAPIProxyEndpoint, "kubernetes-dashboard-api-proxy-endpoint", "http://kubernetes-dashboard-api.karmada-system.svc.cluster.local:8000", "kubernetes-dashboard-api endpoint")
+	fs.BoolVar(&o.EnableMetricsScraperProxy, "enable-metrics-scraper-proxy", true, "whether enable proxy to karmada-dashboard-metrics-scraper, if set true, all requests with /metrics-scraper prefix will be proxied to the metrics-scraper endpoint")
+	fs.StringVar(&o.MetricsScraperProxyEndpoint, "metrics-scraper-proxy-endpoint", "http://karmada-dashboard-metrics-scraper.karmada-system.svc.cluster.local:8000", "karmada-dashboard-metrics-scraper endpoint")
 	fs.StringVar(&o.DashboardConfigPath, "dashboard-config-path", "./config/dashboard-config.yaml", "path to dashboard config file")
 }

--- a/cmd/web/app/web.go
+++ b/cmd/web/app/web.go
@@ -158,6 +158,15 @@ func serve(opts *options.Options) {
 				klog.Fatalf("failed to parse kubernetes-dashboard-api-proxy-endpoint: %v", err)
 			}
 		}
+		if opts.EnableMetricsScraperProxy {
+			if metricsScraperProxyFunc, err := generateAPIProxy(opts.MetricsScraperProxyEndpoint, func(req *http.Request, _ *gin.Context) {
+				req.URL.Path = strings.TrimPrefix(req.URL.Path, pathPrefix+"/metrics-scraper")
+			}); err == nil {
+				g.Any("/metrics-scraper/*path", metricsScraperProxyFunc)
+			} else {
+				klog.Fatalf("failed to parse metrics-scraper-proxy-endpoint: %v", err)
+			}
+		}
 		g.GET("/i18n/*path", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{})
 		})

--- a/hack/util/constant.sh
+++ b/hack/util/constant.sh
@@ -73,6 +73,7 @@ KARMADA_TARGET_SOURCE=(
   karmada-dashboard-api=cmd/api
   karmada-dashboard-web=cmd/web
   kubernetes-dashboard-api=cmd/kubernetes-dashboard-api
+  karmada-dashboard-metrics-scraper=cmd/metrics-scraper
 )
 
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,8 +114,71 @@ func GetDashboardConfig() DashboardConfig {
 	if config.MenuConfigs == nil {
 		config.MenuConfigs = []MenuConfig{}
 	}
+	if config.MetricsDashboards == nil {
+		config.MetricsDashboards = []MetricsDashboard{}
+	}
 
 	return config
+}
+
+// GetMetricsDashboards returns the persisted metrics dashboards (never nil).
+func GetMetricsDashboards() []MetricsDashboard {
+	if dashboardConfig.MetricsDashboards == nil {
+		return []MetricsDashboard{}
+	}
+	dashboards := make([]MetricsDashboard, len(dashboardConfig.MetricsDashboards))
+	copy(dashboards, dashboardConfig.MetricsDashboards)
+	return dashboards
+}
+
+// UpsertMetricsDashboard inserts or replaces the metrics dashboard for a single
+// component and persists it to the dashboard ConfigMap. It reads the ConfigMap
+// fresh and merges only the metrics dashboards, so other config fields are never
+// clobbered by a stale in-memory cache.
+func UpsertMetricsDashboard(k8sClient kubernetes.Interface, dashboard MetricsDashboard) error {
+	ctx := context.TODO()
+	configMap, err := k8sClient.CoreV1().ConfigMaps(configNamespace).Get(ctx, configName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Failed to get ConfigMap %s: %v", configName, err)
+		return err
+	}
+
+	configKey := GetConfigKey()
+	var current DashboardConfig
+	if raw, ok := configMap.Data[configKey]; ok && raw != "" {
+		if err = yaml.Unmarshal([]byte(raw), &current); err != nil {
+			klog.Errorf("Failed to unmarshal ConfigMap %s: %v", configName, err)
+			return err
+		}
+	}
+
+	replaced := false
+	for i := range current.MetricsDashboards {
+		if current.MetricsDashboards[i].Component == dashboard.Component {
+			current.MetricsDashboards[i] = dashboard
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		current.MetricsDashboards = append(current.MetricsDashboards, dashboard)
+	}
+
+	buff, err := yaml.Marshal(current)
+	if err != nil {
+		klog.Errorf("Failed to marshal dashboard config: %v", err)
+		return err
+	}
+	if configMap.Data == nil {
+		configMap.Data = map[string]string{}
+	}
+	configMap.Data[configKey] = string(buff)
+	if _, err = k8sClient.CoreV1().ConfigMaps(configNamespace).Update(ctx, configMap, metav1.UpdateOptions{}); err != nil {
+		klog.Errorf("Failed to update ConfigMap %s: %v", configName, err)
+		return err
+	}
+	dashboardConfig = current
+	return nil
 }
 
 // UpdateDashboardConfig updates the dashboard configuration in the Kubernetes ConfigMap.

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -42,10 +42,42 @@ type MenuConfig struct {
 	Children   []MenuConfig `yaml:"children" json:"children,omitempty"`
 }
 
+// MetricLabelFilter represents a single label matcher used by a metric panel query.
+type MetricLabelFilter struct {
+	Key   string `yaml:"key" json:"key"`
+	Value string `yaml:"value" json:"value"`
+}
+
+// MetricPanelQuery represents the query definition backing a metric panel.
+type MetricPanelQuery struct {
+	Metric       string              `yaml:"metric" json:"metric"`
+	Aggregation  string              `yaml:"aggregation" json:"aggregation"`
+	LabelFilters []MetricLabelFilter `yaml:"label_filters,omitempty" json:"labelFilters,omitempty"`
+}
+
+// MetricPanel represents a single chart panel on the metrics dashboard.
+type MetricPanel struct {
+	ID         string            `yaml:"id" json:"id"`
+	MetricName string            `yaml:"metric_name" json:"metricName"`
+	ChartType  string            `yaml:"chart_type" json:"chartType"`
+	Title      string            `yaml:"title" json:"title"`
+	Visible    bool              `yaml:"visible" json:"visible"`
+	Query      *MetricPanelQuery `yaml:"query,omitempty" json:"query,omitempty"`
+	Order      *int              `yaml:"order,omitempty" json:"order,omitempty"`
+}
+
+// MetricsDashboard represents the persisted panel layout for a single component.
+type MetricsDashboard struct {
+	Version   int           `yaml:"version" json:"version"`
+	Component string        `yaml:"component" json:"component"`
+	Panels    []MetricPanel `yaml:"panels" json:"panels"`
+}
+
 // DashboardConfig represents the configuration structure for the Karmada dashboard.
 type DashboardConfig struct {
-	DockerRegistries []DockerRegistry `yaml:"docker_registries" json:"docker_registries"`
-	ChartRegistries  []ChartRegistry  `yaml:"chart_registries" json:"chart_registries"`
-	MenuConfigs      []MenuConfig     `yaml:"menu_configs" json:"menu_configs"`
-	PathPrefix       string           `yaml:"path_prefix" json:"path_prefix"`
+	DockerRegistries  []DockerRegistry   `yaml:"docker_registries" json:"docker_registries"`
+	ChartRegistries   []ChartRegistry    `yaml:"chart_registries" json:"chart_registries"`
+	MenuConfigs       []MenuConfig       `yaml:"menu_configs" json:"menu_configs"`
+	PathPrefix        string             `yaml:"path_prefix" json:"path_prefix"`
+	MetricsDashboards []MetricsDashboard `yaml:"metrics_dashboards,omitempty" json:"metrics_dashboards,omitempty"`
 }

--- a/ui/DESIGN.md
+++ b/ui/DESIGN.md
@@ -1,0 +1,310 @@
+# Design System Inspired by Vercel
+
+## 1. Visual Theme & Atmosphere
+
+Vercel's website is the visual thesis of developer infrastructure made invisible — a design system so restrained it borders on philosophical. The page is overwhelmingly white (`#ffffff`) with near-black (`#171717`) text, creating a gallery-like emptiness where every element earns its pixel. This isn't minimalism as decoration; it's minimalism as engineering principle. The Geist design system treats the interface like a compiler treats code — every unnecessary token is stripped away until only structure remains.
+
+The custom Geist font family is the crown jewel. Geist Sans uses aggressive negative letter-spacing (-2.4px to -2.88px at display sizes), creating headlines that feel compressed, urgent, and engineered — like code that's been minified for production. At body sizes, the tracking relaxes but the geometric precision persists. Geist Mono completes the system as the monospace companion for code, terminal output, and technical labels. Both fonts enable OpenType `"liga"` (ligatures) globally, adding a layer of typographic sophistication that rewards close reading.
+
+What distinguishes Vercel from other monochrome design systems is its shadow-as-border philosophy. Instead of traditional CSS borders, Vercel uses `box-shadow: 0px 0px 0px 1px rgba(0,0,0,0.08)` — a zero-offset, zero-blur, 1px-spread shadow that creates a border-like line without the box model implications. This technique allows borders to exist in the shadow layer, enabling smoother transitions, rounded corners without clipping, and a subtler visual weight than traditional borders. The entire depth system is built on layered, multi-value shadow stacks where each layer serves a specific purpose: one for the border, one for soft elevation, one for ambient depth.
+
+**Key Characteristics:**
+- Geist Sans with extreme negative letter-spacing (-2.4px to -2.88px at display) — text as compressed infrastructure
+- Geist Mono for code and technical labels with OpenType `"liga"` globally
+- Shadow-as-border technique: `box-shadow 0px 0px 0px 1px` replaces traditional borders throughout
+- Multi-layer shadow stacks for nuanced depth (border + elevation + ambient in single declarations)
+- Near-pure white canvas with `#171717` text — not quite black, creating micro-contrast softness
+- Workflow-specific accent colors: Ship Red (`#ff5b4f`), Preview Pink (`#de1d8d`), Develop Blue (`#0a72ef`)
+- Focus ring system using `hsla(212, 100%, 48%, 1)` — a saturated blue for accessibility
+- Pill badges (9999px) with tinted backgrounds for status indicators
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Vercel Black** (`#171717`): Primary text, headings, dark surface backgrounds. Not pure black — the slight warmth prevents harshness.
+- **Pure White** (`#ffffff`): Page background, card surfaces, button text on dark.
+- **True Black** (`#000000`): Secondary use, `--geist-console-text-color-default`, used in specific console/code contexts.
+
+### Workflow Accent Colors
+- **Ship Red** (`#ff5b4f`): `--ship-text`, the "ship to production" workflow step — warm, urgent coral-red.
+- **Preview Pink** (`#de1d8d`): `--preview-text`, the preview deployment workflow — vivid magenta-pink.
+- **Develop Blue** (`#0a72ef`): `--develop-text`, the development workflow — bright, focused blue.
+
+### Console / Code Colors
+- **Console Blue** (`#0070f3`): `--geist-console-text-color-blue`, syntax highlighting blue.
+- **Console Purple** (`#7928ca`): `--geist-console-text-color-purple`, syntax highlighting purple.
+- **Console Pink** (`#eb367f`): `--geist-console-text-color-pink`, syntax highlighting pink.
+
+### Interactive
+- **Link Blue** (`#0072f5`): Primary link color with underline decoration.
+- **Focus Blue** (`hsla(212, 100%, 48%, 1)`): `--ds-focus-color`, focus ring on interactive elements.
+- **Ring Blue** (`rgba(147, 197, 253, 0.5)`): `--tw-ring-color`, Tailwind ring utility.
+
+### Neutral Scale
+- **Gray 900** (`#171717`): Primary text, headings, nav text.
+- **Gray 600** (`#4d4d4d`): Secondary text, description copy.
+- **Gray 500** (`#666666`): Tertiary text, muted links.
+- **Gray 400** (`#808080`): Placeholder text, disabled states.
+- **Gray 100** (`#ebebeb`): Borders, card outlines, dividers.
+- **Gray 50** (`#fafafa`): Subtle surface tint, inner shadow highlight.
+
+### Surface & Overlay
+- **Overlay Backdrop** (`hsla(0, 0%, 98%, 1)`): `--ds-overlay-backdrop-color`, modal/dialog backdrop.
+- **Selection Text** (`hsla(0, 0%, 95%, 1)`): `--geist-selection-text-color`, text selection highlight.
+- **Badge Blue Bg** (`#ebf5ff`): Pill badge background, tinted blue surface.
+- **Badge Blue Text** (`#0068d6`): Pill badge text, darker blue for readability.
+
+### Shadows & Depth
+- **Border Shadow** (`rgba(0, 0, 0, 0.08) 0px 0px 0px 1px`): The signature — replaces traditional borders.
+- **Subtle Elevation** (`rgba(0, 0, 0, 0.04) 0px 2px 2px`): Minimal lift for cards.
+- **Card Stack** (`rgba(0,0,0,0.08) 0px 0px 0px 1px, rgba(0,0,0,0.04) 0px 2px 2px, rgba(0,0,0,0.04) 0px 8px 8px -8px, #fafafa 0px 0px 0px 1px`): Full multi-layer card shadow.
+- **Ring Border** (`rgb(235, 235, 235) 0px 0px 0px 1px`): Light gray ring-border for tabs and images.
+
+## 3. Typography Rules
+
+### Font Family
+- **Primary**: `Geist`, with fallbacks: `Arial, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol`
+- **Monospace**: `Geist Mono`, with fallbacks: `ui-monospace, SFMono-Regular, Roboto Mono, Menlo, Monaco, Liberation Mono, DejaVu Sans Mono, Courier New`
+- **OpenType Features**: `"liga"` enabled globally on all Geist text; `"tnum"` for tabular numbers on specific captions.
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Geist | 48px (3.00rem) | 600 | 1.00–1.17 (tight) | -2.4px to -2.88px | Maximum compression, billboard impact |
+| Section Heading | Geist | 40px (2.50rem) | 600 | 1.20 (tight) | -2.4px | Feature section titles |
+| Sub-heading Large | Geist | 32px (2.00rem) | 600 | 1.25 (tight) | -1.28px | Card headings, sub-sections |
+| Sub-heading | Geist | 32px (2.00rem) | 400 | 1.50 | -1.28px | Lighter sub-headings |
+| Card Title | Geist | 24px (1.50rem) | 600 | 1.33 | -0.96px | Feature cards |
+| Card Title Light | Geist | 24px (1.50rem) | 500 | 1.33 | -0.96px | Secondary card headings |
+| Body Large | Geist | 20px (1.25rem) | 400 | 1.80 (relaxed) | normal | Introductions, feature descriptions |
+| Body | Geist | 18px (1.13rem) | 400 | 1.56 | normal | Standard reading text |
+| Body Small | Geist | 16px (1.00rem) | 400 | 1.50 | normal | Standard UI text |
+| Body Medium | Geist | 16px (1.00rem) | 500 | 1.50 | normal | Navigation, emphasized text |
+| Body Semibold | Geist | 16px (1.00rem) | 600 | 1.50 | -0.32px | Strong labels, active states |
+| Button / Link | Geist | 14px (0.88rem) | 500 | 1.43 | normal | Buttons, links, captions |
+| Button Small | Geist | 14px (0.88rem) | 400 | 1.00 (tight) | normal | Compact buttons |
+| Caption | Geist | 12px (0.75rem) | 400–500 | 1.33 | normal | Metadata, tags |
+| Mono Body | Geist Mono | 16px (1.00rem) | 400 | 1.50 | normal | Code blocks |
+| Mono Caption | Geist Mono | 13px (0.81rem) | 500 | 1.54 | normal | Code labels |
+| Mono Small | Geist Mono | 12px (0.75rem) | 500 | 1.00 (tight) | normal | `text-transform: uppercase`, technical labels |
+| Micro Badge | Geist | 7px (0.44rem) | 700 | 1.00 (tight) | normal | `text-transform: uppercase`, tiny badges |
+
+### Principles
+- **Compression as identity**: Geist Sans at display sizes uses -2.4px to -2.88px letter-spacing — the most aggressive negative tracking of any major design system. This creates text that feels _minified_, like code optimized for production. The tracking progressively relaxes as size decreases: -1.28px at 32px, -0.96px at 24px, -0.32px at 16px, and normal at 14px.
+- **Ligatures everywhere**: Every Geist text element enables OpenType `"liga"`. Ligatures aren't decorative — they're structural, creating tighter, more efficient glyph combinations.
+- **Three weights, strict roles**: 400 (body/reading), 500 (UI/interactive), 600 (headings/emphasis). No bold (700) except for tiny micro-badges. This narrow weight range creates hierarchy through size and tracking, not weight.
+- **Mono for identity**: Geist Mono in uppercase with `"tnum"` or `"liga"` serves as the "developer console" voice — compact technical labels that connect the marketing site to the product.
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary White (Shadow-bordered)**
+- Background: `#ffffff`
+- Text: `#171717`
+- Padding: 0px 6px (minimal — content-driven width)
+- Radius: 6px (subtly rounded)
+- Shadow: `rgb(235, 235, 235) 0px 0px 0px 1px` (ring-border)
+- Hover: background shifts to `var(--ds-gray-1000)` (dark)
+- Focus: `2px solid var(--ds-focus-color)` outline + `var(--ds-focus-ring)` shadow
+- Use: Standard secondary button
+
+**Primary Dark (Inferred from Geist system)**
+- Background: `#171717`
+- Text: `#ffffff`
+- Padding: 8px 16px
+- Radius: 6px
+- Use: Primary CTA ("Start Deploying", "Get Started")
+
+**Pill Button / Badge**
+- Background: `#ebf5ff` (tinted blue)
+- Text: `#0068d6`
+- Padding: 0px 10px
+- Radius: 9999px (full pill)
+- Font: 12px weight 500
+- Use: Status badges, tags, feature labels
+
+**Large Pill (Navigation)**
+- Background: transparent or `#171717`
+- Radius: 64px–100px
+- Use: Tab navigation, section selectors
+
+### Cards & Containers
+- Background: `#ffffff`
+- Border: via shadow — `rgba(0, 0, 0, 0.08) 0px 0px 0px 1px`
+- Radius: 8px (standard), 12px (featured/image cards)
+- Shadow stack: `rgba(0,0,0,0.08) 0px 0px 0px 1px, rgba(0,0,0,0.04) 0px 2px 2px, #fafafa 0px 0px 0px 1px`
+- Image cards: `1px solid #ebebeb` with 12px top radius
+- Hover: subtle shadow intensification
+
+### Inputs & Forms
+- Radio: standard styling with focus `var(--ds-gray-200)` background
+- Focus shadow: `1px 0 0 0 var(--ds-gray-alpha-600)`
+- Focus outline: `2px solid var(--ds-focus-color)` — consistent blue focus ring
+- Border: via shadow technique, not traditional border
+
+### Navigation
+- Clean horizontal nav on white, sticky
+- Vercel logotype left-aligned, 262x52px
+- Links: Geist 14px weight 500, `#171717` text
+- Active: weight 600 or underline
+- CTA: dark pill buttons ("Start Deploying", "Contact Sales")
+- Mobile: hamburger menu collapse
+- Product dropdowns with multi-level menus
+
+### Image Treatment
+- Product screenshots with `1px solid #ebebeb` border
+- Top-rounded images: `12px 12px 0px 0px` radius
+- Dashboard/code preview screenshots dominate feature sections
+- Soft gradient backgrounds behind hero images (pastel multi-color)
+
+### Distinctive Components
+
+**Workflow Pipeline**
+- Three-step horizontal pipeline: Develop → Preview → Ship
+- Each step has its own accent color: Blue → Pink → Red
+- Connected with lines/arrows
+- The visual metaphor for Vercel's core value proposition
+
+**Trust Bar / Logo Grid**
+- Company logos (Perplexity, ChatGPT, Cursor, etc.) in grayscale
+- Horizontal scroll or grid layout
+- Subtle `#ebebeb` border separation
+
+**Metric Cards**
+- Large number display (e.g., "10x faster")
+- Geist 48px weight 600 for the metric
+- Description below in gray body text
+- Shadow-bordered card container
+
+## 5. Layout Principles
+
+### Spacing System
+- Base unit: 8px
+- Scale: 1px, 2px, 3px, 4px, 5px, 6px, 8px, 10px, 12px, 14px, 16px, 32px, 36px, 40px
+- Notable gap: jumps from 16px to 32px — no 20px or 24px in primary scale
+
+### Grid & Container
+- Max content width: approximately 1200px
+- Hero: centered single-column with generous top padding
+- Feature sections: 2–3 column grids for cards
+- Full-width dividers using `border-bottom: 1px solid #171717`
+- Code/dashboard screenshots as full-width or contained with border
+
+### Whitespace Philosophy
+- **Gallery emptiness**: Massive vertical padding between sections (80px–120px+). The white space IS the design — it communicates that Vercel has nothing to prove and nothing to hide.
+- **Compressed text, expanded space**: The aggressive negative letter-spacing on headlines is counterbalanced by generous surrounding whitespace. The text is dense; the space around it is vast.
+- **Section rhythm**: White sections alternate with white sections — there's no color variation between sections. Separation comes from borders (shadow-borders) and spacing alone.
+
+### Border Radius Scale
+- Micro (2px): Inline code snippets, small spans
+- Subtle (4px): Small containers
+- Standard (6px): Buttons, links, functional elements
+- Comfortable (8px): Cards, list items
+- Image (12px): Featured cards, image containers (top-rounded)
+- Large (64px): Tab navigation pills
+- XL (100px): Large navigation links
+- Full Pill (9999px): Badges, status pills, tags
+- Circle (50%): Menu toggle, avatar containers
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow | Page background, text blocks |
+| Ring (Level 1) | `rgba(0,0,0,0.08) 0px 0px 0px 1px` | Shadow-as-border for most elements |
+| Light Ring (Level 1b) | `rgb(235,235,235) 0px 0px 0px 1px` | Lighter ring for tabs, images |
+| Subtle Card (Level 2) | Ring + `rgba(0,0,0,0.04) 0px 2px 2px` | Standard cards with minimal lift |
+| Full Card (Level 3) | Ring + Subtle + `rgba(0,0,0,0.04) 0px 8px 8px -8px` + inner `#fafafa` ring | Featured cards, highlighted panels |
+| Focus (Accessibility) | `2px solid hsla(212, 100%, 48%, 1)` outline | Keyboard focus on all interactive elements |
+
+**Shadow Philosophy**: Vercel has arguably the most sophisticated shadow system in modern web design. Rather than using shadows for elevation in the traditional Material Design sense, Vercel uses multi-value shadow stacks where each layer has a distinct architectural purpose: one creates the "border" (0px spread, 1px), another adds ambient softness (2px blur), another handles depth at distance (8px blur with negative spread), and an inner ring (`#fafafa`) creates the subtle highlight that makes the card "glow" from within. This layered approach means cards feel built, not floating.
+
+### Decorative Depth
+- Hero gradient: soft, pastel multi-color gradient wash behind hero content (barely visible, atmospheric)
+- Section borders: `1px solid #171717` (full dark line) between major sections
+- No background color variation — depth comes entirely from shadow layering and border contrast
+
+## 7. Do's and Don'ts
+
+### Do
+- Use Geist Sans with aggressive negative letter-spacing at display sizes (-2.4px to -2.88px at 48px)
+- Use shadow-as-border (`0px 0px 0px 1px rgba(0,0,0,0.08)`) instead of traditional CSS borders
+- Enable `"liga"` on all Geist text — ligatures are structural, not optional
+- Use the three-weight system: 400 (body), 500 (UI), 600 (headings)
+- Apply workflow accent colors (Red/Pink/Blue) only in their workflow context
+- Use multi-layer shadow stacks for cards (border + elevation + ambient + inner highlight)
+- Keep the color palette achromatic — grays from `#171717` to `#ffffff` are the system
+- Use `#171717` instead of `#000000` for primary text — the micro-warmth matters
+
+### Don't
+- Don't use positive letter-spacing on Geist Sans — it's always negative or zero
+- Don't use weight 700 (bold) on body text — 600 is the maximum, used only for headings
+- Don't use traditional CSS `border` on cards — use the shadow-border technique
+- Don't introduce warm colors (oranges, yellows, greens) into the UI chrome
+- Don't apply the workflow accent colors (Ship Red, Preview Pink, Develop Blue) decoratively
+- Don't use heavy shadows (> 0.1 opacity) — the shadow system is whisper-level
+- Don't increase body text letter-spacing — Geist is designed to run tight
+- Don't use pill radius (9999px) on primary action buttons — pills are for badges/tags only
+- Don't skip the inner `#fafafa` ring in card shadows — it's the glow that makes the system work
+
+## 8. Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Mobile Small | <400px | Tight single column, minimal padding |
+| Mobile | 400–600px | Standard mobile, stacked layout |
+| Tablet Small | 600–768px | 2-column grids begin |
+| Tablet | 768–1024px | Full card grids, expanded padding |
+| Desktop Small | 1024–1200px | Standard desktop layout |
+| Desktop | 1200–1400px | Full layout, maximum content width |
+| Large Desktop | >1400px | Centered, generous margins |
+
+### Touch Targets
+- Buttons use comfortable padding (8px–16px vertical)
+- Navigation links at 14px with adequate spacing
+- Pill badges have 10px horizontal padding for tap targets
+- Mobile menu toggle uses 50% radius circular button
+
+### Collapsing Strategy
+- Hero: display 48px → scales down, maintains negative tracking proportionally
+- Navigation: horizontal links + CTAs → hamburger menu
+- Feature cards: 3-column → 2-column → single column stacked
+- Code screenshots: maintain aspect ratio, may horizontally scroll
+- Trust bar logos: grid → horizontal scroll
+- Footer: multi-column → stacked single column
+- Section spacing: 80px+ → 48px on mobile
+
+### Image Behavior
+- Dashboard screenshots maintain border treatment at all sizes
+- Hero gradient softens/simplifies on mobile
+- Product screenshots use responsive images with consistent border radius
+- Full-width sections maintain edge-to-edge treatment
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Primary CTA: Vercel Black (`#171717`)
+- Background: Pure White (`#ffffff`)
+- Heading text: Vercel Black (`#171717`)
+- Body text: Gray 600 (`#4d4d4d`)
+- Border (shadow): `rgba(0, 0, 0, 0.08) 0px 0px 0px 1px`
+- Link: Link Blue (`#0072f5`)
+- Focus ring: Focus Blue (`hsla(212, 100%, 48%, 1)`)
+
+### Example Component Prompts
+- "Create a hero section on white background. Headline at 48px Geist weight 600, line-height 1.00, letter-spacing -2.4px, color #171717. Subtitle at 20px Geist weight 400, line-height 1.80, color #4d4d4d. Dark CTA button (#171717, 6px radius, 8px 16px padding) and ghost button (white, shadow-border rgba(0,0,0,0.08) 0px 0px 0px 1px, 6px radius)."
+- "Design a card: white background, no CSS border. Use shadow stack: rgba(0,0,0,0.08) 0px 0px 0px 1px, rgba(0,0,0,0.04) 0px 2px 2px, #fafafa 0px 0px 0px 1px. Radius 8px. Title at 24px Geist weight 600, letter-spacing -0.96px. Body at 16px weight 400, #4d4d4d."
+- "Build a pill badge: #ebf5ff background, #0068d6 text, 9999px radius, 0px 10px padding, 12px Geist weight 500."
+- "Create navigation: white sticky header. Geist 14px weight 500 for links, #171717 text. Dark pill CTA 'Start Deploying' right-aligned. Shadow-border on bottom: rgba(0,0,0,0.08) 0px 0px 0px 1px."
+- "Design a workflow section showing three steps: Develop (text color #0a72ef), Preview (#de1d8d), Ship (#ff5b4f). Each step: 14px Geist Mono uppercase label + 24px Geist weight 600 title + 16px weight 400 description in #4d4d4d."
+
+### Iteration Guide
+1. Always use shadow-as-border instead of CSS border — `0px 0px 0px 1px rgba(0,0,0,0.08)` is the foundation
+2. Letter-spacing scales with font size: -2.4px at 48px, -1.28px at 32px, -0.96px at 24px, normal at 14px
+3. Three weights only: 400 (read), 500 (interact), 600 (announce)
+4. Color is functional, never decorative — workflow colors (Red/Pink/Blue) mark pipeline stages only
+5. The inner `#fafafa` ring in card shadows is what gives Vercel cards their subtle inner glow
+6. Geist Mono uppercase for technical labels, Geist Sans for everything else

--- a/ui/PRODUCT.md
+++ b/ui/PRODUCT.md
@@ -1,0 +1,30 @@
+# Product
+
+## Register
+
+product
+
+## Users
+Karmada dashboard is used by platform engineers, SREs, and cluster administrators operating multi-cluster Kubernetes fleets. They typically work in an operations context, often switching between incident triage, routine inspection, and policy/resource management. Their primary job is to understand control-plane health and quickly act on cluster, policy, and workload changes.
+
+## Product Purpose
+Karmada Dashboard provides a web control plane for Karmada multi-cluster management. It centralizes visibility and operations for control-plane status, member clusters, policies, and resources so operators can make safe, fast decisions without relying only on CLI flows. Success means users can reliably detect status issues, locate affected scopes, and complete common management actions with low cognitive load.
+
+## Brand Personality
+Pragmatic, trustworthy, and precise. The UI tone should feel operationally calm and technically credible, with clear hierarchy and no decorative noise. It should communicate confidence during normal operation and clarity during degraded states.
+
+## Anti-references
+- Consumer-style marketing aesthetics that prioritize decoration over information density.
+- Heavy visual effects (glassmorphism, oversized gradients, ornamental motion) that reduce readability.
+- Inconsistent admin surfaces where each page invents its own interaction model.
+- Ambiguous status presentation that hides failures behind neutral styling.
+
+## Design Principles
+- Operational clarity first: expose the most decision-critical signals early and clearly.
+- Consistency over novelty: shared patterns for tables, filters, status, and actions across pages.
+- Progressive disclosure: summarize first, then reveal detail when users need to drill down.
+- State-complete interfaces: loading, empty, error, and success states are explicit and actionable.
+- International-ready and accessible by default: i18n-ready copy, keyboard-visible focus, and readable contrast.
+
+## Accessibility & Inclusion
+Target WCAG AA contrast for text and controls. Preserve visible focus indicators for keyboard navigation. Keep motion minimal and functional, with no dependency on animation for understanding status. Ensure key operational information is conveyed by text, not color alone, and keep copy translatable for multilingual operators.

--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -30,6 +30,9 @@
   "dependencies": {
     "@ant-design/cssinjs": "^2.1.2",
     "@chatui/core": "^3.8.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@karmada/chatui": "workspace:*",
     "@karmada/i18n-tool": "workspace:*",
     "@karmada/terminal": "workspace:*",
@@ -55,6 +58,7 @@
     "react-helmet-async": "^3.0.0",
     "react-i18next": "^17.0.8",
     "react-router-dom": "^7.14.2",
+    "recharts": "^3.8.1",
     "sockjs-client": "^1.6.1",
     "tailwind-merge": "^3.6.0",
     "yaml": "^2.9.0",

--- a/ui/apps/dashboard/src/components/auth/index.tsx
+++ b/ui/apps/dashboard/src/components/auth/index.tsx
@@ -26,6 +26,7 @@ import { Me, MeResponse } from '@/services/auth.ts';
 import { karmadaClient } from '@/services';
 import { useQuery } from '@tanstack/react-query';
 import { karmadaMemberClusterClient } from "@/services/base.ts";
+import { metricsScraperClient } from "@/services/metrics.ts";
 
 export interface AuthUser {
   name?: string;
@@ -69,6 +70,9 @@ const AuthProvider = ({ children }: { children: ReactNode }) => {
           'Authorization'
         ] = `Bearer ${token}`;
         karmadaMemberClusterClient.defaults.headers.common[
+          'Authorization'
+        ] = `Bearer ${token}`;
+        metricsScraperClient.defaults.headers.common[
           'Authorization'
         ] = `Bearer ${token}`;
         const ret = await Me();

--- a/ui/apps/dashboard/src/components/data-table/index.tsx
+++ b/ui/apps/dashboard/src/components/data-table/index.tsx
@@ -1,0 +1,255 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Empty, Table as AntdTable } from 'antd';
+import type { TableProps } from 'antd';
+import type { AnyObject } from 'antd/es/_util/type';
+import type { KeyboardEvent } from 'react';
+import type { ReactNode } from 'react';
+import { cn } from '@/utils/cn';
+
+type TableColumn<RecordType extends AnyObject> = NonNullable<
+  TableProps<RecordType>['columns']
+>[number];
+
+const MIN_COLUMN_WIDTH = 116;
+const MAX_INFERRED_WIDTH = 360;
+
+function getTitleText(title: TableColumn<AnyObject>['title']): string {
+  if (typeof title === 'string' || typeof title === 'number') {
+    return String(title);
+  }
+  return '';
+}
+
+function getColumnKey(column: TableColumn<AnyObject>): string {
+  const dataIndex = 'dataIndex' in column ? column.dataIndex : undefined;
+  const rawKey = column.key ?? dataIndex;
+  if (Array.isArray(rawKey)) {
+    return rawKey.join('.');
+  }
+  return rawKey ? String(rawKey) : '';
+}
+
+function getDisplayLength(text: string) {
+  return Array.from(text).reduce((total, char) => {
+    return total + (char.charCodeAt(0) > 255 ? 2 : 1);
+  }, 0);
+}
+
+function inferColumnWidth(column: TableColumn<AnyObject>) {
+  if ('width' in column && column.width) {
+    return undefined;
+  }
+
+  const key = getColumnKey(column).toLowerCase();
+  const title = getTitleText(column.title);
+  const titleWidth = getDisplayLength(title) * 8 + 48;
+  let semanticWidth = MIN_COLUMN_WIDTH;
+
+  if (/^(op|action|actions)$/.test(key) || /操作|actions?/i.test(title)) {
+    semanticWidth = 168;
+  } else if (/name|namespace|cluster|workload|service|config|secret|role/.test(key)) {
+    semanticWidth = 180;
+  } else if (/label|annotation|image|message|subject|selector|rule|resource|host|address/.test(key)) {
+    semanticWidth = 260;
+  } else if (/time|date|age|creation/.test(key) || /时间|age/i.test(title)) {
+    semanticWidth = 172;
+  } else if (/status|ready|phase|mode|type|kind/.test(key) || /状态|模式|类型/.test(title)) {
+    semanticWidth = 132;
+  }
+
+  return Math.min(
+    MAX_INFERRED_WIDTH,
+    Math.max(MIN_COLUMN_WIDTH, semanticWidth, titleWidth),
+  );
+}
+
+function getColumnKind(column: TableColumn<AnyObject>) {
+  const key = getColumnKey(column).toLowerCase();
+  const title = getTitleText(column.title);
+
+  if (/^(op|action|actions)$/.test(key) || /操作|actions?/i.test(title)) {
+    return 'action';
+  }
+  if (/name|namespace|cluster|workload|service|config|secret|role/.test(key)) {
+    return 'identity';
+  }
+  if (/status|ready|phase/.test(key) || /状态|ready|phase/i.test(title)) {
+    return 'status';
+  }
+  if (/time|date|age|creation/.test(key) || /时间|age/i.test(title)) {
+    return 'time';
+  }
+  return 'default';
+}
+
+function getPrimitiveCellTitle(value: unknown): string | undefined {
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return String(value);
+  }
+  return undefined;
+}
+
+function getDataByIndex(record: AnyObject, dataIndex: unknown) {
+  if (!dataIndex) return undefined;
+  const path = Array.isArray(dataIndex) ? dataIndex : String(dataIndex).split('.');
+  return path.reduce<unknown>((current, key) => {
+    if (!current || typeof current !== 'object') return undefined;
+    return (current as Record<string, unknown>)[String(key)];
+  }, record);
+}
+
+function enhanceColumns<RecordType extends AnyObject>(
+  columns?: TableProps<RecordType>['columns'],
+): TableProps<RecordType>['columns'] {
+  if (!columns) return columns;
+
+  return columns.map((column) => {
+    const children =
+      'children' in column && column.children
+        ? enhanceColumns(column.children as TableProps<RecordType>['columns'])
+        : undefined;
+    const dataIndex = 'dataIndex' in column ? column.dataIndex : undefined;
+    const inferredMinWidth = inferColumnWidth(column as TableColumn<AnyObject>);
+    const kind = getColumnKind(column as TableColumn<AnyObject>);
+    const className = cn(
+      'karmada-table-column',
+      `karmada-table-column-${kind}`,
+      column.className,
+    );
+
+    return {
+      ...column,
+      ...(children ? { children } : {}),
+      className,
+      ellipsis:
+        column.ellipsis === undefined && kind !== 'action'
+          ? { showTitle: false }
+          : column.ellipsis,
+      minWidth:
+        'minWidth' in column && column.minWidth !== undefined
+          ? column.minWidth
+          : inferredMinWidth,
+      fixed:
+        kind === 'action' && column.fixed === undefined ? 'right' : column.fixed,
+      width:
+        kind === 'action' && !('width' in column && column.width)
+          ? 168
+          : column.width,
+      onCell: (record: RecordType, rowIndex?: number) => {
+        const cellProps = column.onCell?.(record, rowIndex) ?? {};
+        const title = getPrimitiveCellTitle(
+          getDataByIndex(record as AnyObject, dataIndex),
+        );
+        return title && !cellProps.title
+          ? {
+              ...cellProps,
+              title,
+            }
+          : cellProps;
+      },
+    } as TableColumn<RecordType>;
+  });
+}
+
+function emptyText(): ReactNode {
+  return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />;
+}
+
+export default function DataTable<RecordType extends AnyObject = AnyObject>(
+  props: TableProps<RecordType>,
+) {
+  const {
+    className,
+    columns,
+    locale,
+    onRow,
+    pagination,
+    rowClassName,
+    scroll,
+    showSorterTooltip,
+    size,
+    sticky,
+    tableLayout,
+    ...restProps
+  } = props;
+
+  return (
+    <AntdTable<RecordType>
+      className={cn('karmada-data-table', className)}
+      columns={enhanceColumns(columns)}
+      locale={{
+        emptyText: emptyText(),
+        ...locale,
+      }}
+      pagination={
+        pagination === false
+          ? false
+          : {
+              showSizeChanger: true,
+              showQuickJumper: true,
+              position: ['bottomRight'],
+              showTotal: (total, range) => `${range[0]}-${range[1]} / ${total}`,
+              ...pagination,
+            }
+      }
+      onRow={(record, index) => {
+        const rowProps = onRow?.(record, index) ?? {};
+        const rowClickHandler = rowProps.onClick;
+        return {
+          ...rowProps,
+          className: cn('karmada-data-table-row', rowProps.className),
+          tabIndex: rowClickHandler ? (rowProps.tabIndex ?? 0) : rowProps.tabIndex,
+          onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
+            rowProps.onKeyDown?.(event);
+            if (
+              rowClickHandler &&
+              !event.defaultPrevented &&
+              (event.key === 'Enter' || event.key === ' ')
+            ) {
+              event.preventDefault();
+              (rowClickHandler as unknown as (event: KeyboardEvent<HTMLElement>) => void)(
+                event,
+              );
+            }
+          },
+        };
+      }}
+      rowClassName={(record, index, indent) =>
+        cn(
+          typeof rowClassName === 'function'
+            ? rowClassName(record, index, indent)
+            : rowClassName,
+        )
+      }
+      scroll={{
+        x: 'max-content',
+        scrollToFirstRowOnChange: true,
+        ...scroll,
+      }}
+      showSorterTooltip={showSorterTooltip ?? { target: 'sorter-icon' }}
+      size={size ?? 'middle'}
+      sticky={sticky ?? true}
+      tableLayout={tableLayout ?? 'auto'}
+      {...restProps}
+    />
+  );
+}

--- a/ui/apps/dashboard/src/components/icons/index.tsx
+++ b/ui/apps/dashboard/src/components/icons/index.tsx
@@ -77,6 +77,7 @@ import {
   HardDrive,
   Cloud,
   PanelsTopLeft,
+  Activity,
 
 } from 'lucide-react';
 
@@ -127,6 +128,7 @@ export const Icons = {
   storage: HardDrive,
   cloud: Cloud,
   control: SlidersHorizontal,
+  metrics: Activity,
 
   gitHub: ({ ...props }: LucideProps) => (
     <svg

--- a/ui/apps/dashboard/src/components/overview-workbench/index.module.less
+++ b/ui/apps/dashboard/src/components/overview-workbench/index.module.less
@@ -1,0 +1,355 @@
+.workbench {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hero {
+  position: relative;
+  display: flex;
+  min-height: 116px;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  overflow: hidden;
+  padding: 18px 20px;
+  border: 1px solid #d7e0eb;
+  border-radius: var(--karmada-radius-panel);
+  background:
+    linear-gradient(135deg, rgba(31, 111, 235, 0.08), rgba(255, 255, 255, 0) 52%),
+    linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: auto 18px 0 auto;
+  width: 220px;
+  height: 5px;
+  background: linear-gradient(90deg, #1f6feb, rgba(31, 111, 235, 0.12));
+}
+
+.heroText {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+
+.scope {
+  margin-bottom: 8px;
+  color: var(--karmada-color-primary-strong);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.title {
+  margin: 0;
+  color: var(--karmada-color-text);
+  font-size: 24px;
+  font-weight: 680;
+  line-height: 1.18;
+  letter-spacing: 0;
+  text-wrap: balance;
+}
+
+.subtitle {
+  max-width: 720px;
+  margin: 8px 0 0;
+  color: var(--karmada-color-text-secondary);
+  font-size: 13px;
+  font-weight: 450;
+  line-height: 1.6;
+}
+
+.statusPill {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 1px solid #cfd8e4;
+  border-radius: var(--karmada-radius-control);
+  background: #ffffff;
+  color: var(--karmada-color-text);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.statusDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentcolor;
+  box-shadow: 0 0 0 3px rgba(107, 114, 128, 0.12);
+}
+
+.toneSuccess {
+  color: #18794e;
+  border-color: rgba(24, 121, 78, 0.28);
+  background: #f1faf5;
+}
+
+.toneWarning {
+  color: #9a6700;
+  border-color: rgba(183, 121, 31, 0.32);
+  background: #fff8e8;
+}
+
+.toneDanger {
+  color: #b42318;
+  border-color: rgba(194, 65, 12, 0.3);
+  background: #fff3ed;
+}
+
+.toneNeutral {
+  color: #5f6b7a;
+  border-color: #d4dce7;
+  background: #f6f8fb;
+}
+
+.toneInfo {
+  color: var(--karmada-color-primary-strong);
+  border-color: rgba(31, 111, 235, 0.28);
+  background: var(--karmada-color-primary-soft);
+}
+
+.primaryGrid,
+.metricGroups {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(360px, 0.84fr);
+  gap: 12px;
+}
+
+.metricGroups {
+  align-items: stretch;
+}
+
+.metricGroupsSingle {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.metricGroupsSingle .metricGrid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.panel {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--karmada-color-border);
+  border-radius: var(--karmada-radius-panel);
+  background: #ffffff;
+}
+
+.panelHeader {
+  display: flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px 10px;
+  border-bottom: 1px solid #e8edf4;
+  background: #fbfcfe;
+}
+
+.panelTitle {
+  margin: 0;
+  color: var(--karmada-color-text);
+  font-size: 13px;
+  font-weight: 680;
+  line-height: 1.35;
+}
+
+.panelDescription {
+  max-width: 560px;
+  margin: 4px 0 0;
+  color: var(--karmada-color-text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.infoGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  margin: 0;
+}
+
+.infoItem {
+  min-width: 0;
+  padding: 14px;
+  border-right: 1px solid #edf1f6;
+  border-bottom: 1px solid #edf1f6;
+}
+
+.infoItem:nth-child(3n) {
+  border-right: 0;
+}
+
+.infoItem:nth-last-child(-n + 3) {
+  border-bottom: 0;
+}
+
+.itemLabel {
+  display: block;
+  margin: 0;
+  color: var(--karmada-color-text-secondary);
+  font-size: 12px;
+  font-weight: 560;
+  line-height: 1.35;
+}
+
+.itemValue {
+  margin: 7px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--karmada-color-text);
+  font-size: 15px;
+  font-weight: 680;
+  line-height: 1.36;
+}
+
+.itemMeta {
+  margin: 6px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--karmada-color-text-tertiary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.utilizationList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+}
+
+.utilizationItem {
+  min-width: 0;
+  padding: 0 0 12px;
+  border-bottom: 1px solid #edf1f6;
+}
+
+.utilizationItem:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.utilizationHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.utilizationValue {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--karmada-color-text);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 680;
+  line-height: 1.35;
+  text-align: right;
+}
+
+.metricGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+}
+
+.metricItem {
+  min-width: 0;
+  padding: 14px;
+  border-right: 1px solid #edf1f6;
+  border-bottom: 1px solid #edf1f6;
+}
+
+.metricItem:nth-child(2n) {
+  border-right: 0;
+}
+
+.metricItem:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
+.metricValue {
+  overflow-wrap: anywhere;
+  color: var(--karmada-color-text);
+  font-size: 26px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 680;
+  line-height: 1.08;
+}
+
+@media (max-width: 1180px) {
+  .primaryGrid,
+  .metricGroups {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .hero {
+    flex-direction: column;
+    min-height: 0;
+    gap: 14px;
+    padding: 16px;
+  }
+
+  .title {
+    font-size: 21px;
+  }
+
+  .infoGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .metricGroupsSingle .metricGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .infoItem,
+  .infoItem:nth-child(3n),
+  .infoItem:nth-last-child(-n + 3),
+  .metricItem,
+  .metricItem:nth-child(2n),
+  .metricItem:nth-last-child(-n + 2) {
+    border-right: 0;
+    border-bottom: 1px solid #edf1f6;
+  }
+
+  .infoItem:last-child,
+  .metricItem:last-child {
+    border-bottom: 0;
+  }
+}
+
+@media (max-width: 520px) {
+  .workbench {
+    gap: 12px;
+  }
+
+  .panelHeader,
+  .infoItem,
+  .metricItem,
+  .utilizationList {
+    padding-inline: 12px;
+  }
+
+  .metricGrid,
+  .metricGroupsSingle .metricGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .metricValue {
+    font-size: 23px;
+  }
+}

--- a/ui/apps/dashboard/src/components/overview-workbench/index.tsx
+++ b/ui/apps/dashboard/src/components/overview-workbench/index.tsx
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type { ReactNode } from 'react';
+import { Progress } from 'antd';
+import styles from './index.module.less';
+
+type OverviewTone = 'success' | 'warning' | 'danger' | 'neutral' | 'info';
+
+export interface OverviewStatus {
+  label: ReactNode;
+  tone?: OverviewTone;
+}
+
+export interface OverviewInfoItem {
+  key: string;
+  label: ReactNode;
+  value: ReactNode;
+  meta?: ReactNode;
+}
+
+export interface OverviewMetricItem {
+  key: string;
+  label: ReactNode;
+  value: ReactNode;
+  meta?: ReactNode;
+}
+
+export interface OverviewMetricGroup {
+  key: string;
+  title: ReactNode;
+  description?: ReactNode;
+  items: OverviewMetricItem[];
+}
+
+export interface OverviewUtilizationItem {
+  key: string;
+  label: ReactNode;
+  value: ReactNode;
+  percent?: number | null;
+  meta?: ReactNode;
+  tone?: OverviewTone;
+}
+
+export interface OverviewWorkbenchProps {
+  scopeLabel: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  status: OverviewStatus;
+  infoTitle: ReactNode;
+  infoItems: OverviewInfoItem[];
+  utilizationTitle?: ReactNode;
+  utilizationItems?: OverviewUtilizationItem[];
+  metricGroups?: OverviewMetricGroup[];
+}
+
+const toneClassMap: Record<OverviewTone, string> = {
+  success: styles.toneSuccess,
+  warning: styles.toneWarning,
+  danger: styles.toneDanger,
+  neutral: styles.toneNeutral,
+  info: styles.toneInfo,
+};
+
+const progressColorMap: Record<OverviewTone, string> = {
+  success: '#18794e',
+  warning: '#b7791f',
+  danger: '#c2410c',
+  neutral: '#6b7280',
+  info: '#1f6feb',
+};
+
+function normalizePercent(percent?: number | null) {
+  if (percent === undefined || percent === null || Number.isNaN(percent)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, percent));
+}
+
+export default function OverviewWorkbench({
+  scopeLabel,
+  title,
+  subtitle,
+  status,
+  infoTitle,
+  infoItems,
+  utilizationTitle,
+  utilizationItems = [],
+  metricGroups = [],
+}: OverviewWorkbenchProps) {
+  const hasUtilization = utilizationItems.length > 0;
+  const hasMetrics = metricGroups.length > 0;
+  const statusTone = status.tone ?? 'neutral';
+
+  return (
+    <div className={styles.workbench}>
+      <section className={styles.hero}>
+        <div className={styles.heroText}>
+          <div className={styles.scope}>{scopeLabel}</div>
+          <h2 className={styles.title}>{title}</h2>
+          {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
+        </div>
+        <div className={`${styles.statusPill} ${toneClassMap[statusTone]}`}>
+          <span className={styles.statusDot} />
+          <span>{status.label}</span>
+        </div>
+      </section>
+
+      <section className={styles.primaryGrid}>
+        <article className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <h3 className={styles.panelTitle}>{infoTitle}</h3>
+          </div>
+          <dl className={styles.infoGrid}>
+            {infoItems.map((item) => (
+              <div key={item.key} className={styles.infoItem}>
+                <dt className={styles.itemLabel}>{item.label}</dt>
+                <dd className={styles.itemValue}>{item.value}</dd>
+                {item.meta && <dd className={styles.itemMeta}>{item.meta}</dd>}
+              </div>
+            ))}
+          </dl>
+        </article>
+
+        {hasUtilization && (
+          <article className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <h3 className={styles.panelTitle}>{utilizationTitle}</h3>
+            </div>
+            <div className={styles.utilizationList}>
+              {utilizationItems.map((item) => {
+                const tone = item.tone ?? 'info';
+                const percent = normalizePercent(item.percent);
+                return (
+                  <div key={item.key} className={styles.utilizationItem}>
+                    <div className={styles.utilizationHead}>
+                      <span className={styles.itemLabel}>{item.label}</span>
+                      <span className={styles.utilizationValue}>{item.value}</span>
+                    </div>
+                    <Progress
+                      percent={percent}
+                      showInfo={false}
+                      size="small"
+                      strokeColor={progressColorMap[tone]}
+                      railColor="#e8edf4"
+                    />
+                    {item.meta && <div className={styles.itemMeta}>{item.meta}</div>}
+                  </div>
+                );
+              })}
+            </div>
+          </article>
+        )}
+      </section>
+
+      {hasMetrics && (
+        <section
+          className={`${styles.metricGroups} ${
+            metricGroups.length === 1 ? styles.metricGroupsSingle : ''
+          }`}
+        >
+          {metricGroups.map((group) => (
+            <article key={group.key} className={styles.panel}>
+              <div className={styles.panelHeader}>
+                <div>
+                  <h3 className={styles.panelTitle}>{group.title}</h3>
+                  {group.description && (
+                    <p className={styles.panelDescription}>{group.description}</p>
+                  )}
+                </div>
+              </div>
+              <div className={styles.metricGrid}>
+                {group.items.map((item) => (
+                  <div key={item.key} className={styles.metricItem}>
+                    <div className={styles.metricValue}>{item.value}</div>
+                    <div className={styles.itemLabel}>{item.label}</div>
+                    {item.meta && <div className={styles.itemMeta}>{item.meta}</div>}
+                  </div>
+                ))}
+              </div>
+            </article>
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/ui/apps/dashboard/src/layout/index.module.less
+++ b/ui/apps/dashboard/src/layout/index.module.less
@@ -1,0 +1,36 @@
+.shell {
+  position: relative;
+  background: var(--karmada-color-bg);
+}
+
+.shell::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.4), transparent 220px);
+}
+
+.sider {
+  position: relative;
+  z-index: 1;
+  border-right: 1px solid var(--karmada-color-shell-border);
+  box-shadow: 6px 0 18px rgba(20, 27, 43, 0.08);
+}
+
+.mainPane {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  height: 100%;
+  background: transparent;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  flex: 1 1 auto;
+  height: calc(100dvh - 48px);
+  overflow: hidden;
+}

--- a/ui/apps/dashboard/src/layout/sidebar.module.less
+++ b/ui/apps/dashboard/src/layout/sidebar.module.less
@@ -1,0 +1,282 @@
+.sidebar {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), transparent 190px),
+    linear-gradient(90deg, rgba(31, 111, 235, 0.1), transparent 120px),
+    var(--karmada-color-shell);
+  color: var(--karmada-color-shell-text);
+}
+
+.sidebar::before {
+  content: '';
+  position: absolute;
+  inset: 48px 0 auto 0;
+  height: 1px;
+  pointer-events: none;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(225, 231, 240, 0.16) 16%,
+    rgba(225, 231, 240, 0.06) 74%,
+    transparent
+  );
+}
+
+.sidebarBrand {
+  height: 48px;
+  flex: 0 0 48px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--karmada-color-shell-border);
+  box-sizing: border-box;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.sidebarBrandCollapsed {
+  justify-content: center;
+  padding: 0;
+}
+
+.logoFrame {
+  width: 31px;
+  height: 31px;
+  flex: 0 0 31px;
+  border: 1px solid rgba(225, 231, 240, 0.18);
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.98);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.78);
+}
+
+.logo {
+  width: 21px;
+  height: auto;
+  display: block;
+}
+
+.brandText {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  line-height: 1.12;
+}
+
+.brandName {
+  color: #ffffff;
+  font-size: 13.5px;
+  font-weight: 680;
+}
+
+.brandSubline {
+  margin-top: 2px;
+  color: var(--karmada-color-shell-muted);
+  font-size: 11px;
+  font-weight: 560;
+}
+
+.menuScroll {
+  position: relative;
+  min-width: 0;
+  flex: 1;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 12px 0 16px;
+}
+
+.menuScroll::-webkit-scrollbar {
+  width: 10px;
+}
+
+.menuScroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.menuScroll::-webkit-scrollbar-thumb {
+  border: 3px solid transparent;
+  border-radius: 8px;
+  background: rgba(142, 154, 171, 0.38);
+  background-clip: padding-box;
+}
+
+.menuScroll::-webkit-scrollbar-thumb:hover {
+  background: rgba(174, 186, 204, 0.5);
+  background-clip: padding-box;
+}
+
+.memberContext {
+  margin: 12px 12px 0;
+  padding: 8px 9px;
+  overflow: hidden;
+  border: 1px solid rgba(225, 231, 240, 0.12);
+  border-radius: var(--karmada-radius-control);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.03)),
+    rgba(255, 255, 255, 0.03);
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.menu {
+  width: 100% !important;
+  max-width: 100%;
+  overflow-x: hidden;
+  border-inline-end: 0 !important;
+  background: transparent !important;
+
+  :global(.ant-menu-submenu-title),
+  :global(.ant-menu-item) {
+    position: relative;
+    display: flex;
+    align-items: center;
+    color: var(--karmada-color-shell-text);
+    font-size: 13px;
+    font-weight: 560;
+    letter-spacing: 0;
+    overflow: hidden;
+    box-sizing: border-box;
+  }
+
+  :global(.ant-menu-title-content) {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  :global(.ant-menu-sub.ant-menu-inline) {
+    max-width: calc(100% - 28px);
+    margin: 3px 10px 8px 18px;
+    padding: 4px 0 5px 7px;
+    overflow-x: hidden;
+    border-left: 1px solid rgba(225, 231, 240, 0.1);
+    border-radius: var(--karmada-radius-control);
+    background: rgba(7, 11, 18, 0.22) !important;
+  }
+
+  :global(.ant-menu-sub.ant-menu-inline .ant-menu-item) {
+    margin-inline: 0 !important;
+    width: calc(100% - 4px) !important;
+    height: 32px;
+    margin-block: 1px !important;
+    padding-inline-end: 10px;
+    box-sizing: border-box;
+    color: #aeb9c8;
+    font-size: 12.5px;
+  }
+
+  :global(.ant-menu-submenu-title::after),
+  :global(.ant-menu-item::after) {
+    display: none;
+  }
+
+  :global(.ant-menu-submenu-title:hover),
+  :global(.ant-menu-item:hover) {
+    background: rgba(225, 231, 240, 0.085) !important;
+    color: #ffffff !important;
+  }
+
+  :global(.ant-menu-submenu-title:active),
+  :global(.ant-menu-item:active) {
+    transform: translateY(1px);
+  }
+
+  :global(.ant-menu-submenu-open > .ant-menu-submenu-title) {
+    background: rgba(225, 231, 240, 0.045) !important;
+    color: #ffffff !important;
+  }
+
+  :global(.ant-menu-item-selected) {
+    background:
+      linear-gradient(90deg, rgba(31, 111, 235, 0.28), rgba(31, 111, 235, 0.11)),
+      rgba(31, 111, 235, 0.14) !important;
+    color: #ffffff !important;
+    border: 1px solid rgba(97, 151, 245, 0.28);
+    box-shadow:
+      inset 3px 0 0 #6ea4ff,
+      0 8px 18px rgba(7, 11, 18, 0.18);
+  }
+
+  :global(.ant-menu-item-icon) {
+    flex: 0 0 auto;
+    color: var(--karmada-color-shell-muted);
+    opacity: 0.9;
+    transition:
+      color 0.2s ease,
+      opacity 0.2s ease,
+      transform 0.2s ease;
+  }
+
+  :global(.ant-menu-submenu-title:hover .ant-menu-item-icon),
+  :global(.ant-menu-item:hover .ant-menu-item-icon) {
+    color: #c9d5e6;
+    opacity: 1;
+    transform: translateX(1px);
+  }
+
+  :global(.ant-menu-item-selected .ant-menu-item-icon) {
+    color: #9fc4ff;
+    opacity: 1;
+  }
+
+  :global(.ant-menu-submenu-arrow) {
+    color: var(--karmada-color-shell-muted);
+    inset-inline-end: 14px;
+  }
+
+  :global(.ant-menu-submenu-selected) > :global(.ant-menu-submenu-title) {
+    color: #ffffff !important;
+  }
+
+  :global(.ant-menu-inline-collapsed) {
+    width: 100% !important;
+  }
+
+  :global(.ant-menu-inline-collapsed > .ant-menu-item),
+  :global(.ant-menu-inline-collapsed > .ant-menu-submenu > .ant-menu-submenu-title) {
+    width: 44px !important;
+    height: 40px !important;
+    margin: 4px auto !important;
+    padding-inline: 0 !important;
+    justify-content: center;
+  }
+
+  :global(.ant-menu-inline-collapsed .ant-menu-item-icon) {
+    margin-inline-end: 0 !important;
+    transform: none !important;
+  }
+}
+
+.versionLink {
+  position: relative;
+  flex: 0 0 46px;
+  margin: 0 10px 10px;
+  width: auto !important;
+  border: 1px solid rgba(225, 231, 240, 0.1) !important;
+  border-radius: var(--karmada-radius-control);
+  background: rgba(7, 11, 18, 0.42) !important;
+  color: var(--karmada-color-shell-muted) !important;
+  font-variant-numeric: tabular-nums;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+
+  &:hover {
+    border-color: rgba(225, 231, 240, 0.18) !important;
+    background: rgba(32, 38, 50, 0.72) !important;
+    color: #ffffff !important;
+  }
+}
+
+.versionLabel {
+  color: var(--karmada-color-shell-muted);
+}
+
+.versionValue {
+  color: var(--karmada-color-shell-text);
+}

--- a/ui/apps/dashboard/src/pages/metrics/charts/MetricAreaChart.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/charts/MetricAreaChart.tsx
@@ -1,0 +1,125 @@
+import { useId } from 'react';
+import { theme } from 'antd';
+import { Area, AreaChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+
+import type { MetricChartProps } from './index';
+
+const DEFAULT_HEIGHT = 320;
+const HEADER_HEIGHT = 40;
+
+function formatNumber(value: number, fractionDigits = 3) {
+  if (!Number.isFinite(value)) return '0';
+  return value.toLocaleString(undefined, { maximumFractionDigits: fractionDigits });
+}
+
+function formatTimestamp(value: string) {
+  return new Date(value).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function getLatestValue(data: MetricChartProps['data']) {
+  for (let index = data.length - 1; index >= 0; index -= 1) {
+    const point = data[index];
+    if (typeof point?.value === 'number' && Number.isFinite(point.value)) {
+      return point.value;
+    }
+  }
+  return undefined;
+}
+
+const MetricAreaChart = ({
+  data,
+  title,
+  color,
+  valueFormatter = (value) => formatNumber(value),
+  axisFormatter = (value) => formatNumber(value, 1),
+  width,
+  height = DEFAULT_HEIGHT,
+}: MetricChartProps) => {
+  const { token } = theme.useToken();
+  const gradientId = useId().replace(/:/g, '');
+  const latestValue = getLatestValue(data);
+  const chartHeight = Math.max(height - HEADER_HEIGHT, 180);
+
+  return (
+    <div className="flex flex-col gap-3" style={{ width }}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
+          <span className="text-sm font-medium" style={{ color: token.colorTextHeading }}>
+            {title}
+          </span>
+        </div>
+        <span className="text-sm font-medium" style={{ color: token.colorText }}>
+          {typeof latestValue === 'number' ? valueFormatter(latestValue) : '--'}
+        </span>
+      </div>
+
+      <div
+        className="w-full min-w-0 overflow-hidden rounded-md px-1 pt-2"
+        style={{ backgroundColor: token.colorFillQuaternary }}
+      >
+        {data.length === 0 ? (
+          <div
+            className="flex items-center justify-center text-sm"
+            style={{ height: chartHeight, color: token.colorTextTertiary }}
+          >
+            No data available
+          </div>
+        ) : (
+          <AreaChart width={Math.max(width - 8, 0)} height={chartHeight} data={data} margin={{ left: 4, right: 4, top: 6, bottom: 2 }}>
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={color} stopOpacity={0.2} />
+                <stop offset="95%" stopColor={color} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid vertical={false} strokeDasharray="2 6" stroke={token.colorBorderSecondary} />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatTimestamp}
+              minTickGap={28}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <YAxis
+              width={54}
+              tickFormatter={axisFormatter}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <Tooltip
+              cursor={{ stroke: token.colorBorder, strokeDasharray: '4 4' }}
+              contentStyle={{
+                borderRadius: 8,
+                border: `1px solid ${token.colorBorderSecondary}`,
+                boxShadow: token.boxShadowSecondary,
+                background: token.colorBgElevated,
+              }}
+              labelStyle={{ color: token.colorTextSecondary, fontSize: 12 }}
+              labelFormatter={(timestamp) => new Date(timestamp as string).toLocaleString()}
+              formatter={(tooltipValue) => [valueFormatter(Number(tooltipValue)), title]}
+            />
+            <Area
+              type="monotoneX"
+              dataKey="value"
+              stroke={color}
+              fill={`url(#${gradientId})`}
+              fillOpacity={1}
+              strokeWidth={2}
+              connectNulls
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MetricAreaChart;

--- a/ui/apps/dashboard/src/pages/metrics/charts/MetricBarChart.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/charts/MetricBarChart.tsx
@@ -1,0 +1,108 @@
+import { theme } from 'antd';
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+
+import type { MetricChartProps } from './index';
+
+const DEFAULT_HEIGHT = 320;
+const HEADER_HEIGHT = 40;
+
+function formatNumber(value: number, fractionDigits = 3) {
+  if (!Number.isFinite(value)) return '0';
+  return value.toLocaleString(undefined, { maximumFractionDigits: fractionDigits });
+}
+
+function formatTimestamp(value: string) {
+  return new Date(value).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function getLatestValue(data: MetricChartProps['data']) {
+  for (let index = data.length - 1; index >= 0; index -= 1) {
+    const point = data[index];
+    if (typeof point?.value === 'number' && Number.isFinite(point.value)) {
+      return point.value;
+    }
+  }
+  return undefined;
+}
+
+const MetricBarChart = ({
+  data,
+  title,
+  color,
+  valueFormatter = (value) => formatNumber(value),
+  axisFormatter = (value) => formatNumber(value, 1),
+  width,
+  height = DEFAULT_HEIGHT,
+}: MetricChartProps) => {
+  const { token } = theme.useToken();
+  const latestValue = getLatestValue(data);
+  const chartHeight = Math.max(height - HEADER_HEIGHT, 180);
+
+  return (
+    <div className="flex flex-col gap-3" style={{ width }}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
+          <span className="text-sm font-medium" style={{ color: token.colorTextHeading }}>
+            {title}
+          </span>
+        </div>
+        <span className="text-sm font-medium" style={{ color: token.colorText }}>
+          {typeof latestValue === 'number' ? valueFormatter(latestValue) : '--'}
+        </span>
+      </div>
+
+      <div
+        className="w-full min-w-0 overflow-hidden rounded-md px-1 pt-2"
+        style={{ backgroundColor: token.colorFillQuaternary }}
+      >
+        {data.length === 0 ? (
+          <div
+            className="flex items-center justify-center text-sm"
+            style={{ height: chartHeight, color: token.colorTextTertiary }}
+          >
+            No data available
+          </div>
+        ) : (
+          <BarChart width={Math.max(width - 8, 0)} height={chartHeight} data={data} margin={{ left: 4, right: 4, top: 6, bottom: 2 }}>
+            <CartesianGrid vertical={false} strokeDasharray="2 6" stroke={token.colorBorderSecondary} />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatTimestamp}
+              minTickGap={28}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <YAxis
+              width={54}
+              tickFormatter={axisFormatter}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <Tooltip
+              cursor={{ fill: token.colorFillQuaternary }}
+              contentStyle={{
+                borderRadius: 8,
+                border: `1px solid ${token.colorBorderSecondary}`,
+                boxShadow: token.boxShadowSecondary,
+                background: token.colorBgElevated,
+              }}
+              labelStyle={{ color: token.colorTextSecondary, fontSize: 12 }}
+              labelFormatter={(timestamp) => new Date(timestamp as string).toLocaleString()}
+              formatter={(tooltipValue) => [valueFormatter(Number(tooltipValue)), title]}
+            />
+            <Bar dataKey="value" fill={color} fillOpacity={0.8} radius={[2, 2, 0, 0]} isAnimationActive={false} />
+          </BarChart>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MetricBarChart;

--- a/ui/apps/dashboard/src/pages/metrics/charts/MetricGaugeChart.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/charts/MetricGaugeChart.tsx
@@ -1,0 +1,104 @@
+import { useId, useMemo } from 'react';
+import { theme } from 'antd';
+
+import type { MetricGaugeChartProps } from './index';
+
+const DEFAULT_HEIGHT = 320;
+const HEADER_HEIGHT = 44;
+
+function formatNumber(value: number, fractionDigits = 2) {
+  if (!Number.isFinite(value)) return '0';
+  return value.toLocaleString(undefined, { maximumFractionDigits: fractionDigits });
+}
+
+const MetricGaugeChart = ({
+  title,
+  color,
+  valueFormatter = (value) => formatNumber(value),
+  width,
+  height = DEFAULT_HEIGHT,
+  min = 0,
+  max = 100,
+  currentValue,
+}: MetricGaugeChartProps) => {
+  const { token } = theme.useToken();
+  const gradientId = useId().replace(/:/g, '');
+  const safeMax = max <= min ? min + 1 : max;
+  const progress = Math.min(Math.max((currentValue - min) / (safeMax - min), 0), 1);
+  const chartWidth = Math.max(width - 24, 160);
+  const chartHeight = Math.max(height - HEADER_HEIGHT, 180);
+
+  const { backgroundArc, valueArc, cx, cy, radius, strokeWidth } = useMemo(() => {
+    const localCx = chartWidth / 2;
+    const localCy = chartHeight * 0.72;
+    const localRadius = Math.min(chartWidth * 0.34, chartHeight * 0.5);
+    const angle = progress * 180;
+    const endAngle = Math.PI - (angle * Math.PI) / 180;
+    const arcX2 = localCx + localRadius * Math.cos(endAngle);
+    const arcY2 = localCy - localRadius * Math.sin(endAngle);
+
+    return {
+      backgroundArc: `M ${localCx - localRadius} ${localCy} A ${localRadius} ${localRadius} 0 0 1 ${localCx + localRadius} ${localCy}`,
+      valueArc:
+        angle > 0
+          ? `M ${localCx - localRadius} ${localCy} A ${localRadius} ${localRadius} 0 0 1 ${arcX2} ${arcY2}`
+          : undefined,
+      cx: localCx,
+      cy: localCy,
+      radius: localRadius,
+      strokeWidth: Math.max(12, Math.min(18, chartWidth * 0.04)),
+    };
+  }, [chartHeight, chartWidth, progress]);
+
+  return (
+    <div className="flex flex-col gap-3" style={{ width }}>
+      <div className="flex items-center gap-2">
+        <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
+        <span className="text-sm font-medium" style={{ color: token.colorTextHeading }}>
+          {title}
+        </span>
+      </div>
+
+      <div className="overflow-hidden rounded-md px-3 py-4" style={{ backgroundColor: token.colorFillQuaternary }}>
+        <svg width={chartWidth} height={chartHeight} viewBox={`0 0 ${chartWidth} ${chartHeight}`} role="img" aria-label={title}>
+          <defs>
+            <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stopColor={token.colorError} />
+              <stop offset="55%" stopColor={token.colorWarning} />
+              <stop offset="100%" stopColor={color} />
+            </linearGradient>
+          </defs>
+
+          <path
+            d={backgroundArc}
+            fill="none"
+            stroke={token.colorBorderSecondary}
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+          />
+          {valueArc ? (
+            <path
+              d={valueArc}
+              fill="none"
+              stroke={`url(#${gradientId})`}
+              strokeWidth={strokeWidth}
+              strokeLinecap="round"
+            />
+          ) : null}
+
+          <text x={cx} y={cy + 10} textAnchor="middle" fontSize="28" fontWeight="600" fill={token.colorTextHeading}>
+            {valueFormatter(currentValue)}
+          </text>
+          <text x={cx - radius} y={cy + 30} textAnchor="start" fontSize="12" fill={token.colorTextSecondary}>
+            {valueFormatter(min)}
+          </text>
+          <text x={cx + radius} y={cy + 30} textAnchor="end" fontSize="12" fill={token.colorTextSecondary}>
+            {valueFormatter(safeMax)}
+          </text>
+        </svg>
+      </div>
+    </div>
+  );
+};
+
+export default MetricGaugeChart;

--- a/ui/apps/dashboard/src/pages/metrics/charts/MetricLineChart.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/charts/MetricLineChart.tsx
@@ -1,0 +1,117 @@
+import { theme } from 'antd';
+import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis } from 'recharts';
+
+import type { MetricChartProps } from './index';
+
+const DEFAULT_HEIGHT = 320;
+const HEADER_HEIGHT = 40;
+
+function formatNumber(value: number, fractionDigits = 3) {
+  if (!Number.isFinite(value)) return '0';
+  return value.toLocaleString(undefined, { maximumFractionDigits: fractionDigits });
+}
+
+function formatTimestamp(value: string) {
+  return new Date(value).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function getLatestValue(data: MetricChartProps['data']) {
+  for (let index = data.length - 1; index >= 0; index -= 1) {
+    const point = data[index];
+    if (typeof point?.value === 'number' && Number.isFinite(point.value)) {
+      return point.value;
+    }
+  }
+  return undefined;
+}
+
+const MetricLineChart = ({
+  data,
+  title,
+  color,
+  valueFormatter = (value) => formatNumber(value),
+  axisFormatter = (value) => formatNumber(value, 1),
+  width,
+  height = DEFAULT_HEIGHT,
+}: MetricChartProps) => {
+  const { token } = theme.useToken();
+  const latestValue = getLatestValue(data);
+  const chartHeight = Math.max(height - HEADER_HEIGHT, 180);
+
+  return (
+    <div className="flex flex-col gap-3" style={{ width }}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
+          <span className="text-sm font-medium" style={{ color: token.colorTextHeading }}>
+            {title}
+          </span>
+        </div>
+        <span className="text-sm font-medium" style={{ color: token.colorText }}>
+          {typeof latestValue === 'number' ? valueFormatter(latestValue) : '--'}
+        </span>
+      </div>
+
+      <div
+        className="w-full min-w-0 overflow-hidden rounded-md px-1 pt-2"
+        style={{ backgroundColor: token.colorFillQuaternary }}
+      >
+        {data.length === 0 ? (
+          <div
+            className="flex items-center justify-center text-sm"
+            style={{ height: chartHeight, color: token.colorTextTertiary }}
+          >
+            No data available
+          </div>
+        ) : (
+          <LineChart width={Math.max(width - 8, 0)} height={chartHeight} data={data} margin={{ left: 4, right: 4, top: 6, bottom: 2 }}>
+            <CartesianGrid vertical={false} strokeDasharray="2 6" stroke={token.colorBorderSecondary} />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatTimestamp}
+              minTickGap={28}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <YAxis
+              width={54}
+              tickFormatter={axisFormatter}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <Tooltip
+              cursor={{ stroke: token.colorBorder, strokeDasharray: '4 4' }}
+              contentStyle={{
+                borderRadius: 8,
+                border: `1px solid ${token.colorBorderSecondary}`,
+                boxShadow: token.boxShadowSecondary,
+                background: token.colorBgElevated,
+              }}
+              labelStyle={{ color: token.colorTextSecondary, fontSize: 12 }}
+              labelFormatter={(timestamp) => new Date(timestamp as string).toLocaleString()}
+              formatter={(tooltipValue) => [valueFormatter(Number(tooltipValue)), title]}
+            />
+            <Line
+              type="monotoneX"
+              dataKey="value"
+              stroke={color}
+              dot={false}
+              activeDot={{ r: 3, fill: color, stroke: token.colorBgContainer, strokeWidth: 1 }}
+              strokeWidth={2}
+              connectNulls
+              isAnimationActive={false}
+            />
+          </LineChart>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MetricLineChart;

--- a/ui/apps/dashboard/src/pages/metrics/charts/index.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/charts/index.tsx
@@ -1,0 +1,68 @@
+import MetricAreaChart from './MetricAreaChart';
+import MetricBarChart from './MetricBarChart';
+import MetricGaugeChart from './MetricGaugeChart';
+import MetricLineChart from './MetricLineChart';
+
+export interface MetricChartProps {
+  data: Array<{ timestamp: string; value: number }>;
+  title: string;
+  color: string;
+  valueFormatter?: (value: number) => string;
+  axisFormatter?: (value: number) => string;
+  width: number;
+  height?: number;
+}
+
+export interface MetricGaugeChartProps extends MetricChartProps {
+  min?: number;
+  max?: number;
+  currentValue: number;
+}
+
+export type ChartType = 'line' | 'area' | 'bar' | 'gauge';
+
+export interface ChartFactoryProps extends MetricChartProps {
+  chartType: ChartType;
+  min?: number;
+  max?: number;
+  currentValue?: number;
+}
+
+function getLatestMetricValue(data: MetricChartProps['data']) {
+  for (let index = data.length - 1; index >= 0; index -= 1) {
+    const point = data[index];
+    if (typeof point?.value === 'number' && Number.isFinite(point.value)) {
+      return point.value;
+    }
+  }
+  return undefined;
+}
+
+export const ChartFactory = ({ chartType, currentValue, min, max, ...props }: ChartFactoryProps) => {
+  switch (chartType) {
+    case 'line':
+      return <MetricLineChart {...props} />;
+    case 'area':
+      return <MetricAreaChart {...props} />;
+    case 'bar':
+      return <MetricBarChart {...props} />;
+    case 'gauge':
+      return (
+        <MetricGaugeChart
+          {...props}
+          min={min}
+          max={max}
+          currentValue={currentValue ?? getLatestMetricValue(props.data) ?? 0}
+        />
+      );
+    default:
+      return null;
+  }
+};
+
+export { default as MetricAreaChart } from './MetricAreaChart';
+export { default as MetricBarChart } from './MetricBarChart';
+export { default as MetricGaugeChart } from './MetricGaugeChart';
+export { default as MetricLineChart } from './MetricLineChart';
+
+export default ChartFactory;

--- a/ui/apps/dashboard/src/pages/metrics/components/DashboardToolbar.module.less
+++ b/ui/apps/dashboard/src/pages/metrics/components/DashboardToolbar.module.less
@@ -1,0 +1,49 @@
+.toolbar {
+  justify-content: flex-end;
+}
+
+.toolbar :global(.ant-btn) {
+  font-weight: 650;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease;
+}
+
+.toolbar :global(.ant-btn:hover) {
+  transform: translateY(-1px);
+}
+
+.toolbar :global(.ant-btn:active) {
+  transform: translateY(0) scale(0.98);
+}
+
+.secondaryButton {
+  border-color: rgba(23, 109, 99, 0.16) !important;
+  color: #176d63 !important;
+  background: rgba(255, 255, 255, 0.72) !important;
+  box-shadow: 0 8px 18px rgba(23, 109, 99, 0.08);
+}
+
+.secondaryButton:hover {
+  border-color: rgba(23, 109, 99, 0.34) !important;
+  box-shadow: 0 12px 24px rgba(23, 109, 99, 0.12);
+}
+
+.primaryButton {
+  border-color: #176d63 !important;
+  background: #176d63 !important;
+  box-shadow: 0 10px 24px rgba(23, 109, 99, 0.22);
+}
+
+.primaryButton:hover {
+  border-color: #11564f !important;
+  background: #11564f !important;
+  box-shadow: 0 14px 30px rgba(23, 109, 99, 0.26);
+}
+
+.dangerButton {
+  background: rgba(255, 255, 255, 0.72) !important;
+  box-shadow: 0 8px 18px rgba(151, 65, 53, 0.08);
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/DashboardToolbar.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/components/DashboardToolbar.tsx
@@ -1,0 +1,97 @@
+import { Button, Popconfirm, Space, Tooltip } from 'antd';
+import {
+  Check,
+  Compass,
+  Copy,
+  Pencil,
+  Plus,
+  RotateCcw,
+} from 'lucide-react';
+
+import styles from './DashboardToolbar.module.less';
+
+interface DashboardToolbarProps {
+  editMode: boolean;
+  hasCustomConfig: boolean;
+  onToggleEdit: () => void;
+  onAddPanel: () => void;
+  onReset: () => void;
+  onExplore?: () => void;
+  onCopy?: () => void;
+  exporting?: boolean;
+}
+
+export default function DashboardToolbar({
+  editMode,
+  hasCustomConfig,
+  onToggleEdit,
+  onAddPanel,
+  onReset,
+  onExplore,
+  onCopy,
+  exporting,
+}: DashboardToolbarProps) {
+  return (
+    <Space size="small" className={styles.toolbar} wrap>
+      <Tooltip title="Explore metrics with DSL query">
+        <Button
+          size="middle"
+          className={styles.secondaryButton}
+          icon={<Compass size={16} />}
+          onClick={onExplore}
+        />
+      </Tooltip>
+      {editMode && (
+        <>
+          <Tooltip title="Add panel">
+            <Button
+              type="primary"
+              size="middle"
+              className={styles.primaryButton}
+              icon={<Plus size={16} />}
+              onClick={onAddPanel}
+            />
+          </Tooltip>
+          {hasCustomConfig && (
+            <Popconfirm
+              title="Reset to default?"
+              description="This will remove all customizations and show all metrics."
+              onConfirm={onReset}
+              okText="Reset"
+              cancelText="Cancel"
+            >
+              <Tooltip title="Reset to default">
+                <Button
+                  size="middle"
+                  className={styles.dangerButton}
+                  icon={<RotateCcw size={16} />}
+                  danger
+                />
+              </Tooltip>
+            </Popconfirm>
+          )}
+        </>
+      )}
+      {onCopy && (
+        <Tooltip title="Copy current component metrics JSON">
+          <Button
+            size="middle"
+            className={styles.secondaryButton}
+            icon={<Copy size={16} />}
+            loading={exporting}
+            onClick={onCopy}
+          />
+        </Tooltip>
+      )}
+      <Tooltip title={editMode ? 'Done editing' : 'Customize dashboard'}>
+        <Button
+          size="middle"
+          className={editMode ? styles.primaryButton : styles.secondaryButton}
+          type={editMode ? 'primary' : 'default'}
+          icon={editMode ? <Check size={16} /> : <Pencil size={16} />}
+          onClick={onToggleEdit}
+        />
+      </Tooltip>
+    </Space>
+  );
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/DragPanel.module.less
+++ b/ui/apps/dashboard/src/pages/metrics/components/DragPanel.module.less
@@ -1,0 +1,43 @@
+.dragPanel {
+  position: relative;
+}
+
+.withHandle :global(.ant-card-head-title) {
+  padding-left: 34px;
+}
+
+.dragHandle {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 20;
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(35, 48, 44, 0.1);
+  border-radius: 9px;
+  color: rgba(23, 33, 31, 0.54);
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 8px 18px rgba(45, 58, 55, 0.12);
+  cursor: grab;
+  backdrop-filter: blur(10px);
+  transition:
+    transform 160ms ease,
+    color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.dragHandle:hover {
+  border-color: rgba(23, 109, 99, 0.28);
+  color: #176d63;
+  box-shadow: 0 12px 24px rgba(23, 109, 99, 0.16);
+  transform: translateY(-1px);
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+  transform: translateY(0) scale(0.97);
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/DragPanel.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/components/DragPanel.tsx
@@ -1,0 +1,47 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical } from 'lucide-react';
+import type { CSSProperties, ReactNode } from 'react';
+
+import { cn } from '@/utils/cn';
+import styles from './DragPanel.module.less';
+
+interface DragPanelProps {
+  id: string;
+  children: ReactNode;
+  disabled?: boolean;
+}
+
+export default function DragPanel({ id, children, disabled }: DragPanelProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, disabled });
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    position: 'relative',
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(styles.dragPanel, !disabled && styles.withHandle)}
+      style={style}
+      {...attributes}
+    >
+      {!disabled && (
+        <div {...listeners} className={styles.dragHandle}>
+          <GripVertical size={14} />
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/LazyChart.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/components/LazyChart.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Skeleton, Spin } from 'antd';
+
+interface LazyChartProps {
+  children: ReactNode;
+  height?: number;
+  /** Whether data is still loading */
+  loading?: boolean;
+  /** Extra margin around viewport to pre-render (default 200px) */
+  rootMargin?: string;
+}
+
+/**
+ * LazyChart only renders its children (expensive chart SVGs) when the container
+ * enters the viewport. Once rendered, it stays rendered to avoid flicker on
+ * scroll back. Uses IntersectionObserver with rootMargin for pre-loading.
+ * Shows independent loading skeleton when data is being fetched.
+ */
+export default function LazyChart({ children, height = 252, loading = false, rootMargin = '200px' }: LazyChartProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [hasBeenVisible, setHasBeenVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || hasBeenVisible) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setHasBeenVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasBeenVisible, rootMargin]);
+
+  const placeholder = (
+    <div style={{ height, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      {loading ? (
+        <Spin tip="Loading..." size="small">
+          <div style={{ width: '100%', height: height - 32, padding: 16 }}>
+            <Skeleton active paragraph={{ rows: 4 }} title={false} />
+          </div>
+        </Spin>
+      ) : (
+        <Skeleton.Node active style={{ width: '100%', height: height - 16 }}>
+          <div style={{ width: 48, height: 48 }} />
+        </Skeleton.Node>
+      )}
+    </div>
+  );
+
+  return (
+    <div ref={ref} style={{ minHeight: height, contentVisibility: 'auto', containIntrinsicSize: `auto ${height}px` }}>
+      {hasBeenVisible && !loading ? children : placeholder}
+    </div>
+  );
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/MetricExplorer.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/components/MetricExplorer.tsx
@@ -1,0 +1,403 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Card,
+  Drawer,
+  Empty,
+  Input,
+  Select,
+  Spin,
+  Tag,
+  Typography,
+  theme,
+} from 'antd';
+import { useQuery } from '@tanstack/react-query';
+import { Area, AreaChart, CartesianGrid, Line, LineChart, Bar, BarChart, Tooltip, XAxis, YAxis } from 'recharts';
+import { Plus, X } from 'lucide-react';
+
+import {
+  ExploreMetric,
+  KarmadaComponentKey,
+  LabelFilter,
+  MetricCatalogItem,
+} from '@/services/metrics';
+import type { AggregationType, ChartType, PanelConfig } from '../dashboard-config';
+import { generatePanelId } from '../dashboard-config';
+
+const { Text } = Typography;
+
+interface MetricExplorerProps {
+  open: boolean;
+  onClose: () => void;
+  onAddToDashboard: (panel: PanelConfig) => void;
+  catalog: MetricCatalogItem[];
+  component: KarmadaComponentKey;
+  pod: string;
+}
+
+const aggregationOptions = [
+  { value: 'sum', label: 'Sum — total across all series' },
+  { value: 'avg', label: 'Avg — average across series' },
+  { value: 'max', label: 'Max — maximum value' },
+  { value: 'min', label: 'Min — minimum value' },
+  { value: 'rate', label: 'Rate — per-second rate of change' },
+];
+
+const chartTypeOptions: { value: ChartType; label: string }[] = [
+  { value: 'line', label: '📈 Line' },
+  { value: 'area', label: '📊 Area' },
+  { value: 'bar', label: '📉 Bar' },
+  { value: 'gauge', label: '🎯 Gauge' },
+];
+
+function formatTimestamp(value: string) {
+  return new Date(value).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+export default function MetricExplorer({
+  open,
+  onClose,
+  onAddToDashboard,
+  catalog,
+  component,
+  pod,
+}: MetricExplorerProps) {
+  const { token } = theme.useToken();
+  const [selectedMetric, setSelectedMetric] = useState<string>('');
+  const [aggregation, setAggregation] = useState<AggregationType>('sum');
+  const [chartType, setChartType] = useState<ChartType>('line');
+  const [labelFilters, setLabelFilters] = useState<LabelFilter[]>([]);
+  const [panelTitle, setPanelTitle] = useState('');
+
+  // Reset when drawer closes
+  useEffect(() => {
+    if (!open) {
+      setSelectedMetric('');
+      setAggregation('sum');
+      setChartType('line');
+      setLabelFilters([]);
+      setPanelTitle('');
+    }
+  }, [open]);
+
+  // Update chart type and title when metric changes
+  useEffect(() => {
+    if (selectedMetric) {
+      const item = catalog.find((m) => m.name === selectedMetric);
+      if (item) {
+        setChartType(item.suggestedChart);
+        setPanelTitle(item.name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()));
+      }
+    }
+  }, [selectedMetric, catalog]);
+
+  const {
+    data: exploreData,
+    isLoading: exploring,
+    error: exploreError,
+  } = useQuery({
+    queryKey: ['metricExplore', component, selectedMetric, aggregation, JSON.stringify(labelFilters), pod],
+    queryFn: () =>
+      ExploreMetric(component, {
+        metric: selectedMetric,
+        aggregation,
+        labels: labelFilters.length > 0 ? labelFilters : undefined,
+        window: '15m',
+        pod,
+      }),
+    enabled: open && !!selectedMetric,
+    refetchInterval: 10_000,
+  });
+
+  const availableLabels = useMemo(
+    () => exploreData?.availableLabels ?? {},
+    [exploreData?.availableLabels],
+  );
+
+  const addLabelFilter = useCallback(() => {
+    const keys = Object.keys(availableLabels);
+    if (keys.length === 0) return;
+    setLabelFilters((prev) => [...prev, { key: keys[0], value: '' }]);
+  }, [availableLabels]);
+
+  const updateLabelFilter = useCallback((index: number, updates: Partial<LabelFilter>) => {
+    setLabelFilters((prev) =>
+      prev.map((f, i) => (i === index ? { ...f, ...updates } : f)),
+    );
+  }, []);
+
+  const removeLabelFilter = useCallback((index: number) => {
+    setLabelFilters((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleAddToDashboard = () => {
+    const panel: PanelConfig = {
+      id: generatePanelId(),
+      metricName: selectedMetric,
+      chartType,
+      title: panelTitle || selectedMetric,
+      visible: true,
+      query: {
+        metric: selectedMetric,
+        aggregation,
+        labelFilters: labelFilters.filter((f) => f.key && f.value),
+      },
+    };
+    onAddToDashboard(panel);
+    onClose();
+  };
+
+  const renderPreviewChart = () => {
+    if (!exploreData?.timeseries?.length) {
+      return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No data for this query" />;
+    }
+
+    const data = exploreData.timeseries.map((p) => ({
+      timestamp: p.timestamp,
+      value: p.value,
+    }));
+
+    const chartWidth = 520;
+    const chartHeight = 200;
+    const commonProps = {
+      width: chartWidth,
+      height: chartHeight,
+      data,
+      margin: { left: 4, right: 4, top: 6, bottom: 2 },
+    };
+
+    const xAxis = (
+      <XAxis
+        dataKey="timestamp"
+        tickFormatter={formatTimestamp}
+        minTickGap={28}
+        axisLine={false}
+        tickLine={false}
+        tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+      />
+    );
+    const yAxis = (
+      <YAxis
+        width={54}
+        axisLine={false}
+        tickLine={false}
+        tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+      />
+    );
+    const tooltip = (
+      <Tooltip
+        contentStyle={{
+          borderRadius: 8,
+          border: `1px solid ${token.colorBorderSecondary}`,
+          background: token.colorBgElevated,
+        }}
+        labelFormatter={(ts) => new Date(ts as string).toLocaleString()}
+      />
+    );
+    const grid = <CartesianGrid vertical={false} strokeDasharray="2 6" stroke={token.colorBorderSecondary} />;
+
+    if (chartType === 'bar') {
+      return (
+        <BarChart {...commonProps}>
+          {grid}{xAxis}{yAxis}{tooltip}
+          <Bar dataKey="value" fill={token.colorPrimary} fillOpacity={0.8} radius={[2, 2, 0, 0]} isAnimationActive={false} />
+        </BarChart>
+      );
+    }
+    if (chartType === 'line') {
+      return (
+        <LineChart {...commonProps}>
+          {grid}{xAxis}{yAxis}{tooltip}
+          <Line type="monotoneX" dataKey="value" stroke={token.colorPrimary} dot={false} strokeWidth={2} isAnimationActive={false} />
+        </LineChart>
+      );
+    }
+    // Default: area
+    return (
+      <AreaChart {...commonProps}>
+        {grid}{xAxis}{yAxis}{tooltip}
+        <Area type="monotoneX" dataKey="value" stroke={token.colorPrimary} fill={token.colorPrimaryBg} strokeWidth={2} isAnimationActive={false} />
+      </AreaChart>
+    );
+  };
+
+  return (
+    <Drawer
+      title="Metric Explorer"
+      open={open}
+      onClose={onClose}
+      width={640}
+      extra={
+        <Button
+          type="primary"
+          icon={<Plus size={14} />}
+          disabled={!selectedMetric || !exploreData?.timeseries?.length}
+          onClick={handleAddToDashboard}
+        >
+          Add to Dashboard
+        </Button>
+      }
+    >
+      <div className="space-y-4">
+        {/* Query Builder */}
+        <Card size="small" title="Query Builder">
+          <div className="space-y-3">
+            {/* Metric selector */}
+            <div>
+              <Text type="secondary" className="text-xs block mb-1">Metric</Text>
+              <Select
+                showSearch
+                placeholder="Search and select a metric..."
+                optionFilterProp="label"
+                value={selectedMetric || undefined}
+                onChange={setSelectedMetric}
+                style={{ width: '100%' }}
+                options={catalog.map((m) => ({
+                  value: m.name,
+                  label: `${m.name} (${m.prometheusType})`,
+                }))}
+              />
+              {selectedMetric && (
+                <Text type="secondary" className="text-xs mt-1 block">
+                  {catalog.find((m) => m.name === selectedMetric)?.help || ''}
+                </Text>
+              )}
+            </div>
+
+            {/* Aggregation */}
+            <div>
+              <Text type="secondary" className="text-xs block mb-1">Aggregation</Text>
+              <Select
+                value={aggregation}
+                onChange={setAggregation}
+                style={{ width: '100%' }}
+                options={aggregationOptions}
+              />
+            </div>
+
+            {/* Chart type */}
+            <div>
+              <Text type="secondary" className="text-xs block mb-1">Chart Type</Text>
+              <Select
+                value={chartType}
+                onChange={setChartType}
+                style={{ width: 200 }}
+                options={chartTypeOptions}
+              />
+            </div>
+
+            {/* Label filters */}
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <Text type="secondary" className="text-xs">Label Filters</Text>
+                <Button
+                  size="small"
+                  type="dashed"
+                  icon={<Plus size={12} />}
+                  onClick={addLabelFilter}
+                  disabled={Object.keys(availableLabels).length === 0}
+                >
+                  Add Filter
+                </Button>
+              </div>
+              {labelFilters.map((filter, index) => (
+                <div key={index} className="flex items-center gap-2 mb-2">
+                  <Select
+                    size="small"
+                    value={filter.key}
+                    onChange={(key) => updateLabelFilter(index, { key, value: '' })}
+                    style={{ width: 160 }}
+                    options={Object.keys(availableLabels).map((k) => ({ value: k, label: k }))}
+                  />
+                  <Text type="secondary">=</Text>
+                  <Select
+                    size="small"
+                    value={filter.value || undefined}
+                    onChange={(value) => updateLabelFilter(index, { value })}
+                    style={{ width: 200 }}
+                    placeholder="Select value..."
+                    showSearch
+                    options={(availableLabels[filter.key] ?? []).map((v) => ({ value: v, label: v }))}
+                  />
+                  <Button
+                    size="small"
+                    type="text"
+                    danger
+                    icon={<X size={12} />}
+                    onClick={() => removeLabelFilter(index)}
+                  />
+                </div>
+              ))}
+              {Object.keys(availableLabels).length === 0 && selectedMetric && !exploring && (
+                <Text type="secondary" className="text-xs">No labels available for this metric</Text>
+              )}
+            </div>
+
+            {/* Panel title */}
+            <div>
+              <Text type="secondary" className="text-xs block mb-1">Panel Title</Text>
+              <Input
+                value={panelTitle}
+                onChange={(e) => setPanelTitle(e.target.value)}
+                placeholder="Enter panel title..."
+              />
+            </div>
+          </div>
+        </Card>
+
+        {/* Preview */}
+        <Card
+          size="small"
+          title="Preview"
+          extra={
+            exploring ? <Spin size="small" /> : (
+              exploreData?.timeseries?.length ? (
+                <Tag color="green">{exploreData.timeseries.length} points</Tag>
+              ) : null
+            )
+          }
+        >
+          {!selectedMetric ? (
+            <div className="flex items-center justify-center h-[200px]">
+              <Text type="secondary">Select a metric to preview</Text>
+            </div>
+          ) : exploring ? (
+            <div className="flex items-center justify-center h-[200px]">
+              <Spin />
+            </div>
+          ) : exploreError ? (
+            <div className="flex items-center justify-center h-[200px]">
+              <Text type="danger">Query failed: {(exploreError as Error).message}</Text>
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-md" style={{ background: token.colorFillQuaternary, padding: '8px' }}>
+              {renderPreviewChart()}
+            </div>
+          )}
+        </Card>
+
+        {/* Active query summary */}
+        {selectedMetric && exploreData && (
+          <Card size="small" title="Query DSL">
+            <pre className="text-xs overflow-auto" style={{ background: token.colorFillQuaternary, padding: 8, borderRadius: 6 }}>
+{JSON.stringify(
+  {
+    metric: selectedMetric,
+    aggregation,
+    labelFilters: labelFilters.filter((f) => f.key && f.value),
+    chartType,
+  },
+  null,
+  2,
+)}
+            </pre>
+          </Card>
+        )}
+      </div>
+    </Drawer>
+  );
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/PanelEditor.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/components/PanelEditor.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react';
+import { Modal, Form, Input, Select, Typography } from 'antd';
+import type { MetricCatalogItem } from '@/services/metrics';
+import type { PanelConfig, ChartType } from '../dashboard-config';
+import { generatePanelId } from '../dashboard-config';
+
+const { Text } = Typography;
+
+interface PanelEditorProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (panels: PanelConfig[]) => void;
+  catalog: MetricCatalogItem[];
+  editingPanel?: PanelConfig | null;
+  existingMetricNames?: string[];
+}
+
+const buildTitle = (name: string) =>
+  name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+const chartTypeOptions = [
+  { value: 'line', label: '📈 Line Chart' },
+  { value: 'area', label: '📊 Area Chart' },
+  { value: 'bar', label: '📉 Bar Chart' },
+  { value: 'gauge', label: '🎯 Gauge' },
+];
+
+export default function PanelEditor({
+  open,
+  onClose,
+  onSave,
+  catalog,
+  editingPanel,
+  existingMetricNames = [],
+}: PanelEditorProps) {
+  const [form] = Form.useForm();
+  const [selectedMetric, setSelectedMetric] = useState<MetricCatalogItem | null>(null);
+
+  const isEditing = Boolean(editingPanel);
+  const existingSet = new Set(existingMetricNames);
+
+  useEffect(() => {
+    if (open) {
+      if (editingPanel) {
+        form.setFieldsValue({
+          metricName: editingPanel.metricName,
+          chartType: editingPanel.chartType,
+          title: editingPanel.title,
+        });
+        const found = catalog.find((m) => m.name === editingPanel.metricName);
+        setSelectedMetric(found ?? null);
+      } else {
+        form.resetFields();
+        setSelectedMetric(null);
+      }
+    }
+  }, [open, editingPanel, form, catalog]);
+
+  const handleMetricChange = (metricName: string) => {
+    const item = catalog.find((m) => m.name === metricName);
+    setSelectedMetric(item ?? null);
+    if (item) {
+      form.setFieldsValue({
+        chartType: item.suggestedChart,
+        title: buildTitle(item.name),
+      });
+    }
+  };
+
+  const handleSave = () => {
+    form.validateFields().then((values) => {
+      if (isEditing) {
+        const panel: PanelConfig = {
+          id: editingPanel?.id ?? generatePanelId(),
+          metricName: values.metricName,
+          chartType: values.chartType as ChartType,
+          title: values.title,
+          visible: true,
+        };
+        onSave([panel]);
+        onClose();
+        return;
+      }
+
+      const metricNames: string[] = values.metricNames ?? [];
+      const panels: PanelConfig[] = metricNames.map((name) => {
+        const item = catalog.find((m) => m.name === name);
+        return {
+          id: generatePanelId(),
+          metricName: name,
+          chartType: (item?.suggestedChart ?? 'line') as ChartType,
+          title: buildTitle(name),
+          visible: true,
+        };
+      });
+      onSave(panels);
+      onClose();
+    });
+  };
+
+  return (
+    <Modal
+      title={isEditing ? 'Edit Panel' : 'Add Panel'}
+      open={open}
+      onOk={handleSave}
+      onCancel={onClose}
+      okText={isEditing ? 'Update' : 'Add'}
+      width={560}
+      destroyOnClose
+    >
+      <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
+        {isEditing ? (
+          <>
+            <Form.Item
+              name="metricName"
+              label="Metric"
+              rules={[{ required: true, message: 'Please select a metric' }]}
+            >
+              <Select
+                showSearch
+                placeholder="Search and select a metric..."
+                optionFilterProp="label"
+                onChange={handleMetricChange}
+                options={catalog.map((m) => ({
+                  value: m.name,
+                  label: m.name,
+                }))}
+              />
+            </Form.Item>
+
+            {selectedMetric && (
+              <div style={{ marginBottom: 16, padding: '8px 12px', background: '#f5f5f5', borderRadius: 6 }}>
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  {selectedMetric.help || 'No description available'}
+                </Text>
+                <br />
+                <Text type="secondary" style={{ fontSize: 11 }}>
+                  Type: <strong>{selectedMetric.prometheusType}</strong> | Group:{' '}
+                  <strong>{selectedMetric.group}</strong>
+                </Text>
+              </div>
+            )}
+
+            <Form.Item
+              name="chartType"
+              label="Chart Type"
+              rules={[{ required: true, message: 'Please select a chart type' }]}
+            >
+              <Select options={chartTypeOptions} />
+            </Form.Item>
+
+            <Form.Item
+              name="title"
+              label="Panel Title"
+              rules={[{ required: true, message: 'Please enter a title' }]}
+            >
+              <Input placeholder="Enter panel title" />
+            </Form.Item>
+          </>
+        ) : (
+          <Form.Item
+            name="metricNames"
+            label="Metric"
+            rules={[{ required: true, message: 'Please select at least one metric' }]}
+            extra="Already added metrics are disabled. You can select multiple metrics at once."
+          >
+            <Select
+              mode="multiple"
+              showSearch
+              allowClear
+              placeholder="Search and select metrics..."
+              optionFilterProp="label"
+              options={catalog.map((m) => ({
+                value: m.name,
+                label: m.name,
+                disabled: existingSet.has(m.name),
+              }))}
+            />
+          </Form.Item>
+        )}
+      </Form>
+    </Modal>
+  );
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/index.ts
+++ b/ui/apps/dashboard/src/pages/metrics/components/index.ts
@@ -1,0 +1,5 @@
+export { default as DashboardToolbar } from './DashboardToolbar';
+export { default as DragPanel } from './DragPanel';
+export { default as LazyChart } from './LazyChart';
+export { default as MetricExplorer } from './MetricExplorer';
+export { default as PanelEditor } from './PanelEditor';

--- a/ui/apps/dashboard/src/pages/metrics/dashboard-config.test.ts
+++ b/ui/apps/dashboard/src/pages/metrics/dashboard-config.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { MetricCatalogItem } from '@/services/metrics';
+
+import {
+  DEFAULT_METRIC_NAMES_BY_COMPONENT,
+  buildDefaultConfig,
+  getConfiguredMetricNames,
+  selectDefaultCatalogMetrics,
+  serializeComponentDashboardConfig,
+  type DashboardConfig,
+} from './dashboard-config.ts';
+
+const COMPONENTS = [
+  'karmada-scheduler',
+  'karmada-controller-manager',
+  'karmada-agent',
+  'karmada-aggregated-apiserver',
+  'karmada-apiserver',
+  'karmada-descheduler',
+  'karmada-kube-controller-manager',
+  'karmada-metrics-adapter',
+  'karmada-scheduler-estimator-member1',
+  'karmada-scheduler-estimator-member2',
+  'karmada-scheduler-estimator-member3',
+  'karmada-search',
+  'karmada-webhook',
+] as const;
+
+const INTERNAL_METRIC_PREFIXES = [
+  'go_',
+  'process_',
+  'promhttp_',
+  'grpc_',
+  'rest_client_',
+  'certwatcher_',
+];
+
+function catalogItem(name: string): MetricCatalogItem {
+  return {
+    name,
+    help: '',
+    prometheusType: 'gauge',
+    suggestedChart: 'line',
+    group: 'test',
+  };
+}
+
+test('every dashboard component has non-internal defaults', () => {
+  assert.deepEqual(
+    Object.keys(DEFAULT_METRIC_NAMES_BY_COMPONENT).sort(),
+    [...COMPONENTS].sort(),
+  );
+
+  for (const component of COMPONENTS) {
+    const defaults = DEFAULT_METRIC_NAMES_BY_COMPONENT[component];
+    assert.ok(defaults.length > 0, `${component} has no defaults`);
+    for (const metricName of defaults) {
+      assert.equal(
+        INTERNAL_METRIC_PREFIXES.some((prefix) =>
+          metricName.startsWith(prefix),
+        ),
+        false,
+        `${component} unexpectedly defaults to ${metricName}`,
+      );
+    }
+  }
+});
+
+test('default metrics preserve allowlist order and require catalog presence', () => {
+  const selected = selectDefaultCatalogMetrics(
+    'karmada-kube-controller-manager',
+    [
+      catalogItem('go_gc_duration_seconds'),
+      catalogItem('workqueue_depth'),
+      catalogItem('node_collector_update_node_health_duration_seconds'),
+      catalogItem('node_collector_update_all_nodes_health_duration_seconds'),
+    ],
+  );
+
+  assert.deepEqual(
+    selected.map((item) => item.name),
+    [
+      'node_collector_update_all_nodes_health_duration_seconds',
+      'node_collector_update_node_health_duration_seconds',
+      'workqueue_depth',
+    ],
+  );
+});
+
+test('internal metrics are never selected by an automatic fallback', () => {
+  const config = buildDefaultConfig('karmada-webhook', [
+    catalogItem('go_gc_duration_seconds'),
+    catalogItem('process_resident_memory_bytes'),
+  ]);
+  assert.deepEqual(config.panels, []);
+});
+
+test('explicit user configuration keeps internal metrics', () => {
+  const config: DashboardConfig = {
+    version: 1,
+    component: 'karmada-webhook',
+    panels: [
+      {
+        id: 'go-gc',
+        metricName: 'go_gc_duration_seconds',
+        chartType: 'line',
+        title: 'Go GC Duration',
+        visible: true,
+      },
+    ],
+  };
+
+  assert.deepEqual(getConfiguredMetricNames(config), [
+    'go_gc_duration_seconds',
+  ]);
+});
+
+test('component export contains only the selected dashboard', () => {
+  const config: DashboardConfig = {
+    version: 1,
+    component: 'karmada-apiserver',
+    panels: [
+      {
+        id: 'request-total',
+        metricName: 'apiserver_request_total',
+        chartType: 'line',
+        title: 'API Server Requests',
+        visible: true,
+      },
+    ],
+  };
+
+  assert.deepEqual(JSON.parse(serializeComponentDashboardConfig(config)), {
+    metrics_dashboards: [config],
+  });
+});

--- a/ui/apps/dashboard/src/pages/metrics/dashboard-config.ts
+++ b/ui/apps/dashboard/src/pages/metrics/dashboard-config.ts
@@ -1,0 +1,364 @@
+import type {
+  KarmadaComponentKey,
+  MetricCatalogItem,
+} from '@/services/metrics';
+
+export type ChartType = 'line' | 'area' | 'bar' | 'gauge';
+export type AggregationType = 'sum' | 'avg' | 'max' | 'min' | 'rate';
+
+export interface LabelFilter {
+  key: string;
+  value: string;
+}
+
+export interface MetricQuery {
+  metric: string;
+  aggregation: AggregationType;
+  labelFilters?: LabelFilter[];
+}
+
+export interface PanelConfig {
+  id: string;
+  metricName: string;
+  chartType: ChartType;
+  title: string;
+  visible: boolean;
+  query?: MetricQuery;
+  /** Grid position (order index) */
+  order?: number;
+}
+
+export interface DashboardConfig {
+  version: number;
+  component: string;
+  panels: PanelConfig[];
+}
+
+const STORAGE_PREFIX = 'karmada-metrics-dashboard:';
+const CONFIG_VERSION = 1;
+const DEFAULT_PANEL_LIMIT = 12;
+
+/**
+ * Ordered, component-specific defaults. Only metrics in both this allowlist
+ * and the live catalog become automatic panels. Runtime/process metrics stay
+ * available in the catalog so an explicit user configuration can add them.
+ */
+export const DEFAULT_METRIC_NAMES_BY_COMPONENT = {
+  'karmada-scheduler': [
+    'karmada_scheduler_schedule_attempts_total',
+    'karmada_scheduler_queue_incoming_bindings_total',
+    'karmada_scheduler_e2e_scheduling_duration_seconds',
+    'karmada_scheduler_scheduling_algorithm_duration_seconds',
+    'karmada_scheduler_framework_extension_point_duration_seconds',
+    'karmada_scheduler_plugin_execution_duration_seconds',
+    'scheduler_pending_bindings',
+    'leader_election_master_status',
+    'workqueue_depth',
+    'workqueue_retries_total',
+    'workqueue_longest_running_processor_seconds',
+    'karmada_build_info',
+  ],
+  'karmada-controller-manager': [
+    'cluster_ready_state',
+    'cluster_ready_node_number',
+    'cluster_node_number',
+    'cluster_cpu_allocatable_number',
+    'cluster_cpu_allocated_number',
+    'cluster_memory_allocatable_bytes',
+    'cluster_memory_allocated_bytes',
+    'cluster_pod_allocatable_number',
+    'cluster_pod_allocated_number',
+    'cluster_sync_status_duration_seconds',
+    'policy_apply_attempts_total',
+    'resource_apply_policy_duration_seconds',
+  ],
+  'karmada-agent': [
+    'cluster_ready_state',
+    'cluster_ready_node_number',
+    'cluster_node_number',
+    'cluster_cpu_allocatable_number',
+    'cluster_cpu_allocated_number',
+    'cluster_memory_allocatable_bytes',
+    'cluster_memory_allocated_bytes',
+    'cluster_pod_allocatable_number',
+    'cluster_pod_allocated_number',
+    'cluster_sync_status_duration_seconds',
+    'sync_workload_duration_seconds',
+    'workqueue_depth',
+  ],
+  'karmada-aggregated-apiserver': [
+    'apiserver_request_total',
+    'apiserver_request_duration_seconds',
+    'apiserver_current_inflight_requests',
+    'apiserver_longrunning_requests',
+    'apiserver_request_sli_duration_seconds',
+    'apiserver_response_sizes',
+    'apiserver_storage_objects',
+    'apiserver_storage_size_bytes',
+    'apiserver_storage_db_total_size_in_bytes',
+    'apiserver_tls_handshake_errors_total',
+    'apiserver_delegated_authz_request_total',
+    'apiserver_delegated_authz_request_duration_seconds',
+  ],
+  'karmada-apiserver': [
+    'apiserver_request_total',
+    'apiserver_request_duration_seconds',
+    'apiserver_current_inflight_requests',
+    'apiserver_current_inqueue_requests',
+    'apiserver_longrunning_requests',
+    'apiserver_flowcontrol_current_executing_requests',
+    'apiserver_flowcontrol_current_inqueue_requests',
+    'apiserver_flowcontrol_request_wait_duration_seconds',
+    'apiserver_admission_controller_admission_duration_seconds',
+    'apiserver_storage_objects',
+    'apiserver_storage_size_bytes',
+    'apiserver_tls_handshake_errors_total',
+  ],
+  'karmada-descheduler': [
+    'leader_election_master_status',
+    'workqueue_depth',
+    'workqueue_adds_total',
+    'workqueue_retries_total',
+    'workqueue_queue_duration_seconds',
+    'workqueue_work_duration_seconds',
+    'workqueue_longest_running_processor_seconds',
+    'workqueue_unfinished_work_seconds',
+    'karmada_build_info',
+  ],
+  'karmada-kube-controller-manager': [
+    'node_collector_update_all_nodes_health_duration_seconds',
+    'node_collector_update_node_health_duration_seconds',
+    'garbagecollector_controller_resources_sync_error_total',
+    'ttl_after_finished_controller_job_deletion_duration_seconds',
+    'leader_election_master_status',
+    'workqueue_depth',
+    'workqueue_adds_total',
+    'workqueue_retries_total',
+    'workqueue_longest_running_processor_seconds',
+    'workqueue_unfinished_work_seconds',
+  ],
+  'karmada-metrics-adapter': [
+    'apiserver_request_total',
+    'apiserver_request_duration_seconds',
+    'apiserver_request_sli_duration_seconds',
+    'apiserver_request_slo_duration_seconds',
+    'apiserver_request_filter_duration_seconds',
+    'apiserver_current_inflight_requests',
+    'workqueue_depth',
+    'workqueue_adds_total',
+    'workqueue_retries_total',
+    'karmada_build_info',
+  ],
+  'karmada-scheduler-estimator-member1': [
+    'karmada_scheduler_estimator_estimating_request_total',
+    'karmada_scheduler_estimator_estimating_algorithm_duration_seconds',
+    'karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds',
+    'karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds',
+    'karmada_build_info',
+  ],
+  'karmada-scheduler-estimator-member2': [
+    'karmada_scheduler_estimator_estimating_request_total',
+    'karmada_scheduler_estimator_estimating_algorithm_duration_seconds',
+    'karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds',
+    'karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds',
+    'karmada_build_info',
+  ],
+  'karmada-scheduler-estimator-member3': [
+    'karmada_scheduler_estimator_estimating_request_total',
+    'karmada_scheduler_estimator_estimating_algorithm_duration_seconds',
+    'karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds',
+    'karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds',
+    'karmada_build_info',
+  ],
+  'karmada-search': [
+    'apiserver_request_total',
+    'apiserver_request_duration_seconds',
+    'apiserver_current_inflight_requests',
+    'apiserver_longrunning_requests',
+    'apiserver_request_sli_duration_seconds',
+    'apiserver_request_slo_duration_seconds',
+    'apiserver_request_filter_duration_seconds',
+    'apiserver_storage_objects',
+    'apiserver_storage_size_bytes',
+    'etcd_request_duration_seconds',
+    'etcd_requests_total',
+    'workqueue_depth',
+  ],
+  'karmada-webhook': [
+    'controller_runtime_webhook_requests_total',
+    'controller_runtime_webhook_latency_seconds',
+    'controller_runtime_webhook_requests_in_flight',
+    'controller_runtime_webhook_panics_total',
+    'controller_runtime_conversion_webhook_panics_total',
+    'karmada_build_info',
+  ],
+} satisfies Record<KarmadaComponentKey, readonly string[]>;
+
+export function getDefaultMetricNamesForComponent(
+  component: string,
+): readonly string[] {
+  return (
+    DEFAULT_METRIC_NAMES_BY_COMPONENT[component as KarmadaComponentKey] ?? []
+  );
+}
+
+/**
+ * Generate a unique panel ID
+ */
+export function generatePanelId(): string {
+  return `panel-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Load dashboard config from localStorage for a specific component.
+ * Returns null if no config exists.
+ */
+export function loadDashboardConfig(component: string): DashboardConfig | null {
+  try {
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}${component}`);
+    if (!raw) return null;
+    const config = JSON.parse(raw) as DashboardConfig;
+    if (config.version !== CONFIG_VERSION) return null;
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save dashboard config to localStorage for a specific component.
+ */
+export function saveDashboardConfig(config: DashboardConfig): void {
+  localStorage.setItem(
+    `${STORAGE_PREFIX}${config.component}`,
+    JSON.stringify(config),
+  );
+}
+
+/**
+ * Reset (delete) the dashboard config for a component.
+ */
+export function resetDashboardConfig(component: string): void {
+  localStorage.removeItem(`${STORAGE_PREFIX}${component}`);
+}
+
+/**
+ * Create a PanelConfig from a MetricCatalogItem with sensible defaults.
+ */
+export function createPanelFromCatalogItem(
+  item: MetricCatalogItem,
+): PanelConfig {
+  return {
+    id: generatePanelId(),
+    metricName: item.name,
+    chartType: item.suggestedChart,
+    title: item.name
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, (c) => c.toUpperCase()),
+    visible: true,
+  };
+}
+
+/**
+ * Pick a compact default metric subset centered on Karmada control-plane health.
+ */
+export function selectDefaultCatalogMetrics(
+  component: string,
+  catalog: MetricCatalogItem[],
+): MetricCatalogItem[] {
+  const catalogByName = new Map(catalog.map((item) => [item.name, item]));
+  return getDefaultMetricNamesForComponent(component)
+    .map((name) => catalogByName.get(name))
+    .filter((item): item is MetricCatalogItem => item !== undefined)
+    .slice(0, DEFAULT_PANEL_LIMIT);
+}
+
+/**
+ * Build a compact default config from catalog.
+ */
+export function buildDefaultConfig(
+  component: string,
+  catalog: MetricCatalogItem[],
+): DashboardConfig {
+  return {
+    version: CONFIG_VERSION,
+    component,
+    panels: selectDefaultCatalogMetrics(component, catalog).map(
+      createPanelFromCatalogItem,
+    ),
+  };
+}
+
+/**
+ * Add a panel to the config and save.
+ */
+export function addPanel(
+  config: DashboardConfig,
+  panel: PanelConfig,
+): DashboardConfig {
+  const updated = {
+    ...config,
+    panels: [...config.panels, panel],
+  };
+  saveDashboardConfig(updated);
+  return updated;
+}
+
+/**
+ * Remove a panel by ID and save.
+ */
+export function removePanel(
+  config: DashboardConfig,
+  panelId: string,
+): DashboardConfig {
+  const updated = {
+    ...config,
+    panels: config.panels.filter((p) => p.id !== panelId),
+  };
+  saveDashboardConfig(updated);
+  return updated;
+}
+
+/**
+ * Update a panel by ID and save.
+ */
+export function updatePanel(
+  config: DashboardConfig,
+  panelId: string,
+  updates: Partial<PanelConfig>,
+): DashboardConfig {
+  const updated = {
+    ...config,
+    panels: config.panels.map((p) =>
+      p.id === panelId ? { ...p, ...updates } : p,
+    ),
+  };
+  saveDashboardConfig(updated);
+  return updated;
+}
+
+/**
+ * Reorder panels and save.
+ */
+export function reorderPanels(
+  config: DashboardConfig,
+  panels: PanelConfig[],
+): DashboardConfig {
+  const updated = { ...config, panels };
+  saveDashboardConfig(updated);
+  return updated;
+}
+
+/**
+ * Get the list of metric names from the config (for API filtering).
+ */
+export function getConfiguredMetricNames(config: DashboardConfig): string[] {
+  return config.panels.filter((p) => p.visible).map((p) => p.metricName);
+}
+
+/** Serialize one component dashboard in the ConfigMap-compatible JSON shape. */
+export function serializeComponentDashboardConfig(
+  config: DashboardConfig,
+): string {
+  return JSON.stringify({ metrics_dashboards: [config] }, null, 2);
+}

--- a/ui/apps/dashboard/src/pages/metrics/index.module.less
+++ b/ui/apps/dashboard/src/pages/metrics/index.module.less
@@ -1,0 +1,435 @@
+.metricsPage {
+  --metrics-panel: rgba(255, 255, 255, 0.82);
+  --metrics-ink: #17211f;
+  --metrics-muted: #66736f;
+  --metrics-line: rgba(34, 48, 44, 0.1);
+  --metrics-accent: #176d63;
+
+  position: relative;
+  min-height: 100%;
+  overflow: hidden;
+  color: var(--metrics-ink);
+  background: transparent;
+}
+
+.metricsPage > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 20px;
+  border: 1px solid var(--metrics-line);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(46, 60, 56, 0.06);
+}
+
+.heroCopy {
+  min-width: 0;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 8px;
+  color: var(--metrics-accent);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pageTitle {
+  margin: 0 !important;
+  color: var(--metrics-ink) !important;
+  font-size: clamp(24px, 3vw, 32px) !important;
+  font-weight: 700 !important;
+  line-height: 1.1 !important;
+  text-wrap: balance;
+}
+
+.heroMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.heroMeta span {
+  display: inline-flex;
+  min-height: 28px;
+  align-items: center;
+  padding: 5px 10px;
+  border: 1px solid rgba(23, 109, 99, 0.13);
+  border-radius: 8px;
+  color: var(--metrics-muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.refreshButton {
+  border-color: rgba(23, 109, 99, 0.18) !important;
+  color: var(--metrics-accent) !important;
+  font-weight: 650;
+  background: rgba(255, 255, 255, 0.76) !important;
+  box-shadow: 0 8px 18px rgba(23, 109, 99, 0.08);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease !important;
+}
+
+.refreshButton:hover {
+  border-color: rgba(23, 109, 99, 0.36) !important;
+  box-shadow: 0 12px 26px rgba(23, 109, 99, 0.12);
+  transform: translateY(-1px);
+}
+
+.refreshButton:active {
+  transform: translateY(0) scale(0.98);
+}
+
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.summaryItem {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--metrics-line);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(46, 60, 56, 0.05);
+}
+
+.summaryLabel {
+  display: block;
+  color: var(--metrics-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.summaryValue {
+  display: block;
+  margin-top: 4px;
+  color: var(--metrics-ink);
+  font-size: 24px;
+  font-weight: 760;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.scopeCard {
+  margin-top: 14px;
+  border: 1px solid var(--metrics-line);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(46, 60, 56, 0.05);
+}
+
+.scopeCard :global(.ant-card-body) {
+  padding: 16px;
+}
+
+.scopeGrid {
+  display: grid;
+  grid-template-columns:
+    minmax(220px, 1.15fr) minmax(128px, 0.56fr) minmax(240px, 1fr)
+    auto;
+  gap: 14px;
+  align-items: end;
+}
+
+.controlField {
+  display: grid;
+  min-width: 0;
+  gap: 7px;
+}
+
+.controlLabel {
+  color: var(--metrics-muted) !important;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.componentSelect,
+.windowSelect,
+.podSelect {
+  width: 100%;
+  min-width: 0;
+}
+
+.componentSelect :global(.ant-select-selection-item),
+.windowSelect :global(.ant-select-selection-item),
+.podSelect :global(.ant-select-selection-item) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scopeMeta {
+  min-width: 170px;
+  padding: 8px 0 6px 14px;
+  border-left: 1px solid var(--metrics-line);
+  text-align: right;
+}
+
+.metaLine {
+  display: block;
+  overflow: hidden;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inlineAlert {
+  margin-top: 14px;
+  border-radius: 12px;
+}
+
+.metricsSection {
+  margin-top: 20px;
+}
+
+.metricGroups {
+  display: grid;
+  gap: 24px;
+  margin-top: 18px;
+}
+
+.metricGroup {
+  display: grid;
+  gap: 14px;
+}
+
+.groupHeading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 2px;
+}
+
+.groupTitle {
+  color: var(--metrics-ink) !important;
+  font-size: 18px;
+  font-weight: 760;
+}
+
+.groupCount {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.prefixGroups {
+  display: grid;
+  gap: 18px;
+}
+
+.prefixGroup {
+  display: grid;
+  gap: 10px;
+}
+
+.prefixHeading {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: baseline;
+}
+
+.prefixTitle {
+  color: #26312e !important;
+  font-size: 13px;
+  font-weight: 720;
+}
+
+.prefixDescription {
+  max-width: 62ch;
+  font-size: 12px;
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+
+.chartGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.chartCard {
+  position: relative;
+  min-height: 344px;
+  overflow: hidden;
+  border: 1px solid var(--metrics-line);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(45, 58, 55, 0.06);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.chartCard:hover {
+  border-color: rgba(23, 109, 99, 0.22);
+  box-shadow: 0 6px 16px rgba(45, 58, 55, 0.1);
+  transform: translateY(-2px);
+}
+
+.chartCard :global(.ant-card-head) {
+  min-height: 72px;
+  border-bottom: 1px solid rgba(35, 48, 44, 0.08);
+  padding: 0 16px;
+}
+
+.chartCard :global(.ant-card-body) {
+  padding: 14px 14px 16px;
+}
+
+.chartHeader {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.chartTitleRow {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.chartName {
+  min-width: 0;
+}
+
+.chartTitle {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--metrics-ink) !important;
+  font-size: 14px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.latestValue {
+  flex: 0 0 auto;
+  color: var(--metrics-ink) !important;
+  font-size: 15px;
+  font-weight: 760;
+  font-variant-numeric: tabular-nums;
+}
+
+.chartRange {
+  display: block;
+  overflow: hidden;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.panelActions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+  padding: 3px;
+  border: 1px solid rgba(35, 48, 44, 0.08);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 8px 18px rgba(45, 58, 55, 0.1);
+  backdrop-filter: blur(10px);
+}
+
+.chartCanvas {
+  width: 100%;
+  height: 252px;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgba(35, 48, 44, 0.06);
+  border-radius: 12px;
+  padding: 8px 8px 0 0;
+  background:
+    linear-gradient(
+      180deg,
+      rgba(247, 250, 249, 0.95),
+      rgba(240, 245, 243, 0.74)
+    ),
+    radial-gradient(
+      circle at 14% 0%,
+      rgba(23, 109, 99, 0.08),
+      transparent 13rem
+    );
+}
+
+.emptyCard {
+  border: 1px dashed rgba(35, 48, 44, 0.16);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+@media (max-width: 1180px) {
+  .scopeGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .scopeMeta {
+    grid-column: 1 / -1;
+    min-width: 0;
+    padding: 10px 0 0;
+    border-top: 1px solid var(--metrics-line);
+    border-left: 0;
+    text-align: left;
+  }
+
+  .chartGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .hero {
+    grid-template-columns: 1fr;
+    padding: 18px;
+  }
+
+  .heroActions {
+    justify-content: flex-start;
+  }
+
+  .summaryGrid,
+  .scopeGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .pageTitle {
+    font-size: 30px !important;
+  }
+
+  .chartCard {
+    min-height: 336px;
+  }
+}

--- a/ui/apps/dashboard/src/pages/metrics/index.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/index.tsx
@@ -1,0 +1,1291 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import axios from 'axios';
+import {
+  Alert,
+  Button,
+  Card,
+  Empty,
+  Popconfirm,
+  Select,
+  Space,
+  Tooltip as AntTooltip,
+  Typography,
+  message,
+  theme,
+} from 'antd';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
+
+import Panel from '@/components/panel';
+import { Icons } from '@/components/icons';
+import {
+  GetComponentPods,
+  GetSchedulerVisualization,
+  GetMetricsDashboards,
+  KARMADA_COMPONENTS,
+  KarmadaComponentKey,
+  MetricCatalogItem,
+  SchedulerVisualizationResponse,
+} from '@/services/metrics';
+
+import {
+  DashboardToolbar,
+  DragPanel,
+  LazyChart,
+  MetricExplorer,
+  PanelEditor,
+} from './components';
+import {
+  addPanel,
+  buildDefaultConfig,
+  getConfiguredMetricNames,
+  getDefaultMetricNamesForComponent,
+  removePanel,
+  reorderPanels,
+  resetDashboardConfig,
+  selectDefaultCatalogMetrics,
+  serializeComponentDashboardConfig,
+  saveDashboardConfig,
+  updatePanel,
+  type DashboardConfig,
+  type PanelConfig,
+} from './dashboard-config';
+import styles from './index.module.less';
+
+const { Title, Text } = Typography;
+
+const defaultWindow = '15m';
+
+type ChartType = 'line' | 'area' | 'bar' | 'gauge';
+
+type SeriesKey = string;
+
+interface ChartPointRow {
+  timestamp: string;
+  [key: string]: string | number | undefined;
+}
+
+interface ChartConfig {
+  key: SeriesKey;
+  title: string;
+  color: string;
+  chart: ChartType;
+  panelId?: string;
+  valueFormatter?: (value: number) => string;
+  axisFormatter?: (value: number) => string;
+}
+
+const CHART_COLORS = [
+  '#2f6fdf',
+  '#16877a',
+  '#b86f28',
+  '#7161c9',
+  '#bf4f7f',
+  '#2f8b57',
+  '#bd4d46',
+  '#7a63d2',
+  '#178ea7',
+  '#c28722',
+  '#bd5f95',
+  '#229c8c',
+  '#c66c2d',
+];
+
+function formatNumber(value: number, fractionDigits = 3) {
+  if (!Number.isFinite(value)) return '0';
+  return value.toLocaleString(undefined, {
+    maximumFractionDigits: fractionDigits,
+  });
+}
+
+function formatOps(value: number) {
+  if (!Number.isFinite(value)) return '0 ops/s';
+  return `${formatNumber(value)} ops/s`;
+}
+
+function shortOps(value: number) {
+  if (!Number.isFinite(value)) return '0';
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+  return formatNumber(value, 1);
+}
+
+function getAutoFormatter(metricName: string): {
+  valueFormatter?: (v: number) => string;
+  axisFormatter?: (v: number) => string;
+} {
+  if (metricName.includes('_bytes'))
+    return { valueFormatter: formatBytes, axisFormatter: shortBytes };
+  if (metricName.includes('_seconds') || metricName.includes('_duration')) {
+    return { valueFormatter: formatSeconds, axisFormatter: shortSeconds };
+  }
+  if (metricName.endsWith('_total') || metricName.includes('Rate')) {
+    return { valueFormatter: formatOps, axisFormatter: shortOps };
+  }
+  return {};
+}
+
+function metricNameToTitle(name: string): string {
+  return name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatBytes(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  return `${value.toFixed(2)} ${units[unitIndex]}`;
+}
+
+function shortBytes(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0';
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)}G`;
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)}M`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)}K`;
+  return formatNumber(bytes, 0);
+}
+
+function formatSeconds(value: number) {
+  if (!Number.isFinite(value)) return '0 s';
+  if (value < 0.001) return `${(value * 1000).toFixed(2)} ms`;
+  if (value < 1) return `${(value * 1000).toFixed(1)} ms`;
+  return `${value.toFixed(3)} s`;
+}
+
+function shortSeconds(value: number) {
+  if (!Number.isFinite(value)) return '0';
+  if (value < 0.001) return `${(value * 1000).toFixed(1)}ms`;
+  if (value < 1) return `${(value * 1000).toFixed(0)}ms`;
+  return `${value.toFixed(2)}s`;
+}
+
+function formatTimestamp(value: string) {
+  return new Date(value).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+function formatDateTime(value: string | number) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ` +
+    `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+  );
+}
+
+function mapVisualizationRows(
+  data?: SchedulerVisualizationResponse,
+): ChartPointRow[] {
+  if (!data?.timeseries) return [];
+
+  const rowMap = new Map<string, ChartPointRow>();
+
+  Object.entries(data.timeseries).forEach(([seriesName, points]) => {
+    if (!Array.isArray(points) || points.length === 0) return;
+
+    points.forEach((point) => {
+      const row = rowMap.get(point.timestamp) ?? { timestamp: point.timestamp };
+      row[seriesName] = point.value;
+      rowMap.set(point.timestamp, row);
+    });
+  });
+
+  return Array.from(rowMap.values()).sort((a, b) =>
+    a.timestamp.localeCompare(b.timestamp),
+  );
+}
+
+function getLatestSeriesValue(rows: ChartPointRow[], key: SeriesKey) {
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const value = rows[i][key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function getSeriesBounds(rows: ChartPointRow[], key: SeriesKey) {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  rows.forEach((row) => {
+    const value = row[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      min = Math.min(min, value);
+      max = Math.max(max, value);
+    }
+  });
+
+  if (min === Number.POSITIVE_INFINITY || max === Number.NEGATIVE_INFINITY) {
+    return undefined;
+  }
+  return { min, max };
+}
+
+function buildChartConfigFromCatalog(
+  item: MetricCatalogItem,
+  index: number,
+): ChartConfig {
+  const formatters = getAutoFormatter(item.name);
+  return {
+    key: item.name,
+    title: metricNameToTitle(item.name),
+    color: CHART_COLORS[index % CHART_COLORS.length],
+    chart: item.suggestedChart,
+    valueFormatter: formatters.valueFormatter,
+    axisFormatter: formatters.axisFormatter,
+  };
+}
+
+const MetricsPage = () => {
+  const queryClient = useQueryClient();
+  const { token } = theme.useToken();
+
+  const [activeComponent, setActiveComponent] = useState<KarmadaComponentKey>(
+    KARMADA_COMPONENTS[0].key,
+  );
+  const [visualizationPod, setVisualizationPod] = useState<string>('all');
+  const [hasInitializedPodSelection, setHasInitializedPodSelection] =
+    useState<boolean>(false);
+  const [editMode, setEditMode] = useState(false);
+  // "committedConfig" drives API queries; "draftConfig" is used during editing
+  const [committedConfig, setCommittedConfig] =
+    useState<DashboardConfig | null>(null);
+  const [draftConfig, setDraftConfig] = useState<DashboardConfig | null>(null);
+  const [panelEditorOpen, setPanelEditorOpen] = useState(false);
+  const [editingPanel, setEditingPanel] = useState<PanelConfig | null>(null);
+  const [explorerOpen, setExplorerOpen] = useState(false);
+
+  // The active config for rendering panels (draft in edit mode, committed otherwise)
+  const dashboardConfig = editMode ? draftConfig : committedConfig;
+
+  // Metrics display follows the backend config (ConfigMap). Fetch all persisted
+  // component dashboards; the active component's dashboard drives the layout.
+  const { data: remoteDashboards } = useQuery({
+    queryKey: ['metricsDashboards'],
+    queryFn: GetMetricsDashboards,
+  });
+
+  const editModeRef = useRef(editMode);
+  useEffect(() => {
+    editModeRef.current = editMode;
+  }, [editMode]);
+
+  useEffect(() => {
+    // Only re-apply the remote config on component switch or when the backend
+    // config changes — never merely because edit mode toggled (that would drop
+    // in-session edits). Skip while actively editing to avoid clobbering.
+    if (editModeRef.current) return;
+    const remote = remoteDashboards?.find(
+      (item) => item.component === activeComponent,
+    );
+    const config = remote ? (remote as DashboardConfig) : null;
+    setCommittedConfig(config);
+    setDraftConfig(config);
+    setPanelEditorOpen(false);
+    setEditingPanel(null);
+  }, [activeComponent, remoteDashboards]);
+
+  // API queries are driven ONLY by committedConfig (not draft)
+  const configuredMetrics = useMemo(
+    () =>
+      committedConfig ? getConfiguredMetricNames(committedConfig) : undefined,
+    [committedConfig],
+  );
+  const configuredMetricsKey = configuredMetrics?.join(',') ?? 'default';
+
+  const {
+    data: visualizationData,
+    isLoading: visualizationLoading,
+    error: visualizationError,
+  } = useQuery({
+    queryKey: [
+      'componentVisualization',
+      activeComponent,
+      visualizationPod,
+      defaultWindow,
+      configuredMetricsKey,
+    ],
+    queryFn: () =>
+      GetSchedulerVisualization(activeComponent, {
+        window: defaultWindow,
+        pod: visualizationPod,
+        refresh: false,
+        metrics: configuredMetrics,
+      }),
+    enabled: !!activeComponent,
+    refetchInterval: 10_000,
+  });
+
+  const { data: podScopeData } = useQuery({
+    queryKey: ['componentPodScope', activeComponent],
+    queryFn: () => GetComponentPods(activeComponent),
+    enabled: !!activeComponent,
+    refetchInterval: 10_000,
+  });
+
+  const refreshVisualizationMutation = useMutation({
+    mutationFn: () =>
+      GetSchedulerVisualization(activeComponent, {
+        window: defaultWindow,
+        pod: visualizationPod,
+        refresh: true,
+        metrics: configuredMetrics,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [
+          'componentVisualization',
+          activeComponent,
+          visualizationPod,
+          defaultWindow,
+        ],
+      });
+    },
+  });
+
+  const visualizationRows = useMemo(
+    () => mapVisualizationRows(visualizationData),
+    [visualizationData],
+  );
+
+  const visualizationPods = useMemo(
+    () => podScopeData?.pods ?? visualizationData?.pods ?? [],
+    [podScopeData, visualizationData],
+  );
+
+  const activeComponentLabel = useMemo(
+    () =>
+      KARMADA_COMPONENTS.find((item) => item.key === activeComponent)?.label ??
+      activeComponent,
+    [activeComponent],
+  );
+
+  const generatedAtLabel = visualizationData?.meta?.generatedAt
+    ? formatDateTime(visualizationData.meta.generatedAt)
+    : 'Waiting for data';
+
+  const sampleIntervalLabel = visualizationData?.meta?.sampleIntervalSec
+    ? `${visualizationData.meta.sampleIntervalSec}s`
+    : '--';
+
+  useEffect(() => {
+    if (committedConfig || draftConfig) return;
+    if (!visualizationData?.metricsCatalog?.length) return;
+    if (visualizationData.meta.appName !== activeComponent) return;
+
+    const config = buildDefaultConfig(
+      activeComponent,
+      visualizationData.metricsCatalog,
+    );
+    saveDashboardConfig(config);
+    setCommittedConfig(config);
+    setDraftConfig(config);
+  }, [activeComponent, committedConfig, draftConfig, visualizationData]);
+
+  useEffect(() => {
+    if (hasInitializedPodSelection || visualizationPods.length === 0) return;
+    setVisualizationPod(visualizationPods[0]);
+    setHasInitializedPodSelection(true);
+  }, [hasInitializedPodSelection, visualizationPods]);
+
+  useEffect(() => {
+    if (visualizationPod === 'all' || visualizationPods.length === 0) return;
+    if (!visualizationPods.includes(visualizationPod)) {
+      setVisualizationPod(visualizationPods[0]);
+    }
+  }, [visualizationPod, visualizationPods]);
+
+  const seriesKeysWithData = useMemo(() => {
+    if (!visualizationData?.timeseries) return [] as SeriesKey[];
+    return Object.keys(visualizationData.timeseries).filter(
+      (key) => (visualizationData.timeseries[key] ?? []).length > 0,
+    );
+  }, [visualizationData]);
+
+  const handleAddPanels = (panels: PanelConfig[]) => {
+    if (panels.length === 0) return;
+    const catalog = visualizationData?.metricsCatalog ?? [];
+    let config = draftConfig ?? buildDefaultConfig(activeComponent, catalog);
+    for (const panel of panels) {
+      config = addPanel(config, panel);
+    }
+    setDraftConfig(config);
+    if (!editMode) {
+      setCommittedConfig(config);
+    }
+  };
+
+  const handleUpdatePanel = (panel: PanelConfig) => {
+    if (!draftConfig) return;
+    const updated = updatePanel(draftConfig, panel.id, panel);
+    setDraftConfig(updated);
+    if (!editMode) {
+      setCommittedConfig(updated);
+    }
+  };
+
+  const handleDeletePanel = (panelId: string) => {
+    if (!draftConfig) return;
+    const updated = removePanel(draftConfig, panelId);
+    setDraftConfig(updated);
+    if (!editMode) {
+      setCommittedConfig(updated);
+    }
+  };
+
+  const handleResetConfig = () => {
+    resetDashboardConfig(activeComponent);
+    setCommittedConfig(null);
+    setDraftConfig(null);
+    setEditMode(false);
+  };
+
+  const handleSavePanel = (panels: PanelConfig[]) => {
+    if (editingPanel) {
+      if (panels[0]) handleUpdatePanel(panels[0]);
+    } else {
+      handleAddPanels(panels);
+    }
+    setEditingPanel(null);
+  };
+
+  const handleEnterEditMode = useCallback(() => {
+    if (!draftConfig && visualizationData?.metricsCatalog?.length) {
+      const config = buildDefaultConfig(
+        activeComponent,
+        visualizationData.metricsCatalog,
+      );
+      saveDashboardConfig(config);
+      setDraftConfig(config);
+      setCommittedConfig(config);
+    }
+    setEditMode(true);
+  }, [draftConfig, visualizationData, activeComponent]);
+
+  const handleExitEditMode = useCallback(() => {
+    // Commit draft to storage and update committed state
+    if (draftConfig) {
+      saveDashboardConfig(draftConfig);
+      setCommittedConfig(draftConfig);
+    }
+    setEditMode(false);
+  }, [draftConfig]);
+
+  // Copy the active component layout so it can be reviewed or pasted into the
+  // dashboard ConfigMap. Draft edits take precedence while edit mode is open.
+  const [exporting, setExporting] = useState(false);
+
+  const handleCopyComponentConfig = useCallback(async () => {
+    const current =
+      draftConfig ??
+      committedConfig ??
+      buildDefaultConfig(
+        activeComponent,
+        visualizationData?.metricsCatalog ?? [],
+      );
+    const text = serializeComponentDashboardConfig(current);
+    setExporting(true);
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      }
+      message.success(
+        `Copied ${current.component} metrics JSON (${current.panels.length} panels)`,
+      );
+    } catch (err) {
+      message.error(`Failed to copy configuration: ${(err as Error).message}`);
+    } finally {
+      setExporting(false);
+    }
+  }, [draftConfig, committedConfig, activeComponent, visualizationData]);
+
+  const handleExplorerAddPanel = useCallback(
+    (panel: PanelConfig) => {
+      const catalog = visualizationData?.metricsCatalog ?? [];
+      const config =
+        draftConfig ??
+        committedConfig ??
+        buildDefaultConfig(activeComponent, catalog);
+      const updated = addPanel(config, panel);
+      saveDashboardConfig(updated);
+      setDraftConfig(updated);
+      setCommittedConfig(updated);
+    },
+    [draftConfig, committedConfig, activeComponent, visualizationData],
+  );
+
+  // DnD sensors with activation constraint to prevent accidental drags
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id || !draftConfig) return;
+
+      const oldIndex = draftConfig.panels.findIndex((p) => p.id === active.id);
+      const newIndex = draftConfig.panels.findIndex((p) => p.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const newPanels = [...draftConfig.panels];
+      const [moved] = newPanels.splice(oldIndex, 1);
+      newPanels.splice(newIndex, 0, moved);
+
+      const updated = reorderPanels(draftConfig, newPanels);
+      setDraftConfig(updated);
+    },
+    [draftConfig],
+  );
+
+  const panelIds = useMemo(
+    () =>
+      (dashboardConfig?.panels ?? []).filter((p) => p.visible).map((p) => p.id),
+    [dashboardConfig],
+  );
+
+  const visibleCharts = useMemo((): ChartConfig[] => {
+    if (dashboardConfig?.panels?.length) {
+      return dashboardConfig.panels
+        .filter((panel) => panel.visible)
+        .map((panel, idx) => {
+          const formatters = getAutoFormatter(panel.metricName);
+          return {
+            key: panel.metricName,
+            title: panel.title,
+            color: CHART_COLORS[idx % CHART_COLORS.length],
+            chart: panel.chartType as ChartType,
+            panelId: panel.id,
+            valueFormatter: formatters.valueFormatter,
+            axisFormatter: formatters.axisFormatter,
+          };
+        });
+    }
+
+    if (visualizationData?.metricsCatalog?.length) {
+      const keysWithData = new Set(seriesKeysWithData);
+      return selectDefaultCatalogMetrics(
+        activeComponent,
+        visualizationData.metricsCatalog,
+      )
+        .filter((item) => keysWithData.has(item.name))
+        .map((item, idx) => buildChartConfigFromCatalog(item, idx));
+    }
+
+    const defaultMetricNames = new Set(
+      getDefaultMetricNamesForComponent(activeComponent),
+    );
+    return seriesKeysWithData
+      .filter((key) => defaultMetricNames.has(key))
+      .map((key, idx) => {
+        const formatters = getAutoFormatter(key);
+        return {
+          key,
+          title: metricNameToTitle(key),
+          color: CHART_COLORS[idx % CHART_COLORS.length],
+          chart: 'line' as ChartType,
+          valueFormatter: formatters.valueFormatter,
+          axisFormatter: formatters.axisFormatter,
+        };
+      });
+  }, [activeComponent, seriesKeysWithData, visualizationData, dashboardConfig]);
+
+  const visualizationErrorDescription = useMemo(() => {
+    if (!visualizationError) return null;
+
+    if (axios.isAxiosError(visualizationError)) {
+      const status = visualizationError.response?.status;
+      if (status === 400) {
+        return 'Invalid query parameters. Check selected component, pod mode, and window.';
+      }
+      if (status === 502) {
+        return 'Failed to reach upstream metrics endpoint. Verify proxy endpoint and component service.';
+      }
+      if (status === 503) {
+        return 'No usable metrics in the selected window. Wait for new samples or switch pod scope.';
+      }
+    }
+
+    return (visualizationError as Error).message;
+  }, [visualizationError]);
+
+  const isNoDataError = useMemo(() => {
+    if (!visualizationError) return false;
+    return (
+      axios.isAxiosError(visualizationError) &&
+      visualizationError.response?.status === 503
+    );
+  }, [visualizationError]);
+
+  const renderGauge = (
+    config: ChartConfig,
+    currentValue: number,
+    bounds: { min: number; max: number } | undefined,
+  ) => {
+    const min = bounds?.min ?? 0;
+    const max = bounds?.max ?? (currentValue * 1.5 || 100);
+    const ratio =
+      max > min ? Math.min((currentValue - min) / (max - min), 1) : 0;
+    const angle = ratio * 180;
+    const valueFormatter =
+      config.valueFormatter ?? ((v: number) => formatNumber(v));
+
+    const cx = 120;
+    const cy = 100;
+    const r = 80;
+    const startAngle = Math.PI;
+    const endAngle = Math.PI - (angle * Math.PI) / 180;
+
+    const arcX1 = cx + r * Math.cos(startAngle);
+    const arcY1 = cy - r * Math.sin(startAngle);
+    const arcX2 = cx + r * Math.cos(endAngle);
+    const arcY2 = cy - r * Math.sin(endAngle);
+    const largeArc = angle > 180 ? 1 : 0;
+
+    return (
+      <div className="flex flex-col items-center justify-center h-[240px]">
+        <svg width="240" height="140" viewBox="0 0 240 140">
+          {/* Background arc */}
+          <path
+            d={`M ${cx - r} ${cy} A ${r} ${r} 0 0 1 ${cx + r} ${cy}`}
+            fill="none"
+            stroke={token.colorBorderSecondary}
+            strokeWidth="12"
+            strokeLinecap="round"
+          />
+          {/* Value arc */}
+          {angle > 0 && (
+            <path
+              d={`M ${arcX1} ${arcY1} A ${r} ${r} 0 ${largeArc} 1 ${arcX2} ${arcY2}`}
+              fill="none"
+              stroke={config.color}
+              strokeWidth="12"
+              strokeLinecap="round"
+            />
+          )}
+          <text
+            x={cx}
+            y={cy + 10}
+            textAnchor="middle"
+            fontSize="18"
+            fontWeight="bold"
+            fill={token.colorText}
+          >
+            {valueFormatter(currentValue)}
+          </text>
+          <text
+            x={cx - r}
+            y={cy + 28}
+            textAnchor="start"
+            fontSize="10"
+            fill={token.colorTextTertiary}
+          >
+            {valueFormatter(min)}
+          </text>
+          <text
+            x={cx + r}
+            y={cy + 28}
+            textAnchor="end"
+            fontSize="10"
+            fill={token.colorTextTertiary}
+          >
+            {valueFormatter(max)}
+          </text>
+        </svg>
+      </div>
+    );
+  };
+
+  const renderChartContent = (config: ChartConfig) => {
+    const gradientId = `series-gradient-${config.key}`;
+
+    if (config.chart === 'gauge') {
+      const latestValue = getLatestSeriesValue(visualizationRows, config.key);
+      const bounds = getSeriesBounds(visualizationRows, config.key);
+      return renderGauge(config, latestValue ?? 0, bounds);
+    }
+
+    if (config.chart === 'bar') {
+      return (
+        <ResponsiveContainer width="100%" height={240}>
+          <BarChart
+            data={visualizationRows}
+            margin={{ left: 4, right: 8, top: 10, bottom: 2 }}
+          >
+            <CartesianGrid
+              vertical={false}
+              strokeDasharray="2 6"
+              stroke={token.colorBorderSecondary}
+            />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatTimestamp}
+              minTickGap={28}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <YAxis
+              width={54}
+              tickFormatter={
+                config.axisFormatter ?? ((value) => formatNumber(value, 1))
+              }
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <Tooltip
+              cursor={{ fill: token.colorFillQuaternary }}
+              contentStyle={{
+                borderRadius: 10,
+                border: `1px solid ${token.colorBorderSecondary}`,
+                boxShadow: token.boxShadowSecondary,
+                background: token.colorBgElevated,
+              }}
+              labelStyle={{ color: token.colorTextSecondary, fontSize: 12 }}
+              labelFormatter={(ts) => formatDateTime(ts as string)}
+              formatter={(value) => {
+                const numericValue =
+                  typeof value === 'number' ? value : Number(value);
+                return [
+                  (config.valueFormatter ?? formatNumber)(numericValue),
+                  config.title,
+                ];
+              }}
+            />
+            <Bar
+              dataKey={config.key}
+              fill={config.color}
+              fillOpacity={0.82}
+              radius={[4, 4, 0, 0]}
+              isAnimationActive={false}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      );
+    }
+
+    if (config.chart === 'line') {
+      return (
+        <ResponsiveContainer width="100%" height={240}>
+          <LineChart
+            data={visualizationRows}
+            margin={{ left: 4, right: 8, top: 10, bottom: 2 }}
+          >
+            <CartesianGrid
+              vertical={false}
+              strokeDasharray="2 6"
+              stroke={token.colorBorderSecondary}
+            />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatTimestamp}
+              minTickGap={28}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <YAxis
+              width={54}
+              tickFormatter={
+                config.axisFormatter ?? ((value) => formatNumber(value, 1))
+              }
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <Tooltip
+              cursor={{ stroke: token.colorBorder, strokeDasharray: '4 4' }}
+              contentStyle={{
+                borderRadius: 10,
+                border: `1px solid ${token.colorBorderSecondary}`,
+                boxShadow: token.boxShadowSecondary,
+                background: token.colorBgElevated,
+              }}
+              labelStyle={{ color: token.colorTextSecondary, fontSize: 12 }}
+              labelFormatter={(ts) => formatDateTime(ts as string)}
+              formatter={(value) => {
+                const numericValue =
+                  typeof value === 'number' ? value : Number(value);
+                return [
+                  (config.valueFormatter ?? formatNumber)(numericValue),
+                  config.title,
+                ];
+              }}
+            />
+            <Line
+              type="monotoneX"
+              dataKey={config.key}
+              stroke={config.color}
+              dot={false}
+              activeDot={{
+                r: 4,
+                fill: config.color,
+                stroke: token.colorBgContainer,
+                strokeWidth: 2,
+              }}
+              strokeWidth={2.4}
+              connectNulls
+              isAnimationActive={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      );
+    }
+
+    // Default: area chart
+    return (
+      <ResponsiveContainer width="100%" height={240}>
+        <AreaChart
+          data={visualizationRows}
+          margin={{ left: 4, right: 8, top: 10, bottom: 2 }}
+        >
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={config.color} stopOpacity={0.24} />
+              <stop offset="65%" stopColor={config.color} stopOpacity={0.08} />
+              <stop offset="100%" stopColor={config.color} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid
+            vertical={false}
+            strokeDasharray="2 6"
+            stroke={token.colorBorderSecondary}
+          />
+          <XAxis
+            dataKey="timestamp"
+            tickFormatter={formatTimestamp}
+            minTickGap={28}
+            axisLine={false}
+            tickLine={false}
+            tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+          />
+          <YAxis
+            width={54}
+            tickFormatter={
+              config.axisFormatter ?? ((value) => formatNumber(value, 1))
+            }
+            axisLine={false}
+            tickLine={false}
+            tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+          />
+          <Tooltip
+            cursor={{ stroke: token.colorBorder, strokeDasharray: '4 4' }}
+            contentStyle={{
+              borderRadius: 10,
+              border: `1px solid ${token.colorBorderSecondary}`,
+              boxShadow: token.boxShadowSecondary,
+              background: token.colorBgElevated,
+            }}
+            labelStyle={{ color: token.colorTextSecondary, fontSize: 12 }}
+            labelFormatter={(ts) => formatDateTime(ts as string)}
+            formatter={(value) => {
+              const numericValue =
+                typeof value === 'number' ? value : Number(value);
+              return [
+                (config.valueFormatter ?? formatNumber)(numericValue),
+                config.title,
+              ];
+            }}
+          />
+          <Area
+            type="monotoneX"
+            dataKey={config.key}
+            stroke={config.color}
+            fill={`url(#${gradientId})`}
+            fillOpacity={1}
+            strokeWidth={2.4}
+            connectNulls
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    );
+  };
+
+  const renderChartCard = (config: ChartConfig) => {
+    const latestValue = getLatestSeriesValue(visualizationRows, config.key);
+    const valueFormatter =
+      config.valueFormatter ?? ((value: number) => formatNumber(value));
+    const bounds = getSeriesBounds(visualizationRows, config.key);
+    const panel = config.panelId
+      ? dashboardConfig?.panels.find((item) => item.id === config.panelId)
+      : undefined;
+
+    return (
+      <Card
+        key={config.panelId ?? config.key}
+        size="small"
+        variant="borderless"
+        className={styles.chartCard}
+        title={
+          <div className={styles.chartHeader}>
+            <div className={styles.chartTitleRow}>
+              <Space size={8} className={styles.chartName}>
+                <Text strong className={styles.chartTitle}>
+                  {config.title}
+                </Text>
+              </Space>
+              <Text className={styles.latestValue}>
+                {typeof latestValue === 'number'
+                  ? valueFormatter(latestValue)
+                  : '--'}
+              </Text>
+            </div>
+            {bounds ? (
+              <Text type="secondary" className={styles.chartRange}>
+                {valueFormatter(bounds.min)} to {valueFormatter(bounds.max)}
+              </Text>
+            ) : null}
+          </div>
+        }
+      >
+        {editMode && panel ? (
+          <Space size="small" className={styles.panelActions}>
+            <Button
+              size="small"
+              type="text"
+              onClick={() => {
+                setEditingPanel(panel);
+                setPanelEditorOpen(true);
+              }}
+            >
+              Edit
+            </Button>
+            <Popconfirm
+              title="Delete this panel?"
+              onConfirm={() => handleDeletePanel(panel.id)}
+            >
+              <Button size="small" type="text" danger>
+                Delete
+              </Button>
+            </Popconfirm>
+          </Space>
+        ) : null}
+        {visualizationRows.length === 0 ? (
+          <LazyChart height={252} loading={visualizationLoading}>
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="No samples in this window"
+            />
+          </LazyChart>
+        ) : (
+          <LazyChart height={252} loading={visualizationLoading}>
+            <div className={styles.chartCanvas}>
+              {renderChartContent(config)}
+            </div>
+          </LazyChart>
+        )}
+      </Card>
+    );
+  };
+
+  return (
+    <Panel>
+      <main className={styles.metricsPage}>
+        <section className={styles.hero}>
+          <div className={styles.heroCopy}>
+            <Text className={styles.eyebrow}>Karmada telemetry</Text>
+            <Title level={2} className={styles.pageTitle}>
+              Control plane metrics
+            </Title>
+            <div className={styles.heroMeta}>
+              <span>{activeComponentLabel}</span>
+              <span>
+                {visualizationPod === 'all' ? 'All pods' : visualizationPod}
+              </span>
+              <span>{generatedAtLabel}</span>
+            </div>
+          </div>
+
+          <div className={styles.heroActions}>
+            <AntTooltip title="Refresh now">
+              <Button
+                icon={<Icons.spinner size={14} />}
+                size="middle"
+                className={styles.refreshButton}
+                loading={refreshVisualizationMutation.isPending}
+                onClick={() => refreshVisualizationMutation.mutate()}
+              />
+            </AntTooltip>
+            <DashboardToolbar
+              editMode={editMode}
+              hasCustomConfig={!!committedConfig}
+              onToggleEdit={() => {
+                if (editMode) {
+                  handleExitEditMode();
+                } else {
+                  handleEnterEditMode();
+                }
+              }}
+              onAddPanel={() => {
+                setEditingPanel(null);
+                setPanelEditorOpen(true);
+              }}
+              onReset={handleResetConfig}
+              onExplore={() => setExplorerOpen(true)}
+              onCopy={handleCopyComponentConfig}
+              exporting={exporting}
+            />
+          </div>
+        </section>
+
+        <Card size="small" variant="borderless" className={styles.scopeCard}>
+          <div className={styles.scopeGrid}>
+            <label className={styles.controlField}>
+              <Text strong className={styles.controlLabel}>
+                Component
+              </Text>
+              <Select
+                size="middle"
+                variant="filled"
+                showSearch={{ optionFilterProp: 'label' }}
+                value={activeComponent}
+                options={KARMADA_COMPONENTS.map((item) => ({
+                  value: item.key,
+                  label: item.label,
+                }))}
+                className={styles.componentSelect}
+                onChange={(value) => {
+                  setActiveComponent(value as KarmadaComponentKey);
+                  setVisualizationPod('all');
+                  setHasInitializedPodSelection(false);
+                  setEditMode(false);
+                }}
+              />
+            </label>
+
+            <label className={styles.controlField}>
+              <Text strong className={styles.controlLabel}>
+                Window
+              </Text>
+              <Select
+                size="middle"
+                variant="filled"
+                value={defaultWindow}
+                disabled
+                options={[{ label: '15 minutes', value: defaultWindow }]}
+                className={styles.windowSelect}
+              />
+            </label>
+
+            <label className={styles.controlField}>
+              <Text strong className={styles.controlLabel}>
+                Pod
+              </Text>
+              <Select
+                size="middle"
+                variant="filled"
+                showSearch={{ optionFilterProp: 'label' }}
+                value={visualizationPod}
+                className={styles.podSelect}
+                options={[
+                  { label: 'All pods (sum)', value: 'all' },
+                  ...visualizationPods.map((pod) => ({
+                    label: pod,
+                    value: pod,
+                  })),
+                ]}
+                onChange={(value) => setVisualizationPod(value)}
+              />
+            </label>
+
+            <div className={styles.scopeMeta}>
+              {visualizationData?.meta?.sampleIntervalSec ? (
+                <Text type="secondary" className={styles.metaLine}>
+                  Sample interval: {visualizationData.meta.sampleIntervalSec}s
+                </Text>
+              ) : null}
+              {visualizationData?.meta?.generatedAt ? (
+                <Text type="secondary" className={styles.metaLine}>
+                  Last fetched: {formatDateTime(visualizationData.meta.generatedAt)}
+                </Text>
+              ) : null}
+            </div>
+          </div>
+        </Card>
+
+        <section className={styles.summaryGrid}>
+          <div className={styles.summaryItem}>
+            <Text className={styles.summaryLabel}>Panels</Text>
+            <Text className={styles.summaryValue}>{visibleCharts.length}</Text>
+          </div>
+          <div className={styles.summaryItem}>
+            <Text className={styles.summaryLabel}>Pods</Text>
+            <Text className={styles.summaryValue}>
+              {visualizationPods.length || '--'}
+            </Text>
+          </div>
+          <div className={styles.summaryItem}>
+            <Text className={styles.summaryLabel}>Sample</Text>
+            <Text className={styles.summaryValue}>{sampleIntervalLabel}</Text>
+          </div>
+          <div className={styles.summaryItem}>
+            <Text className={styles.summaryLabel}>Window</Text>
+            <Text className={styles.summaryValue}>15m</Text>
+          </div>
+        </section>
+
+        {visualizationData?.warnings?.length ? (
+          <Alert
+            type="warning"
+            className={styles.inlineAlert}
+            title="Partial data detected"
+            description={visualizationData.warnings.join(' ')}
+          />
+        ) : null}
+
+        <section className={styles.metricsSection}>
+          {visualizationError && !isNoDataError ? (
+            <Alert
+              type="error"
+              className={styles.inlineAlert}
+              title={`Failed to load ${activeComponent} visualization`}
+              description={visualizationErrorDescription}
+              action={
+                <Button
+                  size="small"
+                  onClick={() => refreshVisualizationMutation.mutate()}
+                >
+                  Retry now
+                </Button>
+              }
+            />
+          ) : isNoDataError ? (
+            <Card
+              size="small"
+              variant="borderless"
+              className={styles.emptyCard}
+            >
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="No metrics available in the selected window. Wait for new samples or switch pod scope."
+              >
+                <Button
+                  size="small"
+                  onClick={() => refreshVisualizationMutation.mutate()}
+                >
+                  Refresh
+                </Button>
+              </Empty>
+            </Card>
+          ) : (
+            <div className="space-y-4">
+              {visibleCharts.length > 0 ? (
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={handleDragEnd}
+                >
+                  <SortableContext
+                    items={panelIds}
+                    strategy={rectSortingStrategy}
+                  >
+                    <div className={styles.chartGrid}>
+                      {visibleCharts.map((chart) => (
+                        <DragPanel
+                          key={chart.panelId ?? chart.key}
+                          id={chart.panelId ?? chart.key}
+                          disabled={!editMode}
+                        >
+                          {renderChartCard(chart)}
+                        </DragPanel>
+                      ))}
+                    </div>
+                  </SortableContext>
+                </DndContext>
+              ) : (
+                <Card
+                  size="small"
+                  variant="borderless"
+                  className={styles.emptyCard}
+                >
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description="No chartable metric series for this scope."
+                  />
+                </Card>
+              )}
+            </div>
+          )}
+        </section>
+        <PanelEditor
+          open={panelEditorOpen}
+          onClose={() => {
+            setPanelEditorOpen(false);
+            setEditingPanel(null);
+          }}
+          onSave={handleSavePanel}
+          catalog={visualizationData?.metricsCatalog ?? []}
+          editingPanel={editingPanel}
+          existingMetricNames={(dashboardConfig?.panels ?? []).map((p) => p.metricName)}
+        />
+        <MetricExplorer
+          open={explorerOpen}
+          onClose={() => setExplorerOpen(false)}
+          onAddToDashboard={handleExplorerAddPanel}
+          catalog={visualizationData?.metricsCatalog ?? []}
+          component={activeComponent}
+          pod={visualizationPod}
+        />
+      </main>
+    </Panel>
+  );
+};
+
+export default MetricsPage;

--- a/ui/apps/dashboard/src/routes/route.tsx
+++ b/ui/apps/dashboard/src/routes/route.tsx
@@ -65,6 +65,7 @@ import MemberClusterRoles from '@/pages/member-cluster/cluster/roles';
 import MemberClusterServiceAccounts from '@/pages/member-cluster/cluster/service-accounts';
 import Login from '@/pages/login';
 import OIDCCallbackPage from '@/pages/login/callback';
+import MetricsPage from '@/pages/metrics';
 import { Icons } from '@/components/icons';
 
 export interface IRouteObjectHandle {
@@ -318,6 +319,15 @@ export function getRoutes() {
               },
             },
           ],
+        },
+        {
+          path: '/metrics',
+          element: <MetricsPage />,
+          handle: {
+            sidebarKey: 'METRICS',
+            sidebarName: 'Metrics',
+            icon: <Icons.metrics {...IconStyles} />,
+          },
         },
       ],
     },

--- a/ui/apps/dashboard/src/services/index.ts
+++ b/ui/apps/dashboard/src/services/index.ts
@@ -89,6 +89,9 @@ export * from './dashboard-config';
 // Overview/statistics
 export * from './overview';
 
+// Metrics scraper
+export * from './metrics';
+
 // Member cluster services
 const memberClusterServices = {
   workload: () => import('./member-cluster/workload'),

--- a/ui/apps/dashboard/src/services/metrics.ts
+++ b/ui/apps/dashboard/src/services/metrics.ts
@@ -1,0 +1,271 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import axios from 'axios';
+import _ from 'lodash';
+
+let pathPrefix = window.__path_prefix__ || '';
+if (!pathPrefix.startsWith('/')) {
+  pathPrefix = '/' + pathPrefix;
+}
+if (!pathPrefix.endsWith('/')) {
+  pathPrefix = pathPrefix + '/';
+}
+
+const metricsBaseURL: string = _.join(
+  [pathPrefix, 'metrics-scraper/api/v1'],
+  '',
+);
+
+export const metricsScraperClient = axios.create({
+  baseURL: metricsBaseURL,
+});
+
+export const KARMADA_COMPONENTS = [
+  { key: 'karmada-scheduler', label: 'Scheduler' },
+  { key: 'karmada-controller-manager', label: 'Controller Manager' },
+  { key: 'karmada-agent', label: 'Agent' },
+  { key: 'karmada-aggregated-apiserver', label: 'Aggregated APIServer' },
+  { key: 'karmada-apiserver', label: 'APIServer' },
+  { key: 'karmada-descheduler', label: 'Descheduler' },
+  { key: 'karmada-kube-controller-manager', label: 'Kube Controller Manager' },
+  { key: 'karmada-metrics-adapter', label: 'Metrics Adapter' },
+  { key: 'karmada-scheduler-estimator-member1', label: 'Scheduler Estimator (member1)' },
+  { key: 'karmada-scheduler-estimator-member2', label: 'Scheduler Estimator (member2)' },
+  { key: 'karmada-scheduler-estimator-member3', label: 'Scheduler Estimator (member3)' },
+  { key: 'karmada-search', label: 'Search' },
+  { key: 'karmada-webhook', label: 'Webhook' },
+] as const;
+
+export type KarmadaComponentKey = (typeof KARMADA_COMPONENTS)[number]['key'];
+
+export interface MetricValue {
+  labels?: Record<string, string>;
+  value: string;
+  measure: string;
+}
+
+export interface Metric {
+  name: string;
+  help: string;
+  type: string;
+  values?: MetricValue[];
+}
+
+export interface ParsedData {
+  currentTime: string;
+  metrics: Record<string, Metric>;
+}
+
+export interface VisualizationPoint {
+  timestamp: string;
+  value: number;
+}
+
+export interface SchedulerVisualizationMeta {
+  appName: string;
+  window: string;
+  podMode: string;
+  sampleIntervalSec: number;
+  generatedAt: string;
+}
+
+export interface MetricInfo {
+  name: string;
+  type: string;
+  suggestedChart: 'line' | 'area' | 'bar' | 'gauge';
+}
+
+export interface MetricCatalogItem {
+  name: string;
+  help: string;
+  prometheusType: 'gauge' | 'counter' | 'histogram' | 'summary';
+  suggestedChart: 'line' | 'area' | 'bar' | 'gauge';
+  group: string;
+}
+
+export interface SchedulerVisualizationResponse {
+  meta: SchedulerVisualizationMeta;
+  timeseries: Record<string, VisualizationPoint[]>;
+  pods: string[];
+  warnings?: string[];
+  availableMetrics?: MetricInfo[];
+  metricsCatalog?: MetricCatalogItem[];
+}
+
+export interface ComponentPodsResponse {
+  appName: string;
+  pods: string[];
+  warnings?: string[];
+}
+
+/** Response from GET /metrics/:app_name — maps pod name → parsed metrics snapshot */
+export type ComponentMetricsResponse = Record<string, ParsedData>;
+
+/** Response from GET /metrics?type=sync_status — maps component name → syncing */
+export type SyncStatusResponse = Record<string, boolean>;
+
+export async function GetComponentMetrics(
+  appName: string,
+): Promise<ComponentMetricsResponse> {
+  const resp =
+    await metricsScraperClient.get<ComponentMetricsResponse>(
+      `/metrics/${appName}`,
+    );
+  return resp.data;
+}
+
+export async function GetSyncStatus(): Promise<SyncStatusResponse> {
+  const resp = await metricsScraperClient.get<SyncStatusResponse>('/metrics', {
+    params: { type: 'sync_status' },
+  });
+  return resp.data;
+}
+
+export async function SetComponentSync(
+  appName: string | null,
+  enabled: boolean,
+): Promise<void> {
+  const type = enabled ? 'sync_on' : 'sync_off';
+  if (appName) {
+    await metricsScraperClient.get(`/metrics/${appName}`, {
+      params: { type },
+    });
+  } else {
+    await metricsScraperClient.get('/metrics', { params: { type } });
+  }
+}
+
+export async function GetSchedulerVisualization(
+  appName: string,
+  params?: {
+    window?: string;
+    pod?: string;
+    refresh?: boolean;
+    metrics?: string[];
+  },
+): Promise<SchedulerVisualizationResponse> {
+  const queryParams: Record<string, string | boolean | undefined> = {
+    window: params?.window,
+    pod: params?.pod,
+    refresh: params?.refresh,
+  };
+  if (params?.metrics?.length) {
+    queryParams.metrics = params.metrics.join(',');
+  }
+  const resp =
+    await metricsScraperClient.get<SchedulerVisualizationResponse>(
+      `/metrics/${appName}/visualization`,
+      { params: queryParams },
+    );
+  return resp.data;
+}
+
+export async function GetComponentPods(
+  appName: string,
+): Promise<ComponentPodsResponse> {
+  const resp = await metricsScraperClient.get<ComponentPodsResponse>(
+    `/metrics/${appName}/pods`,
+  );
+  return resp.data;
+}
+
+export interface LabelFilter {
+  key: string;
+  value: string;
+}
+
+export interface ExploreResponse {
+  meta: {
+    metric: string;
+    aggregation: string;
+    labels: LabelFilter[];
+    window: string;
+    podMode: string;
+    generatedAt: string;
+  };
+  timeseries: VisualizationPoint[];
+  availableLabels: Record<string, string[]>;
+}
+
+export async function ExploreMetric(
+  appName: string,
+  params: {
+    metric: string;
+    aggregation?: string;
+    labels?: LabelFilter[];
+    window?: string;
+    pod?: string;
+  },
+): Promise<ExploreResponse> {
+  const queryParams: Record<string, string | undefined> = {
+    metric: params.metric,
+    aggregation: params.aggregation,
+    window: params.window,
+    pod: params.pod,
+  };
+  if (params.labels?.length) {
+    queryParams.labels = JSON.stringify(params.labels);
+  }
+  const resp = await metricsScraperClient.get<ExploreResponse>(
+    `/metrics/${appName}/explore`,
+    { params: queryParams },
+  );
+  return resp.data;
+}
+
+export interface MetricsDashboardPanel {
+  id: string;
+  metricName: string;
+  chartType: 'line' | 'area' | 'bar' | 'gauge';
+  title: string;
+  visible: boolean;
+  query?: {
+    metric: string;
+    aggregation: string;
+    labelFilters?: { key: string; value: string }[];
+  };
+  order?: number;
+}
+
+export interface MetricsDashboard {
+  version: number;
+  component: string;
+  panels: MetricsDashboardPanel[];
+}
+
+export interface MetricsDashboardConfigResponse {
+  dashboards: MetricsDashboard[];
+}
+
+/** Fetch all persisted metrics dashboards (from the dashboard ConfigMap). */
+export async function GetMetricsDashboards(): Promise<MetricsDashboard[]> {
+  const resp = await metricsScraperClient.get<MetricsDashboardConfigResponse>(
+    '/metrics-config',
+  );
+  return resp.data?.dashboards ?? [];
+}
+
+/** Persist (upsert) a single component's metrics dashboard to the ConfigMap. */
+export async function SaveMetricsDashboard(
+  dashboard: MetricsDashboard,
+): Promise<MetricsDashboard[]> {
+  const resp = await metricsScraperClient.put<MetricsDashboardConfigResponse>(
+    '/metrics-config',
+    { dashboard },
+  );
+  return resp.data?.dashboards ?? [];
+}

--- a/ui/apps/dashboard/vite.config.ts
+++ b/ui/apps/dashboard/vite.config.ts
@@ -127,6 +127,10 @@ export default defineConfig(({ mode }) => {
           secure: false,
           ws: true,
         },
+        '^/metrics-scraper/.*': {
+          target: 'http://localhost:8000',
+          changeOrigin: true,
+        },
       },
     },
   };

--- a/ui/apps/dashboard/vite.config.ts
+++ b/ui/apps/dashboard/vite.config.ts
@@ -74,7 +74,24 @@ export default defineConfig(({ mode }) => {
       }),
     ],
     resolve: {
-      alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
+      alias: [
+        { find: '@', replacement: path.resolve(__dirname, 'src') },
+        // Vite 8 + rolldown has a CJS transform issue with es-toolkit compat modules
+        // used by recharts. Map them to equivalent lodash helpers to avoid runtime errors.
+        { find: 'es-toolkit/compat/get', replacement: 'lodash/get' },
+        { find: 'es-toolkit/compat/sortBy', replacement: 'lodash/sortBy' },
+        { find: 'es-toolkit/compat/maxBy', replacement: 'lodash/maxBy' },
+        { find: 'es-toolkit/compat/sumBy', replacement: 'lodash/sumBy' },
+        { find: 'es-toolkit/compat/throttle', replacement: 'lodash/throttle' },
+        { find: 'es-toolkit/compat/omit', replacement: 'lodash/omit' },
+        { find: 'es-toolkit/compat/minBy', replacement: 'lodash/minBy' },
+        { find: 'es-toolkit/compat/last', replacement: 'lodash/last' },
+        { find: 'es-toolkit/compat/range', replacement: 'lodash/range' },
+        { find: 'es-toolkit/compat/isPlainObject', replacement: 'lodash/isPlainObject' },
+        { find: 'es-toolkit/compat/uniqBy', replacement: 'lodash/uniqBy' },
+        { find: 'react', replacement: path.resolve(__dirname, 'node_modules/react') },
+        { find: 'react-dom', replacement: path.resolve(__dirname, 'node_modules/react-dom') },
+      ],
       dedupe: ['react', 'react-dom'],
     },
     optimizeDeps: {

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -51,6 +51,15 @@ importers:
       '@chatui/core':
         specifier: ^3.8.0
         version: 3.8.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.7)
       '@karmada/chatui':
         specifier: workspace:*
         version: link:../../packages/chatui
@@ -83,7 +92,7 @@ importers:
         version: 6.0.0
       '@xyflow/react':
         specifier: ^12.10.2
-        version: 12.10.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 12.10.2(@types/react@19.2.17)(immer@11.1.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       antd:
         specifier: ^6.5.0
         version: 6.5.0(moment@2.30.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -126,6 +135,9 @@ importers:
       react-router-dom:
         specifier: ^7.14.2
         version: 7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.10.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)
       sockjs-client:
         specifier: ^1.6.1
         version: 1.6.1
@@ -137,7 +149,7 @@ importers:
         version: 2.9.0
       zustand:
         specifier: ^5.0.14
-        version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+        version: 5.0.14(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     devDependencies:
       '@karmada/eslint-config-ts-react':
         specifier: workspace:*
@@ -668,6 +680,28 @@ packages:
     peerDependencies:
       react: ^19.2.7
       react-dom: ^19.2.7
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: ^19.2.7
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: ^19.2.7
+      react-dom: ^19.2.7
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: ^19.2.7
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: ^19.2.7
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1446,6 +1480,17 @@ packages:
       react: ^19.2.7
       react-dom: ^19.2.7
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^19.2.7
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1805,6 +1850,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
     engines: {node: '>=14'}
@@ -2102,17 +2150,38 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
   '@types/d3-drag@3.0.7':
     resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
 
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
 
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
   '@types/d3-selection@3.0.11':
     resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/d3-transition@3.0.9':
     resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
@@ -2193,6 +2262,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.64.0':
     resolution: {integrity: sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==}
@@ -2778,6 +2850,10 @@ packages:
   csv-parse@7.0.0:
     resolution: {integrity: sha512-CSssqPAK5us09FhMI9juM0jnqXUJP+rtWeIfivTYBLNH/8rnxkQlZvoRemF6MAyfNov9XU8mN2wwF/pP68sxTA==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
@@ -2794,12 +2870,36 @@ packages:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
     engines: {node: '>=12'}
 
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
 
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
   d3-selection@3.0.0:
     resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
     engines: {node: '>=12'}
 
   d3-timer@3.0.1:
@@ -2861,6 +2961,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decompress-response@10.0.0:
     resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
@@ -2996,6 +3099,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   esbuild@0.27.0:
     resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
@@ -3456,6 +3562,9 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
+  immer@11.1.15:
+    resolution: {integrity: sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -3474,6 +3583,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   intersection-observer@0.12.2:
     resolution: {integrity: sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==}
@@ -4312,6 +4425,18 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^19.2.7
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-router-dom@7.14.2:
     resolution: {integrity: sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==}
     engines: {node: '>=20.0.0'}
@@ -4341,6 +4466,22 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  recharts@3.10.0:
+    resolution: {integrity: sha512-wulMvfncpIlmu2uFtRU/mE5/+NiVtASXkw2KdwJTdHs3WsASX0WxZlX+rpKgyn5BDbIhkPtCpUKkB9XNK5KE0w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^19.2.7
+      react-dom: ^19.2.7
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -4351,6 +4492,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -4699,6 +4843,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -4850,6 +4997,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^19.2.7
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-plugin-banner@0.8.1:
     resolution: {integrity: sha512-0+gGguHk3MH0HvzMSOCJC6fGgH4+jtY9KlKVZh+hwwE+PBkGVzY8xe657JL74vEgbeUJD37XjVqTrmve8XvZBQ==}
@@ -5439,6 +5589,31 @@ snapshots:
       intersection-observer: 0.12.2
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -6163,6 +6338,18 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.15
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 19.2.7
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -6359,6 +6546,8 @@ snapshots:
   '@sindresorhus/is@7.2.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
@@ -6594,17 +6783,35 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
   '@types/d3-color@3.1.3': {}
 
   '@types/d3-drag@3.0.7':
     dependencies:
       '@types/d3-selection': 3.0.11
 
+  '@types/d3-ease@3.0.2': {}
+
   '@types/d3-interpolate@3.0.4':
     dependencies:
       '@types/d3-color': 3.1.3
 
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
   '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/d3-transition@3.0.9':
     dependencies:
@@ -6683,6 +6890,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.61.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -6999,13 +7208,13 @@ snapshots:
 
   '@xterm/xterm@6.0.0': {}
 
-  '@xyflow/react@12.10.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@xyflow/react@12.10.2(@types/react@19.2.17)(immer@11.1.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@xyflow/system': 0.0.76
       classcat: 5.0.5
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      zustand: 4.5.7(@types/react@19.2.17)(react@19.2.7)
+      zustand: 4.5.7(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -7412,6 +7621,10 @@ snapshots:
 
   csv-parse@7.0.0: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
   d3-color@3.1.0: {}
 
   d3-dispatch@3.0.1: {}
@@ -7423,11 +7636,35 @@ snapshots:
 
   d3-ease@3.0.1: {}
 
+  d3-format@3.1.2: {}
+
   d3-interpolate@3.0.1:
     dependencies:
       d3-color: 3.1.0
 
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
   d3-selection@3.0.0: {}
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
 
@@ -7487,6 +7724,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decompress-response@10.0.0:
     dependencies:
@@ -7694,6 +7933,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.49.0: {}
 
   esbuild@0.27.0:
     optionalDependencies:
@@ -8282,6 +8523,8 @@ snapshots:
 
   ignore@7.0.6: {}
 
+  immer@11.1.15: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -8301,6 +8544,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   intersection-observer@0.12.2: {}
 
@@ -9070,6 +9315,15 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      redux: 5.0.1
+
   react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -9095,6 +9349,32 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  recharts@3.10.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.49.0
+      eventemitter3: 5.0.4
+      immer: 11.1.15
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-is: 18.3.1
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
+      reselect: 5.2.0
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -9116,6 +9396,8 @@ snapshots:
       set-function-name: 2.0.2
 
   requires-port@1.0.0: {}
+
+  reselect@5.2.0: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -9575,6 +9857,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -9737,6 +10021,23 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-plugin-banner@0.8.1: {}
 
@@ -9934,15 +10235,17 @@ snapshots:
 
   zod@4.2.1: {}
 
-  zustand@4.5.7(@types/react@19.2.17)(react@19.2.7):
+  zustand@4.5.7(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7):
     dependencies:
       use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
+      immer: 11.1.15
       react: 19.2.7
 
-  zustand@5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
+  zustand@5.0.14(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:
       '@types/react': 19.2.17
+      immer: 11.1.15
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

Adds end-to-end component metrics support for Karmada Dashboard:

- collect, aggregate, store, and query component metrics in metrics-scraper
- add configurable component metrics dashboards and visualization in the frontend
- deploy and proxy metrics-scraper through manifests and Helm chart configuration
- allow dashboard editing by default and copying the active component metrics JSON

The implementation is organized into three reviewable commits for metrics collection, frontend visualization, and deployment.

## Which issue(s) this PR fixes

None

## Special notes for reviewers

Frontend validation completed:

- dashboard config unit tests: 5 passed
- targeted ESLint
- TypeScript compilation
- Vite production build

Backend tests were not rerun locally because the available Go toolchain is Go 1.18 while this repository requires Go 1.25.10.