### PR TITLE
feat(metrics-scraper): collect, store, and query component metrics

### DIFF
--- a/cmd/metrics-scraper/app/db/consts.go
+++ b/cmd/metrics-scraper/app/db/consts.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package db
 
+import "strings"
+
 const (
 	// Namespace is the namespace of karmada.
 	Namespace = "karmada-system"
@@ -27,8 +29,112 @@ const (
 	KarmadaSchedulerEstimator = "karmada-scheduler-estimator"
 	// KarmadaControllerManager is the name of karmada controller manager.
 	KarmadaControllerManager = "karmada-controller-manager"
-	// SchedulerPort is the port of karmada scheduler.
-	SchedulerPort = "10351"
-	// ControllerManagerPort is the port of karmada controller manager.
-	ControllerManagerPort = "8080"
+	// KarmadaAggregatedAPIServer is the name of karmada aggregated apiserver.
+	KarmadaAggregatedAPIServer = "karmada-aggregated-apiserver"
+	// KarmadaAPIServer is the name of karmada apiserver.
+	KarmadaAPIServer = "karmada-apiserver"
+	// KarmadaDescheduler is the name of karmada descheduler.
+	KarmadaDescheduler = "karmada-descheduler"
+	// KarmadaKubeControllerManager is the name of karmada kube controller manager.
+	KarmadaKubeControllerManager = "karmada-kube-controller-manager"
+	// KarmadaMetricsAdapter is the name of karmada metrics adapter.
+	KarmadaMetricsAdapter = "karmada-metrics-adapter"
+	// KarmadaSearch is the name of karmada search.
+	KarmadaSearch = "karmada-search"
+	// KarmadaWebhook is the name of karmada webhook.
+	KarmadaWebhook = "karmada-webhook"
+
+	// DefaultMetricsPort is used by Karmada components that expose a dedicated
+	// controller-runtime metrics listener.
+	DefaultMetricsPort = "8080"
 )
+
+// ComponentConfig holds the scrape configuration for a single Karmada component.
+type ComponentConfig struct {
+	// Name is the component name used by the dashboard and metrics database.
+	Name string
+	// LabelSelector selects the component pods in the host cluster.
+	LabelSelector string
+	// Port is the metrics port.
+	Port string
+	// Scheme is "http" or "https".
+	Scheme string
+	// MetricsPath is the path to the metrics endpoint (default "/metrics").
+	MetricsPath string
+	// ServerName is used to verify a secure component's serving certificate
+	// while connecting directly to its pod IP.
+	ServerName string
+	// InsecureSkipVerify is reserved for components such as the upstream
+	// kube-controller-manager that generate an ephemeral self-signed serving
+	// certificate which cannot be validated with the Karmada CA.
+	InsecureSkipVerify bool
+}
+
+// AllComponents returns the full list of scrapeable Karmada control-plane components.
+func AllComponents() []ComponentConfig {
+	return []ComponentConfig{
+		{Name: KarmadaScheduler, LabelSelector: "app=" + KarmadaScheduler, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+		{Name: KarmadaControllerManager, LabelSelector: "app=" + KarmadaControllerManager, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+		{Name: KarmadaAgent, LabelSelector: "app=" + KarmadaAgent, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+		{Name: KarmadaSchedulerEstimator, LabelSelector: "app=" + KarmadaSchedulerEstimator, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+		{Name: KarmadaAggregatedAPIServer, LabelSelector: "app=" + KarmadaAggregatedAPIServer, Port: "443", Scheme: "https", MetricsPath: "/metrics", ServerName: serviceServerName(KarmadaAggregatedAPIServer)},
+		{Name: KarmadaAPIServer, LabelSelector: "app=" + KarmadaAPIServer, Port: "5443", Scheme: "https", MetricsPath: "/metrics", ServerName: serviceServerName(KarmadaAPIServer)},
+		{Name: KarmadaDescheduler, LabelSelector: "app=" + KarmadaDescheduler, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+		// kube-controller-manager generates an ephemeral self-signed serving
+		// certificate for 127.0.0.1 even when it binds to all interfaces.
+		{Name: KarmadaKubeControllerManager, LabelSelector: "app=kube-controller-manager", Port: "10257", Scheme: "https", MetricsPath: "/metrics", InsecureSkipVerify: true},
+		{Name: KarmadaMetricsAdapter, LabelSelector: "app=" + KarmadaMetricsAdapter, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+		{Name: KarmadaSearch, LabelSelector: "app=" + KarmadaSearch, Port: "443", Scheme: "https", MetricsPath: "/metrics", ServerName: serviceServerName(KarmadaSearch)},
+		{Name: KarmadaWebhook, LabelSelector: "app=" + KarmadaWebhook, Port: DefaultMetricsPort, Scheme: "http", MetricsPath: "/metrics"},
+	}
+}
+
+func serviceServerName(component string) string {
+	return component + "." + Namespace + ".svc"
+}
+
+// GetComponentConfig returns the ComponentConfig for the given app name, or nil if not found.
+func GetComponentConfig(appName string) *ComponentConfig {
+	for _, c := range AllComponents() {
+		if c.Name == appName {
+			return &c
+		}
+		if c.Name == KarmadaSchedulerEstimator && strings.HasPrefix(appName, KarmadaSchedulerEstimator+"-") {
+			c.Name = appName
+			c.LabelSelector = "app=" + appName
+			return &c
+		}
+	}
+	return nil
+}
+
+// MetricTier defines storage priority for metrics.
+type MetricTier int
+
+const (
+	// TierHigh - always stored at full resolution (process_*, workqueue_*, go_goroutines, go_threads).
+	TierHigh MetricTier = iota
+	// TierMedium - stored every scrape but without histogram buckets.
+	TierMedium
+	// TierLow - sampled every 3rd scrape (rest_client_*, etcd_*, apiserver_*).
+	TierLow
+)
+
+// GetMetricTier returns the storage tier for a metric based on its name prefix.
+func GetMetricTier(metricName string) MetricTier {
+	// High priority: core operational metrics
+	highPrefixes := []string{"process_", "workqueue_", "go_goroutines", "go_threads", "go_memstats_"}
+	for _, p := range highPrefixes {
+		if strings.HasPrefix(metricName, p) {
+			return TierHigh
+		}
+	}
+	// Low priority: verbose client/etcd/apiserver metrics
+	lowPrefixes := []string{"rest_client_", "etcd_", "apiserver_request_", "reflector_"}
+	for _, p := range lowPrefixes {
+		if strings.HasPrefix(metricName, p) {
+			return TierLow
+		}
+	}
+	return TierMedium
+}

--- a/cmd/metrics-scraper/app/db/consts_test.go
+++ b/cmd/metrics-scraper/app/db/consts_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package db
+
+import "testing"
+
+func TestComponentScrapeConfigs(t *testing.T) {
+	tests := []struct {
+		name       string
+		port       string
+		scheme     string
+		selector   string
+		serverName string
+		insecure   bool
+	}{
+		{KarmadaScheduler, "8080", "http", "app=karmada-scheduler", "", false},
+		{KarmadaDescheduler, "8080", "http", "app=karmada-descheduler", "", false},
+		{KarmadaWebhook, "8080", "http", "app=karmada-webhook", "", false},
+		{KarmadaAggregatedAPIServer, "443", "https", "app=karmada-aggregated-apiserver", "karmada-aggregated-apiserver.karmada-system.svc", false},
+		{KarmadaAPIServer, "5443", "https", "app=karmada-apiserver", "karmada-apiserver.karmada-system.svc", false},
+		{KarmadaSearch, "443", "https", "app=karmada-search", "karmada-search.karmada-system.svc", false},
+		{KarmadaKubeControllerManager, "10257", "https", "app=kube-controller-manager", "", true},
+		{KarmadaSchedulerEstimator + "-member1", "8080", "http", "app=karmada-scheduler-estimator-member1", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := GetComponentConfig(tt.name)
+			if cfg == nil {
+				t.Fatalf("GetComponentConfig(%q) returned nil", tt.name)
+			}
+			if cfg.Port != tt.port || cfg.Scheme != tt.scheme || cfg.LabelSelector != tt.selector || cfg.ServerName != tt.serverName || cfg.InsecureSkipVerify != tt.insecure {
+				t.Fatalf("GetComponentConfig(%q) = %#v, want port=%q scheme=%q selector=%q serverName=%q insecure=%t", tt.name, cfg, tt.port, tt.scheme, tt.selector, tt.serverName, tt.insecure)
+			}
+		})
+	}
+}
+
+func TestGetComponentConfigRejectsUnknownComponent(t *testing.T) {
+	if cfg := GetComponentConfig("not-a-karmada-component"); cfg != nil {
+		t.Fatalf("expected nil config, got %#v", cfg)
+	}
+}

--- a/cmd/metrics-scraper/app/db/models.go
+++ b/cmd/metrics-scraper/app/db/models.go
@@ -19,6 +19,7 @@ package db
 // PodInfo is the pod info.
 type PodInfo struct {
 	Name string `json:"name"`
+	IP   string `json:"ip"`
 }
 
 // Metric is the metric info.

--- a/cmd/metrics-scraper/app/metricsscraper.go
+++ b/cmd/metrics-scraper/app/metricsscraper.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/karmada-io/karmada/pkg/sharedcli/klogflag"
 	"github.com/spf13/cobra"
@@ -88,7 +89,11 @@ func run(ctx context.Context, opts *options.Options) error {
 	)
 	ensureAPIServerConnectionOrDie()
 	serve(opts)
-	go scrape.InitDatabase()
+	scrapeInterval := opts.ScrapeInterval
+	if scrapeInterval <= 0 {
+		scrapeInterval = 10 * time.Second
+	}
+	go scrape.InitDatabase(scrapeInterval)
 
 	config.InitDashboardConfig(client.InClusterClient(), ctx.Done())
 	<-ctx.Done()
@@ -126,7 +131,12 @@ func init() {
 	r := router.V1()
 	r.GET("/metrics", metrics.GetMetrics)
 	r.GET("/metrics/:app_name", metrics.GetMetrics)
+	r.GET("/metrics/:app_name/visualization", metrics.GetVisualization)
+	r.GET("/metrics/:app_name/explore", metrics.GetMetricExplore)
+	r.GET("/metrics/:app_name/pods", metrics.GetComponentPods)
 	r.GET("/metrics/:app_name/:pod_name", metrics.QueryMetrics)
+	r.GET("/metrics-config", metrics.GetDashboardConfig)
+	r.PUT("/metrics-config", metrics.SaveDashboardConfig)
 }
 
 // http://localhost:8000/api/v1/metrics/karmada-scheduler?type=metricsdetails  //from sqlite details bar

--- a/cmd/metrics-scraper/app/options/options.go
+++ b/cmd/metrics-scraper/app/options/options.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"net"
+	"time"
 
 	"github.com/spf13/pflag"
 )
@@ -35,6 +36,7 @@ type Options struct {
 	KarmadaContext                string
 	SkipKarmadaApiserverTLSVerify bool
 	Namespace                     string
+	ScrapeInterval                time.Duration
 	DisableCSRFProtection         bool
 	OpenAPIEnabled                bool
 }
@@ -60,6 +62,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.KarmadaContext, "karmada-context", "", "The name of the karmada-kubeconfig context to use.")
 	fs.BoolVar(&o.SkipKarmadaApiserverTLSVerify, "skip-karmada-apiserver-tls-verify", false, "enable if connection with remote Karmada API server should skip TLS verify")
 	fs.StringVar(&o.Namespace, "namespace", "karmada-dashboard", "Namespace to use when accessing Dashboard specific resources, i.e. configmap")
+	fs.DurationVar(&o.ScrapeInterval, "scrape-interval", 10*time.Second, "Interval between metrics scrape cycles, e.g. 5s, 30s, 1m")
 	fs.BoolVar(&o.DisableCSRFProtection, "disable-csrf-protection", false, "allows disabling CSRF protection")
 	fs.BoolVar(&o.OpenAPIEnabled, "openapi-enabled", false, "enables OpenAPI v2 endpoint under '/apidocs.json'")
 }

--- a/cmd/metrics-scraper/app/routes/metrics/config.go
+++ b/cmd/metrics-scraper/app/routes/metrics/config.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/karmada-io/dashboard/pkg/client"
+	"github.com/karmada-io/dashboard/pkg/config"
+)
+
+// GetDashboardConfig returns the persisted metrics dashboards for every component.
+func GetDashboardConfig(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"dashboards": config.GetMetricsDashboards(),
+	})
+}
+
+// SaveDashboardConfig persists (upserts) the metrics dashboard for a single
+// component into the dashboard ConfigMap so it is shared across browsers.
+func SaveDashboardConfig(c *gin.Context) {
+	var body struct {
+		Dashboard config.MetricsDashboard `json:"dashboard"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body: " + err.Error()})
+		return
+	}
+	if strings.TrimSpace(body.Dashboard.Component) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "dashboard.component is required"})
+		return
+	}
+
+	if err := config.UpsertMetricsDashboard(client.InClusterClient(), body.Dashboard); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to persist config: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"dashboards": config.GetMetricsDashboards(),
+	})
+}

--- a/cmd/metrics-scraper/app/routes/metrics/explore.go
+++ b/cmd/metrics-scraper/app/routes/metrics/explore.go
@@ -1,0 +1,452 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const defaultExploreAggregation = "sum"
+
+// LabelFilter defines a label matcher for metric exploration.
+type LabelFilter struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// ExploreMeta is metadata for metric exploration responses.
+type ExploreMeta struct {
+	Metric      string        `json:"metric"`
+	Aggregation string        `json:"aggregation"`
+	Labels      []LabelFilter `json:"labels"`
+	Window      string        `json:"window"`
+	PodMode     string        `json:"podMode"`
+	GeneratedAt string        `json:"generatedAt"`
+}
+
+// ExploreResponse is the API contract for metric exploration.
+type ExploreResponse struct {
+	Meta            ExploreMeta         `json:"meta"`
+	Timeseries      []Point             `json:"timeseries"`
+	AvailableLabels map[string][]string `json:"availableLabels"`
+}
+
+type exploreBucket struct {
+	Sum      float64
+	Count    int64
+	Max      float64
+	Min      float64
+	HasValue bool
+}
+
+func (b *exploreBucket) merge(sum float64, count int64, max, min float64) {
+	b.Sum += sum
+	b.Count += count
+	if !b.HasValue || max > b.Max {
+		b.Max = max
+	}
+	if !b.HasValue || min < b.Min {
+		b.Min = min
+	}
+	b.HasValue = true
+}
+
+// GetMetricExplore returns a single metric series with configurable aggregation and label filtering.
+func GetMetricExplore(c *gin.Context) {
+	appName := c.Param("app_name")
+	metricName := strings.TrimSpace(c.Query("metric"))
+	if metricName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "metric is required"})
+		return
+	}
+
+	aggregation, err := parseExploreAggregation(c.Query("aggregation"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	labels, err := parseLabelFilters(c.Query("labels"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	window, err := parseWindow(c.Query("window"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	podMode := c.DefaultQuery("pod", defaultPodMode)
+	dbConn, err := getDBFunc(appName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open metrics database"})
+		return
+	}
+
+	podTables, err := listPodTables(dbConn)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to list %s pod tables", appName)})
+		return
+	}
+	if len(podTables) == 0 {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": fmt.Sprintf("no %s metrics data found", appName)})
+		return
+	}
+
+	selectedTables, err := selectPodTables(podTables, podMode)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	measure, err := determineExploreMeasure(dbConn, selectedTables, metricName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to resolve metric metadata: %v", err)})
+		return
+	}
+
+	availableLabels, err := queryAvailableLabels(dbConn, selectedTables, metricName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to query metric labels: %v", err)})
+		return
+	}
+
+	cutoff := time.Now().Add(-window)
+	points, err := queryMetricExploreSeries(dbConn, selectedTables, metricName, measure, aggregation, labels, cutoff)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to query metric timeseries: %v", err)})
+		return
+	}
+	if points == nil {
+		points = []Point{}
+	}
+
+	c.JSON(http.StatusOK, ExploreResponse{
+		Meta: ExploreMeta{
+			Metric:      metricName,
+			Aggregation: aggregation,
+			Labels:      labels,
+			Window:      window.String(),
+			PodMode:     podMode,
+			GeneratedAt: time.Now().Format(time.RFC3339),
+		},
+		Timeseries:      points,
+		AvailableLabels: availableLabels,
+	})
+}
+
+func parseExploreAggregation(raw string) (string, error) {
+	if raw == "" {
+		return defaultExploreAggregation, nil
+	}
+
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch value {
+	case "sum", "avg", "max", "min", "rate":
+		return value, nil
+	default:
+		return "", fmt.Errorf("invalid aggregation %q, expected one of sum, avg, max, min, rate", raw)
+	}
+}
+
+func parseLabelFilters(raw string) ([]LabelFilter, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+
+	var filters []LabelFilter
+	if err := json.Unmarshal([]byte(raw), &filters); err != nil {
+		return nil, fmt.Errorf("invalid labels, expected JSON array of {key,value}: %w", err)
+	}
+
+	for _, filter := range filters {
+		if strings.TrimSpace(filter.Key) == "" {
+			return nil, fmt.Errorf("invalid labels, key must not be empty")
+		}
+	}
+	return filters, nil
+}
+
+func determineExploreMeasure(dbConn *sql.DB, podTables []string, metricName string) (string, error) {
+	for _, table := range podTables {
+		metadataQuery := fmt.Sprintf(`
+			SELECT COALESCE(type, '')
+			FROM %s_metadata
+			WHERE name = ?
+			LIMIT 1
+		`, table)
+
+		var metricType string
+		err := dbConn.QueryRow(metadataQuery, metricName).Scan(&metricType)
+		switch {
+		case err == nil:
+			return primaryMeasureForType(normalizePrometheusType(metricType)), nil
+		case err == sql.ErrNoRows:
+			continue
+		case strings.Contains(err.Error(), "no such table"):
+			continue
+		default:
+			return "", err
+		}
+	}
+
+	measurePriority := []string{"total", "current_value", "sum", "count"}
+	measureSet := map[string]struct{}{}
+	for _, table := range podTables {
+		measureQuery := fmt.Sprintf(`
+			SELECT DISTINCT v.measure
+			FROM %s m
+			INNER JOIN %s_values v ON m.id = v.metric_id
+			WHERE m.name = ?
+		`, table, table)
+		rows, err := dbConn.Query(measureQuery, metricName)
+		if err != nil {
+			return "", err
+		}
+		for rows.Next() {
+			var measure string
+			if scanErr := rows.Scan(&measure); scanErr != nil {
+				rows.Close()
+				return "", scanErr
+			}
+			measureSet[measure] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return "", err
+		}
+		rows.Close()
+	}
+
+	for _, measure := range measurePriority {
+		if _, ok := measureSet[measure]; ok {
+			return measure, nil
+		}
+	}
+	return primaryMeasureForType("gauge"), nil
+}
+
+func queryAvailableLabels(dbConn *sql.DB, podTables []string, metricName string) (map[string][]string, error) {
+	labelSet := make(map[string]map[string]struct{})
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+
+	for _, table := range podTables {
+		wg.Add(1)
+		go func(table string) {
+			defer wg.Done()
+
+			query := fmt.Sprintf(`
+				SELECT DISTINCT ls.key, ls.value
+				FROM %s m
+				INNER JOIN %s_values v ON m.id = v.metric_id
+				INNER JOIN %s_labels l ON v.id = l.value_id
+				INNER JOIN %s_label_strings ls ON l.label_string_id = ls.id
+				WHERE m.name = ?
+			`, table, table, table, table)
+			rows, err := dbConn.Query(query, metricName)
+			if err != nil {
+				if strings.Contains(err.Error(), "no such table") {
+					return
+				}
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+			defer rows.Close()
+
+			local := make(map[string]map[string]struct{})
+			for rows.Next() {
+				var key, value string
+				if scanErr := rows.Scan(&key, &value); scanErr != nil {
+					errOnce.Do(func() { firstErr = scanErr })
+					return
+				}
+				if _, ok := local[key]; !ok {
+					local[key] = make(map[string]struct{})
+				}
+				local[key][value] = struct{}{}
+			}
+			if err := rows.Err(); err != nil {
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+
+			mu.Lock()
+			for key, values := range local {
+				if _, ok := labelSet[key]; !ok {
+					labelSet[key] = make(map[string]struct{})
+				}
+				for value := range values {
+					labelSet[key][value] = struct{}{}
+				}
+			}
+			mu.Unlock()
+		}(table)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	result := make(map[string][]string, len(labelSet))
+	for key, values := range labelSet {
+		result[key] = mapKeys(values)
+	}
+	return result, nil
+}
+
+func queryMetricExploreSeries(dbConn *sql.DB, podTables []string, metricName, measure, aggregation string, labels []LabelFilter, cutoff time.Time) ([]Point, error) {
+	buckets := make(map[time.Time]*exploreBucket)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+
+	for _, table := range podTables {
+		wg.Add(1)
+		go func(table string) {
+			defer wg.Done()
+
+			query, args := buildExploreSeriesQuery(table, metricName, measure, labels, cutoff)
+			rows, err := dbConn.Query(query, args...)
+			if err != nil {
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+			defer rows.Close()
+
+			localBuckets := make(map[time.Time]*exploreBucket)
+			for rows.Next() {
+				var currentTimeRaw string
+				var sum, max, min float64
+				var count int64
+				if scanErr := rows.Scan(&currentTimeRaw, &sum, &count, &max, &min); scanErr != nil {
+					errOnce.Do(func() { firstErr = scanErr })
+					return
+				}
+
+				currentTime, parseErr := parseCurrentTime(currentTimeRaw)
+				if parseErr != nil {
+					continue
+				}
+				normalized := currentTime.UTC().Truncate(time.Second)
+				bucket, ok := localBuckets[normalized]
+				if !ok {
+					bucket = &exploreBucket{}
+					localBuckets[normalized] = bucket
+				}
+				bucket.merge(sum, count, max, min)
+			}
+			if err := rows.Err(); err != nil {
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+
+			mu.Lock()
+			for ts, localBucket := range localBuckets {
+				bucket, ok := buckets[ts]
+				if !ok {
+					bucket = &exploreBucket{}
+					buckets[ts] = bucket
+				}
+				bucket.merge(localBucket.Sum, localBucket.Count, localBucket.Max, localBucket.Min)
+			}
+			mu.Unlock()
+		}(table)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	values := make(map[time.Time]float64, len(buckets))
+	for ts, bucket := range buckets {
+		if !bucket.HasValue {
+			continue
+		}
+		switch aggregation {
+		case "avg":
+			if bucket.Count > 0 {
+				values[ts] = bucket.Sum / float64(bucket.Count)
+			}
+		case "max":
+			values[ts] = bucket.Max
+		case "min":
+			values[ts] = bucket.Min
+		default:
+			values[ts] = bucket.Sum
+		}
+	}
+
+	points := mapToPoints(values)
+	if aggregation == "rate" {
+		return counterRate(points), nil
+	}
+	return points, nil
+}
+
+func buildExploreSeriesQuery(table, metricName, measure string, labels []LabelFilter, cutoff time.Time) (string, []any) {
+	query := fmt.Sprintf(`
+		SELECT m.currentTime, SUM(v.value), COUNT(v.value), MAX(v.value), MIN(v.value)
+		FROM %s m
+		INNER JOIN %s_values v ON m.id = v.metric_id
+		WHERE m.name = ? AND v.measure = ? AND m.currentTime >= ?
+	`, table, table)
+	args := []any{metricName, measure, cutoff.Format(time.RFC3339)}
+
+	for _, filter := range labels {
+		query += fmt.Sprintf(`
+			AND EXISTS (
+				SELECT 1
+				FROM %s_labels l
+				INNER JOIN %s_label_strings ls ON l.label_string_id = ls.id
+				WHERE l.value_id = v.id AND ls.key = ? AND ls.value = ?
+			)
+		`, table, table)
+		args = append(args, filter.Key, filter.Value)
+	}
+
+	query += `
+		GROUP BY m.currentTime
+		ORDER BY m.currentTime ASC
+	`
+	return query, args
+}
+
+func mapKeys(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/cmd/metrics-scraper/app/routes/metrics/handler.go
+++ b/cmd/metrics-scraper/app/routes/metrics/handler.go
@@ -18,13 +18,12 @@ package metrics
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/scrape"
 )
-
-var requests = make(chan scrape.SaveRequest)
 
 // GetMetrics returns the metrics for the given app name
 func GetMetrics(c *gin.Context) {
@@ -50,14 +49,24 @@ func GetMetrics(c *gin.Context) {
 		return
 	}
 
-	allMetrics, errors, err := scrape.FetchMetrics(c.Request.Context(), appName, requests)
+	// Pass nil for the save channel; live metrics are persisted by background goroutines only.
+	allMetrics, errors, err := scrape.FetchMetrics(c.Request.Context(), appName, nil)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"errors": errors, "error": err.Error()})
+		status := http.StatusBadGateway
+		if strings.Contains(strings.ToLower(err.Error()), "no pods found") {
+			status = http.StatusServiceUnavailable
+		}
+		c.JSON(status, gin.H{"errors": errors, "error": err.Error()})
 		return
 	}
 	if len(allMetrics) > 0 {
 		c.JSON(http.StatusOK, allMetrics)
 	} else {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "No metrics data found", "errors": errors})
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "No metrics data found", "errors": errors})
 	}
+}
+
+// GetVisualization returns visualization-oriented time series for the given app.
+func GetVisualization(c *gin.Context) {
+	GetSchedulerVisualization(c)
 }

--- a/cmd/metrics-scraper/app/routes/metrics/handlerqueries.go
+++ b/cmd/metrics-scraper/app/routes/metrics/handlerqueries.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +30,9 @@ import (
 
 	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/scrape"
 )
+
+// validTableNameRe ensures a table name contains only safe identifier characters.
+var validTableNameRe = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 // MetricInfo represents the information about a metric.
 type MetricInfo struct {
@@ -44,6 +49,11 @@ func QueryMetrics(c *gin.Context) {
 
 	sanitizedAppName := strings.ReplaceAll(appName, "-", "_")
 	sanitizedPodName := strings.ReplaceAll(podName, "-", "_")
+
+	if !validTableNameRe.MatchString(sanitizedPodName) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid pod_name"})
+		return
+	}
 
 	db, err := scrape.GetDB(sanitizedAppName)
 	if err != nil {
@@ -71,6 +81,18 @@ func QueryMetrics(c *gin.Context) {
 	case "metricsdetails":
 		queryMetricDetails(c, appName)
 	}
+}
+
+type sqlQueryer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}
+
+func queryWithMetadataFallback(q sqlQueryer, metadataTableName, preferredQuery, fallbackQuery string, args ...any) (*sql.Rows, error) {
+	rows, err := q.Query(preferredQuery, args...)
+	if err != nil && strings.Contains(err.Error(), "no such table: "+metadataTableName) {
+		return q.Query(fallbackQuery, args...)
+	}
+	return rows, err
 }
 
 func queryMetricNames(c *gin.Context, tx *sql.Tx, sanitizedPodName string) {
@@ -101,18 +123,24 @@ func queryMetricDetailsByName(c *gin.Context, tx *sql.Tx, sanitizedPodName, metr
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Metric name required for details"})
 		return
 	}
-	query := `
+	// Single query with JOIN to avoid N+1 queries for labels
+	query := fmt.Sprintf(`
             SELECT 
                 m.currentTime, 
                 m.name, 
                 v.value, 
                 v.measure, 
-                v.id
-            FROM ? m
-            INNER JOIN ? v ON m.id = v.metric_id
+                v.id,
+                COALESCE(ls.key, '') AS label_key,
+                COALESCE(ls.value, '') AS label_value
+            FROM %s m
+            INNER JOIN %s_values v ON m.id = v.metric_id
+            LEFT JOIN %s_labels l ON v.id = l.value_id
+            LEFT JOIN %s_label_strings ls ON l.label_string_id = ls.id
             WHERE m.name = ?
-        `
-	rows, err := tx.Query(query, sanitizedPodName, fmt.Sprintf("%s_values", sanitizedPodName), metricName)
+            ORDER BY m.currentTime, v.id
+        `, sanitizedPodName, sanitizedPodName, sanitizedPodName, sanitizedPodName)
+	rows, err := tx.Query(query, metricName)
 	if err != nil {
 		log.Printf("Error querying metric details: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to query metric details"})
@@ -132,54 +160,47 @@ func queryMetricDetailsByName(c *gin.Context, tx *sql.Tx, sanitizedPodName, metr
 	}
 
 	detailsMap := make(map[string]MetricDetails)
+	// Track values by (timeKey, valueID) to accumulate labels
+	type valueKey struct {
+		timeKey string
+		valueID int
+	}
+	valueLabels := make(map[valueKey]map[string]string)
+	valueIndex := make(map[valueKey]*MetricValue)
 
 	for rows.Next() {
 		var currentTime time.Time
-		var name, value, measure string
+		var name, measure, labelKey, labelValue string
+		var numericValue float64
 		var valueID int
-		if err := rows.Scan(&currentTime, &name, &value, &measure, &valueID); err != nil {
+		if err := rows.Scan(&currentTime, &name, &numericValue, &measure, &valueID, &labelKey, &labelValue); err != nil {
 			log.Printf("Error scanning metric details: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to scan metric details"})
 			return
 		}
 
-		labelsQuery := "SELECT key, value FROM ? WHERE value_id = ?"
-		labelsRows, err := tx.Query(labelsQuery, fmt.Sprintf("%s_labels", sanitizedPodName), valueID)
-		if err != nil {
-			log.Printf("Error querying labels: %v", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to query labels"})
-			return
-		}
-		defer labelsRows.Close()
-
-		labels := make(map[string]string)
-		for labelsRows.Next() {
-			var labelKey, labelValue string
-			if err := labelsRows.Scan(&labelKey, &labelValue); err != nil {
-				log.Printf("Error scanning labels: %v", err)
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to scan labels"})
-				return
-			}
-			labels[labelKey] = labelValue
-		}
-
 		timeKey := currentTime.Format(time.RFC3339)
+		vk := valueKey{timeKey: timeKey, valueID: valueID}
 
-		detail, exists := detailsMap[timeKey]
-		if !exists {
-			detail = MetricDetails{
-				Name:   name,
-				Values: []MetricValue{},
+		if _, exists := valueIndex[vk]; !exists {
+			detail, detailExists := detailsMap[timeKey]
+			if !detailExists {
+				detail = MetricDetails{
+					Name:   name,
+					Values: []MetricValue{},
+				}
 			}
+			labels := make(map[string]string)
+			mv := MetricValue{Value: strconv.FormatFloat(numericValue, 'f', -1, 64), Measure: measure, Labels: labels}
+			detail.Values = append(detail.Values, mv)
+			detailsMap[timeKey] = detail
+			valueLabels[vk] = labels
+			valueIndex[vk] = &detailsMap[timeKey].Values[len(detailsMap[timeKey].Values)-1]
 		}
 
-		detail.Values = append(detail.Values, MetricValue{
-			Value:   value,
-			Measure: measure,
-			Labels:  labels,
-		})
-
-		detailsMap[timeKey] = detail
+		if labelKey != "" {
+			valueLabels[vk][labelKey] = labelValue
+		}
 	}
 
 	c.JSON(http.StatusOK, gin.H{"details": detailsMap})
@@ -187,13 +208,13 @@ func queryMetricDetailsByName(c *gin.Context, tx *sql.Tx, sanitizedPodName, metr
 
 func queryMetricDetails(c *gin.Context, appName string) {
 	// Handle metricsdetails query type
-	db, err := sql.Open("sqlite", strings.ReplaceAll(appName, "-", "_")+".db")
+	sanitizedName := strings.ReplaceAll(appName, "-", "_")
+	db, err := scrape.GetDB(sanitizedName)
 	if err != nil {
 		log.Printf("Error opening database: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to open database"})
 		return
 	}
-	defer db.Close()
 
 	// Get all relevant tables
 	rows, err := db.Query(`
@@ -202,6 +223,8 @@ func queryMetricDetails(c *gin.Context, appName string) {
 			WHERE type='table' 
 			AND name NOT LIKE '%_values' 
 			AND name NOT LIKE '%_labels' 
+			AND name NOT LIKE '%_label_strings'
+			AND name NOT LIKE '%_metadata'
 			AND name NOT LIKE '%_time_load'
 			AND name != 'sqlite_sequence'
 		`)
@@ -223,16 +246,22 @@ func queryMetricDetails(c *gin.Context, appName string) {
 		}
 
 		// Get metrics for this pod
-		metricRows, err := db.Query(fmt.Sprintf(`
+		metadataQuery := fmt.Sprintf(`
+				SELECT DISTINCT m.name, COALESCE(md.help, ''), COALESCE(md.type, '')
+				FROM %s m
+				LEFT JOIN %s_metadata md ON m.name = md.name
+				GROUP BY m.name
+			`, tableName, tableName)
+		fallbackQuery := fmt.Sprintf(`
 				SELECT DISTINCT name, help, type 
 				FROM %s 
 				GROUP BY name
-			`, tableName))
+			`, tableName)
+		metricRows, err := queryWithMetadataFallback(db, fmt.Sprintf("%s_metadata", tableName), metadataQuery, fallbackQuery)
 		if err != nil {
 			log.Printf("Error querying metrics for table %s: %v", tableName, err)
 			continue
 		}
-		defer metricRows.Close()
 
 		podMetrics := make(map[string]MetricInfo)
 
@@ -249,6 +278,7 @@ func queryMetricDetails(c *gin.Context, appName string) {
 				Type: metricType,
 			}
 		}
+		metricRows.Close()
 
 		result[tableName] = podMetrics
 	}

--- a/cmd/metrics-scraper/app/routes/metrics/pods.go
+++ b/cmd/metrics-scraper/app/routes/metrics/pods.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/db"
+	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/scrape"
+)
+
+type componentPodsResponse struct {
+	AppName  string   `json:"appName"`
+	Pods     []string `json:"pods"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+var discoverComponentPods = scrape.DiscoverComponentPods
+
+// GetComponentPods returns the live Kubernetes pods selected for a component.
+func GetComponentPods(c *gin.Context) {
+	appName := c.Param("app_name")
+	if db.GetComponentConfig(appName) == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported metrics component"})
+		return
+	}
+
+	pods, warnings, err := discoverComponentPods(c.Request.Context(), appName)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{
+			"error":    err.Error(),
+			"pods":     pods,
+			"warnings": warnings,
+		})
+		return
+	}
+	if pods == nil {
+		pods = []string{}
+	}
+	c.JSON(http.StatusOK, componentPodsResponse{
+		AppName:  appName,
+		Pods:     pods,
+		Warnings: warnings,
+	})
+}

--- a/cmd/metrics-scraper/app/routes/metrics/pods_test.go
+++ b/cmd/metrics-scraper/app/routes/metrics/pods_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestGetComponentPodsSuccess(t *testing.T) {
+	original := discoverComponentPods
+	defer func() { discoverComponentPods = original }()
+	discoverComponentPods = func(_ context.Context, appName string) ([]string, []string, error) {
+		if appName != "karmada-aggregated-apiserver" {
+			t.Fatalf("unexpected app name %q", appName)
+		}
+		return []string{"aggregated-0", "aggregated-1"}, nil, nil
+	}
+
+	c, w := newVisualizationContext("/api/v1/metrics/karmada-aggregated-apiserver/pods")
+	c.Params = gin.Params{{Key: "app_name", Value: "karmada-aggregated-apiserver"}}
+	GetComponentPods(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var response componentPodsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Pods) != 2 {
+		t.Fatalf("expected 2 pods, got %#v", response.Pods)
+	}
+}
+
+func TestGetComponentPodsDiscoveryFailure(t *testing.T) {
+	original := discoverComponentPods
+	defer func() { discoverComponentPods = original }()
+	discoverComponentPods = func(_ context.Context, _ string) ([]string, []string, error) {
+		return nil, []string{"list failed"}, errors.New("discovery failed")
+	}
+
+	c, w := newVisualizationContext("/api/v1/metrics/karmada-aggregated-apiserver/pods")
+	c.Params = gin.Params{{Key: "app_name", Value: "karmada-aggregated-apiserver"}}
+	GetComponentPods(c)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/cmd/metrics-scraper/app/routes/metrics/visualization.go
+++ b/cmd/metrics-scraper/app/routes/metrics/visualization.go
@@ -1,0 +1,916 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"database/sql"
+	"fmt"
+	"math"
+	"net/http"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/scrape"
+)
+
+const (
+	defaultVisualizationWindow = 15 * time.Minute
+	maxVisualizationWindow     = 6 * time.Hour
+	defaultPodMode             = "all"
+)
+
+var (
+	getDBFunc        = scrape.GetDB
+	triggerScrapeNow = scrape.TriggerScrapeNow
+)
+
+// Point is a single point in a time series.
+type Point struct {
+	Timestamp string  `json:"timestamp"`
+	Value     float64 `json:"value"`
+}
+
+// metricMeta holds discovered metric metadata from the database.
+type metricMeta struct {
+	name    string
+	help    string
+	mtype   string // gauge, counter, histogram, summary
+	measure string // primary measure for aggregation
+}
+
+// VisualizationMeta is metadata for visualization responses.
+type VisualizationMeta struct {
+	AppName           string `json:"appName"`
+	Window            string `json:"window"`
+	PodMode           string `json:"podMode"`
+	SampleIntervalSec int    `json:"sampleIntervalSec"`
+	GeneratedAt       string `json:"generatedAt"`
+}
+
+// VisualizationMetricInfo describes an available metric and its suggested chart type|.
+type VisualizationMetricInfo struct {
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	SuggestedChart string `json:"suggestedChart"`
+}
+
+// MetricCatalogItem provides full metadata about a metric for frontend rendering.
+type MetricCatalogItem struct {
+	Name           string `json:"name"`
+	Help           string `json:"help"`
+	PrometheusType string `json:"prometheusType"`
+	SuggestedChart string `json:"suggestedChart"`
+	Group          string `json:"group"`
+}
+
+// SchedulerVisualizationResponse is the API contract for scheduler metric charts.
+type SchedulerVisualizationResponse struct {
+	Meta             VisualizationMeta         `json:"meta"`
+	Timeseries       map[string][]Point        `json:"timeseries"`
+	Pods             []string                  `json:"pods"`
+	Warnings         []string                  `json:"warnings,omitempty"`
+	AvailableMetrics []VisualizationMetricInfo `json:"availableMetrics,omitempty"`
+	MetricsCatalog   []MetricCatalogItem       `json:"metricsCatalog,omitempty"`
+}
+
+// GetSchedulerVisualization returns chart-oriented scheduler time series from metrics-scraper DB.
+func GetSchedulerVisualization(c *gin.Context) {
+	appName := c.Param("app_name")
+	if appName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "app_name is required"})
+		return
+	}
+
+	window, err := parseWindow(c.Query("window"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	podMode := c.DefaultQuery("pod", defaultPodMode)
+	refresh, err := parseRefresh(c.Query("refresh"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var warnings []string
+	if refresh {
+		scrapeErrors, scrapeErr := triggerScrapeNow(c.Request.Context(), appName)
+		if scrapeErr != nil {
+			c.JSON(http.StatusBadGateway, gin.H{
+				"error":   scrapeErr.Error(),
+				"errors":  scrapeErrors,
+				"message": fmt.Sprintf("failed to refresh %s metrics before visualization query", appName),
+			})
+			return
+		}
+		warnings = append(warnings, scrapeErrors...)
+	}
+
+	dbConn, err := getDBFunc(appName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open metrics database"})
+		return
+	}
+
+	podTables, err := listPodTables(dbConn)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to list %s pod tables", appName)})
+		return
+	}
+	if len(podTables) == 0 {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": fmt.Sprintf("no %s metrics data found", appName)})
+		return
+	}
+
+	selectedTables, err := selectPodTables(podTables, podMode)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	metricsFilter := c.Query("metrics")
+	var requestedMetrics []string
+	if metricsFilter != "" {
+		for _, m := range strings.Split(metricsFilter, ",") {
+			m = strings.TrimSpace(m)
+			if m != "" {
+				requestedMetrics = append(requestedMetrics, m)
+			}
+		}
+	}
+
+	cutoff := time.Now().Add(-window)
+	series, catalog, err := buildDynamicVisualization(dbConn, selectedTables, cutoff, window, requestedMetrics)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to build visualization: %v", err)})
+		return
+	}
+
+	if !hasAnySeriesData(series) {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": fmt.Sprintf("no %s visualization data available in requested window", appName),
+			"pods":  desanitizePods(selectedTables),
+		})
+		return
+	}
+
+	resp := SchedulerVisualizationResponse{
+		Meta: VisualizationMeta{
+			AppName:           appName,
+			Window:            window.String(),
+			PodMode:           podMode,
+			SampleIntervalSec: detectSampleInterval(series),
+			GeneratedAt:       time.Now().Format(time.RFC3339),
+		},
+		Timeseries:       series,
+		Pods:             desanitizePods(selectedTables),
+		Warnings:         warnings,
+		AvailableMetrics: buildAvailableMetrics(series),
+		MetricsCatalog:   catalog,
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+func buildAvailableMetrics(series map[string][]Point) []VisualizationMetricInfo {
+	metricChartMapping := map[string]VisualizationMetricInfo{
+		"workqueueDepth":             {Name: "workqueueDepth", Type: "gauge", SuggestedChart: "bar"},
+		"workqueueAddsRate":          {Name: "workqueueAddsRate", Type: "counter_rate", SuggestedChart: "line"},
+		"workqueueRetriesRate":       {Name: "workqueueRetriesRate", Type: "counter_rate", SuggestedChart: "line"},
+		"workqueueQueueDurationAvg":  {Name: "workqueueQueueDurationAvg", Type: "histogram_avg", SuggestedChart: "area"},
+		"workqueueWorkDurationAvg":   {Name: "workqueueWorkDurationAvg", Type: "histogram_avg", SuggestedChart: "area"},
+		"processResidentMemoryBytes": {Name: "processResidentMemoryBytes", Type: "gauge", SuggestedChart: "gauge"},
+		"processCPUSecondsRate":      {Name: "processCPUSecondsRate", Type: "counter_rate", SuggestedChart: "line"},
+	}
+
+	var available []VisualizationMetricInfo
+	for key, points := range series {
+		if len(points) == 0 {
+			continue
+		}
+		if info, ok := metricChartMapping[key]; ok {
+			available = append(available, info)
+		} else {
+			// Unknown metrics default to line chart
+			available = append(available, VisualizationMetricInfo{Name: key, Type: "unknown", SuggestedChart: "line"})
+		}
+	}
+	return available
+}
+
+func parseWindow(windowRaw string) (time.Duration, error) {
+	if windowRaw == "" {
+		return defaultVisualizationWindow, nil
+	}
+
+	window, err := time.ParseDuration(windowRaw)
+	if err != nil || window <= 0 {
+		return 0, fmt.Errorf("invalid window %q, expected a positive Go duration such as 15m", windowRaw)
+	}
+	if window > maxVisualizationWindow {
+		return 0, fmt.Errorf("invalid window %q, maximum supported window is %s", windowRaw, maxVisualizationWindow)
+	}
+	return window, nil
+}
+
+func parseRefresh(refreshRaw string) (bool, error) {
+	if refreshRaw == "" {
+		return false, nil
+	}
+	value, err := strconv.ParseBool(refreshRaw)
+	if err != nil {
+		return false, fmt.Errorf("invalid refresh %q, expected true or false", refreshRaw)
+	}
+	return value, nil
+}
+
+func listPodTables(dbConn *sql.DB) ([]string, error) {
+	rows, err := dbConn.Query(`
+		SELECT name
+		FROM sqlite_master
+		WHERE type='table'
+		AND name NOT LIKE '%_values'
+		AND name NOT LIKE '%_labels'
+		AND name NOT LIKE '%_label_strings'
+		AND name NOT LIKE '%_metadata'
+		AND name NOT LIKE '%_time_load'
+		AND name NOT LIKE '%_aggregates'
+		AND name != 'sqlite_sequence'
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		if scanErr := rows.Scan(&name); scanErr != nil {
+			return nil, scanErr
+		}
+		tables = append(tables, name)
+	}
+
+	slices.Sort(tables)
+	return tables, nil
+}
+
+func selectPodTables(tables []string, podMode string) ([]string, error) {
+	if podMode == "" || podMode == defaultPodMode {
+		return tables, nil
+	}
+
+	target := strings.ReplaceAll(podMode, "-", "_")
+	for _, table := range tables {
+		if table == target {
+			return []string{table}, nil
+		}
+	}
+	return nil, fmt.Errorf("pod %q not found in metrics data", podMode)
+}
+
+func buildComponentVisualization(dbConn *sql.DB, podTables []string, cutoff time.Time) (map[string][]Point, error) {
+	type metricAccumulator struct {
+		mu   sync.Mutex
+		data map[time.Time]float64
+	}
+
+	workqueueDepth := &metricAccumulator{data: map[time.Time]float64{}}
+	workqueueAdds := &metricAccumulator{data: map[time.Time]float64{}}
+	workqueueRetries := &metricAccumulator{data: map[time.Time]float64{}}
+	queueDurationSum := &metricAccumulator{data: map[time.Time]float64{}}
+	queueDurationCount := &metricAccumulator{data: map[time.Time]float64{}}
+	workDurationSum := &metricAccumulator{data: map[time.Time]float64{}}
+	workDurationCount := &metricAccumulator{data: map[time.Time]float64{}}
+	processResidentMemory := &metricAccumulator{data: map[time.Time]float64{}}
+	processCPUTotal := &metricAccumulator{data: map[time.Time]float64{}}
+
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+
+	for _, table := range podTables {
+		wg.Add(1)
+		go func(table string) {
+			defer wg.Done()
+
+			type metricSpec struct {
+				name    string
+				measure string
+				acc     *metricAccumulator
+			}
+			specs := []metricSpec{
+				{"workqueue_depth", "current_value", workqueueDepth},
+				{"workqueue_adds_total", "total", workqueueAdds},
+				{"workqueue_retries_total", "total", workqueueRetries},
+				{"workqueue_queue_duration_seconds", "sum", queueDurationSum},
+				{"workqueue_queue_duration_seconds", "count", queueDurationCount},
+				{"workqueue_work_duration_seconds", "sum", workDurationSum},
+				{"workqueue_work_duration_seconds", "count", workDurationCount},
+				{"process_resident_memory_bytes", "current_value", processResidentMemory},
+				{"process_cpu_seconds_total", "total", processCPUTotal},
+			}
+
+			for _, spec := range specs {
+				localMap := map[time.Time]float64{}
+				if err := accumulateMetric(dbConn, table, spec.name, spec.measure, cutoff, localMap); err != nil {
+					errOnce.Do(func() { firstErr = err })
+					return
+				}
+				spec.acc.mu.Lock()
+				for t, v := range localMap {
+					spec.acc.data[t] += v
+				}
+				spec.acc.mu.Unlock()
+			}
+		}(table)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	result := map[string][]Point{
+		"workqueueDepth":       mapToPoints(workqueueDepth.data),
+		"workqueueAddsRate":    counterRate(mapToPoints(workqueueAdds.data)),
+		"workqueueRetriesRate": counterRate(mapToPoints(workqueueRetries.data)),
+		"workqueueQueueDurationAvg": histogramAverage(
+			mapToPoints(queueDurationSum.data),
+			mapToPoints(queueDurationCount.data),
+		),
+		"workqueueWorkDurationAvg": histogramAverage(
+			mapToPoints(workDurationSum.data),
+			mapToPoints(workDurationCount.data),
+		),
+		"processResidentMemoryBytes": mapToPoints(processResidentMemory.data),
+		"processCPUSecondsRate":      counterRate(mapToPoints(processCPUTotal.data)),
+	}
+
+	return result, nil
+}
+
+// buildDynamicVisualization discovers all metrics from DB dynamically, classifies them by type,
+// and builds timeseries for each metric. Returns series and a catalog of all discovered metrics.
+func buildDynamicVisualization(dbConn *sql.DB, podTables []string, cutoff time.Time, window time.Duration, requestedMetrics []string) (map[string][]Point, []MetricCatalogItem, error) {
+	if len(podTables) == 0 {
+		return nil, nil, nil
+	}
+
+	resolution := ""
+	useAggregates := false
+	if window > 5*time.Minute && window <= 1*time.Hour {
+		resolution = "1m"
+		useAggregates = true
+	} else if window > 1*time.Hour {
+		resolution = "5m"
+		useAggregates = true
+	}
+
+	// Step 1: discover all distinct metric names and their types from the DB.
+	// Prefer metadata tables so discovery still works when raw samples have aged out.
+	discoveredMetrics := map[string]*metricMeta{}
+	var discoveryMu sync.Mutex
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+
+	for _, table := range podTables {
+		wg.Add(1)
+		go func(table string) {
+			defer wg.Done()
+			query := fmt.Sprintf(`
+				SELECT md.name, COALESCE(md.type, ''), COALESCE(md.help, '')
+				FROM %s_metadata md
+				WHERE ? IS NOT NULL
+			`, table)
+			fallbackQuery := fmt.Sprintf(`
+				SELECT DISTINCT m.name, '', ''
+				FROM %s m
+				WHERE m.currentTime >= ?
+			`, table)
+			rows, err := queryWithMetadataFallback(dbConn, fmt.Sprintf("%s_metadata", table), query, fallbackQuery, cutoff.Format(time.RFC3339))
+			if err != nil {
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+			defer rows.Close()
+
+			for rows.Next() {
+				var name, mtype, help string
+				if err := rows.Scan(&name, &mtype, &help); err != nil {
+					continue
+				}
+				discoveryMu.Lock()
+				if _, exists := discoveredMetrics[name]; !exists {
+					discoveredMetrics[name] = &metricMeta{name: name, help: help, mtype: normalizePrometheusType(mtype)}
+				}
+				discoveryMu.Unlock()
+			}
+		}(table)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, nil, firstErr
+	}
+
+	if len(discoveredMetrics) == 0 {
+		return nil, nil, nil
+	}
+
+	if len(requestedMetrics) > 0 {
+		requestedSet := make(map[string]bool, len(requestedMetrics))
+		for _, m := range requestedMetrics {
+			requestedSet[m] = true
+		}
+		for name := range discoveredMetrics {
+			if !requestedSet[name] {
+				delete(discoveredMetrics, name)
+			}
+		}
+	}
+
+	if len(discoveredMetrics) == 0 {
+		return nil, nil, nil
+	}
+
+	for _, meta := range discoveredMetrics {
+		meta.measure = primaryMeasureForType(meta.mtype)
+	}
+
+	type metricAccumulator struct {
+		mu   sync.Mutex
+		data map[time.Time]float64
+	}
+	type histAcc struct {
+		sum   *metricAccumulator
+		count *metricAccumulator
+	}
+
+	gaugeAccs := map[string]*metricAccumulator{}
+	counterAccs := map[string]*metricAccumulator{}
+	histAccs := map[string]*histAcc{}
+
+	for name, meta := range discoveredMetrics {
+		switch meta.mtype {
+		case "gauge":
+			gaugeAccs[name] = &metricAccumulator{data: map[time.Time]float64{}}
+		case "counter":
+			counterAccs[name] = &metricAccumulator{data: map[time.Time]float64{}}
+		case "histogram", "summary":
+			histAccs[name] = &histAcc{
+				sum:   &metricAccumulator{data: map[time.Time]float64{}},
+				count: &metricAccumulator{data: map[time.Time]float64{}},
+			}
+		}
+	}
+
+	accumulate := func(localMap map[time.Time]float64, table, name, measure string) error {
+		if useAggregates {
+			if err := accumulateFromAggregates(dbConn, table, name, measure, resolution, cutoff, localMap); err != nil {
+				return err
+			}
+			// Fallback to raw data if aggregates are empty (not yet populated)
+			if len(localMap) == 0 {
+				return accumulateMetric(dbConn, table, name, measure, cutoff, localMap)
+			}
+			return nil
+		}
+		return accumulateMetric(dbConn, table, name, measure, cutoff, localMap)
+	}
+
+	// Limit concurrency to match SQLite MaxOpenConns (4)
+	maxWorkers := len(podTables)
+	if maxWorkers > 4 {
+		maxWorkers = 4
+	}
+	sem := make(chan struct{}, maxWorkers)
+
+	for _, table := range podTables {
+		wg.Add(1)
+		sem <- struct{}{} // Acquire semaphore slot
+		go func(table string) {
+			defer wg.Done()
+			defer func() { <-sem }() // Release semaphore slot
+			for name, meta := range discoveredMetrics {
+				switch meta.mtype {
+				case "gauge":
+					acc := gaugeAccs[name]
+					localMap := map[time.Time]float64{}
+					if err := accumulate(localMap, table, name, "current_value"); err != nil {
+						errOnce.Do(func() { firstErr = err })
+						return
+					}
+					acc.mu.Lock()
+					for t, v := range localMap {
+						acc.data[t] += v
+					}
+					acc.mu.Unlock()
+
+				case "counter":
+					acc := counterAccs[name]
+					localMap := map[time.Time]float64{}
+					if err := accumulate(localMap, table, name, "total"); err != nil {
+						errOnce.Do(func() { firstErr = err })
+						return
+					}
+					acc.mu.Lock()
+					for t, v := range localMap {
+						acc.data[t] += v
+					}
+					acc.mu.Unlock()
+
+				case "histogram", "summary":
+					ha := histAccs[name]
+					localSum := map[time.Time]float64{}
+					localCount := map[time.Time]float64{}
+					if err := accumulate(localSum, table, name, "sum"); err != nil {
+						errOnce.Do(func() { firstErr = err })
+						return
+					}
+					if err := accumulate(localCount, table, name, "count"); err != nil {
+						errOnce.Do(func() { firstErr = err })
+						return
+					}
+					ha.sum.mu.Lock()
+					for t, v := range localSum {
+						ha.sum.data[t] += v
+					}
+					ha.sum.mu.Unlock()
+					ha.count.mu.Lock()
+					for t, v := range localCount {
+						ha.count.data[t] += v
+					}
+					ha.count.mu.Unlock()
+				}
+			}
+		}(table)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, nil, firstErr
+	}
+
+	result := map[string][]Point{}
+	for name := range gaugeAccs {
+		points := mapToPoints(gaugeAccs[name].data)
+		if len(points) > 0 {
+			result[name] = points
+		}
+	}
+	for name := range counterAccs {
+		points := counterRate(mapToPoints(counterAccs[name].data))
+		if len(points) > 0 {
+			result[name] = points
+		}
+	}
+	for name := range histAccs {
+		ha := histAccs[name]
+		points := histogramAverage(mapToPoints(ha.sum.data), mapToPoints(ha.count.data))
+		if len(points) > 0 {
+			result[name] = points
+		}
+	}
+
+	catalog := buildMetricsCatalog(discoveredMetrics, result)
+	return result, catalog, nil
+}
+
+func normalizePrometheusType(mtype string) string {
+	mtype = strings.ToLower(strings.TrimSpace(mtype))
+	switch mtype {
+	case "gauge", "counter", "histogram", "summary":
+		return mtype
+	case "untyped":
+		return "gauge"
+	default:
+		return "gauge"
+	}
+}
+
+func primaryMeasureForType(mtype string) string {
+	switch mtype {
+	case "gauge":
+		return "current_value"
+	case "counter":
+		return "total"
+	case "histogram", "summary":
+		return "sum"
+	default:
+		return "current_value"
+	}
+}
+
+func suggestedChartForType(mtype string, metricName string) string {
+	switch mtype {
+	case "gauge":
+		if strings.Contains(metricName, "_bytes") || strings.Contains(metricName, "memory") {
+			return "area"
+		}
+		return "gauge"
+	case "counter":
+		return "line"
+	case "histogram":
+		return "bar"
+	case "summary":
+		return "line"
+	default:
+		return "line"
+	}
+}
+
+func extractMetricGroup(name string) string {
+	// Extract the first meaningful prefix (e.g. "workqueue" from "workqueue_depth")
+	parts := strings.Split(name, "_")
+	if len(parts) >= 2 {
+		// Use first two parts for common prefixes
+		prefix := parts[0]
+		// Known multi-word prefixes
+		multiWordPrefixes := []string{"go", "process", "rest", "workqueue", "leader", "scheduler", "controller"}
+		for _, mp := range multiWordPrefixes {
+			if prefix == mp {
+				return mp
+			}
+		}
+		if len(parts) >= 3 {
+			return parts[0] + "_" + parts[1]
+		}
+		return prefix
+	}
+	return name
+}
+
+func buildMetricsCatalog(metrics map[string]*metricMeta, series map[string][]Point) []MetricCatalogItem {
+	catalog := make([]MetricCatalogItem, 0, len(metrics))
+	for name, meta := range metrics {
+		if _, hasSeries := series[name]; !hasSeries {
+			continue
+		}
+		catalog = append(catalog, MetricCatalogItem{
+			Name:           name,
+			Help:           meta.help,
+			PrometheusType: meta.mtype,
+			SuggestedChart: suggestedChartForType(meta.mtype, name),
+			Group:          extractMetricGroup(name),
+		})
+	}
+	sort.Slice(catalog, func(i, j int) bool {
+		if catalog[i].PrometheusType != catalog[j].PrometheusType {
+			return catalog[i].PrometheusType < catalog[j].PrometheusType
+		}
+		if catalog[i].Group != catalog[j].Group {
+			return catalog[i].Group < catalog[j].Group
+		}
+		return catalog[i].Name < catalog[j].Name
+	})
+	return catalog
+}
+
+func accumulateMetric(dbConn *sql.DB, podTable, metricName, measure string, cutoff time.Time, aggregate map[time.Time]float64) error {
+	query := fmt.Sprintf(`
+		SELECT m.currentTime, SUM(v.value)
+		FROM %s m
+		INNER JOIN %s_values v ON m.id = v.metric_id
+		WHERE m.name = ? AND v.measure = ? AND m.currentTime >= ?
+		GROUP BY m.currentTime
+		ORDER BY m.currentTime ASC
+	`, podTable, podTable)
+
+	rows, err := dbConn.Query(query, metricName, measure, cutoff.Format(time.RFC3339))
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var currentTimeRaw string
+		var total float64
+		if scanErr := rows.Scan(&currentTimeRaw, &total); scanErr != nil {
+			return scanErr
+		}
+
+		currentTime, parseErr := parseCurrentTime(currentTimeRaw)
+		if parseErr != nil {
+			continue
+		}
+
+		normalized := currentTime.UTC().Truncate(time.Second)
+		aggregate[normalized] += total
+	}
+
+	return rows.Err()
+}
+
+func accumulateFromAggregates(dbConn *sql.DB, podTable, metricName, measure, resolution string, cutoff time.Time, aggregate map[time.Time]float64) error {
+	query := fmt.Sprintf(`
+		SELECT bucket_time, avg_value
+		FROM %s_aggregates
+		WHERE name = ? AND measure = ? AND resolution = ? AND bucket_time >= ?
+		ORDER BY bucket_time ASC
+	`, podTable)
+
+	rows, err := dbConn.Query(query, metricName, measure, resolution, cutoff.Format(time.RFC3339))
+	if err != nil {
+		if strings.Contains(err.Error(), "no such table") {
+			return nil
+		}
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var bucketTimeRaw string
+		var avg float64
+		if err := rows.Scan(&bucketTimeRaw, &avg); err != nil {
+			return err
+		}
+		t, err := parseCurrentTime(bucketTimeRaw)
+		if err != nil {
+			continue
+		}
+		normalized := t.UTC().Truncate(time.Second)
+		aggregate[normalized] += avg
+	}
+	return rows.Err()
+}
+
+func parseCurrentTime(raw string) (time.Time, error) {
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02 15:04:05",
+	}
+	for _, layout := range layouts {
+		if ts, err := time.Parse(layout, raw); err == nil {
+			return ts, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid time format: %s", raw)
+}
+
+func mapToPoints(values map[time.Time]float64) []Point {
+	if len(values) == 0 {
+		return nil
+	}
+
+	timestamps := make([]time.Time, 0, len(values))
+	for ts := range values {
+		timestamps = append(timestamps, ts)
+	}
+	sort.Slice(timestamps, func(i, j int) bool {
+		return timestamps[i].Before(timestamps[j])
+	})
+
+	points := make([]Point, 0, len(timestamps))
+	for _, ts := range timestamps {
+		value := values[ts]
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			continue
+		}
+		points = append(points, Point{
+			Timestamp: ts.Format(time.RFC3339),
+			Value:     value,
+		})
+	}
+	return points
+}
+
+func counterRate(cumulative []Point) []Point {
+	if len(cumulative) == 0 {
+		return nil
+	}
+
+	rates := make([]Point, 0, len(cumulative))
+	rates = append(rates, Point{Timestamp: cumulative[0].Timestamp, Value: 0})
+	for i := 1; i < len(cumulative); i++ {
+		now, nowErr := time.Parse(time.RFC3339, cumulative[i].Timestamp)
+		prev, prevErr := time.Parse(time.RFC3339, cumulative[i-1].Timestamp)
+		if nowErr != nil || prevErr != nil {
+			rates = append(rates, Point{Timestamp: cumulative[i].Timestamp, Value: 0})
+			continue
+		}
+
+		deltaSeconds := now.Sub(prev).Seconds()
+		if deltaSeconds <= 0 {
+			rates = append(rates, Point{Timestamp: cumulative[i].Timestamp, Value: 0})
+			continue
+		}
+
+		delta := cumulative[i].Value - cumulative[i-1].Value
+		if delta < 0 {
+			delta = 0
+		}
+
+		rates = append(rates, Point{
+			Timestamp: cumulative[i].Timestamp,
+			Value:     delta / deltaSeconds,
+		})
+	}
+	return rates
+}
+
+func histogramAverage(sumSeries, countSeries []Point) []Point {
+	if len(sumSeries) == 0 || len(countSeries) == 0 {
+		return nil
+	}
+
+	sumMap := make(map[string]float64, len(sumSeries))
+	countMap := make(map[string]float64, len(countSeries))
+	for _, p := range sumSeries {
+		sumMap[p.Timestamp] = p.Value
+	}
+	for _, p := range countSeries {
+		countMap[p.Timestamp] = p.Value
+	}
+
+	var timestamps []string
+	for ts := range sumMap {
+		if _, ok := countMap[ts]; ok {
+			timestamps = append(timestamps, ts)
+		}
+	}
+	sort.Strings(timestamps)
+	if len(timestamps) == 0 {
+		return nil
+	}
+
+	result := make([]Point, 0, len(timestamps))
+	result = append(result, Point{Timestamp: timestamps[0], Value: 0})
+	for i := 1; i < len(timestamps); i++ {
+		prev := timestamps[i-1]
+		curr := timestamps[i]
+		sumDelta := sumMap[curr] - sumMap[prev]
+		countDelta := countMap[curr] - countMap[prev]
+		avg := 0.0
+		if sumDelta >= 0 && countDelta > 0 {
+			avg = sumDelta / countDelta
+		}
+		result = append(result, Point{Timestamp: curr, Value: avg})
+	}
+
+	return result
+}
+
+func hasAnySeriesData(timeseries map[string][]Point) bool {
+	for _, points := range timeseries {
+		if len(points) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func detectSampleInterval(timeseries map[string][]Point) int {
+	for _, points := range timeseries {
+		if len(points) < 2 {
+			continue
+		}
+
+		prev, err := time.Parse(time.RFC3339, points[0].Timestamp)
+		if err != nil {
+			continue
+		}
+		for i := 1; i < len(points); i++ {
+			curr, parseErr := time.Parse(time.RFC3339, points[i].Timestamp)
+			if parseErr != nil {
+				continue
+			}
+			interval := int(curr.Sub(prev).Seconds())
+			if interval > 0 {
+				return interval
+			}
+			prev = curr
+		}
+	}
+
+	return 0
+}
+
+func desanitizePods(tables []string) []string {
+	pods := make([]string, 0, len(tables))
+	for _, table := range tables {
+		pods = append(pods, strings.ReplaceAll(table, "_", "-"))
+	}
+	return pods
+}

--- a/cmd/metrics-scraper/app/routes/metrics/visualization_test.go
+++ b/cmd/metrics-scraper/app/routes/metrics/visualization_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/glebarez/sqlite"
+)
+
+func TestCounterRateHandlesReset(t *testing.T) {
+	points := []Point{
+		{Timestamp: "2026-01-01T00:00:00Z", Value: 10},
+		{Timestamp: "2026-01-01T00:00:10Z", Value: 16},
+		{Timestamp: "2026-01-01T00:00:20Z", Value: 3}, // counter reset
+	}
+
+	got := counterRate(points)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 points, got %d", len(got))
+	}
+	if got[1].Value != 0.6 {
+		t.Fatalf("expected second point rate 0.6, got %f", got[1].Value)
+	}
+	if got[2].Value != 0 {
+		t.Fatalf("expected reset point rate 0, got %f", got[2].Value)
+	}
+}
+
+func TestHistogramAverageUsesDelta(t *testing.T) {
+	sum := []Point{
+		{Timestamp: "2026-01-01T00:00:00Z", Value: 10},
+		{Timestamp: "2026-01-01T00:00:10Z", Value: 16},
+	}
+	count := []Point{
+		{Timestamp: "2026-01-01T00:00:00Z", Value: 2},
+		{Timestamp: "2026-01-01T00:00:10Z", Value: 4},
+	}
+
+	got := histogramAverage(sum, count)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 points, got %d", len(got))
+	}
+	if got[1].Value != 3 {
+		t.Fatalf("expected delta average 3, got %f", got[1].Value)
+	}
+}
+
+func TestGetSchedulerVisualizationInvalidApp(t *testing.T) {
+	origGetDB := getDBFunc
+	defer func() { getDBFunc = origGetDB }()
+	dbConn := mustOpenSQLite(t)
+	getDBFunc = func(_ string) (*sql.DB, error) {
+		return dbConn, nil
+	}
+
+	c, w := newVisualizationContext("/api/v1/metrics/unknown-component/visualization")
+	c.Params = gin.Params{{Key: "app_name", Value: "unknown-component"}}
+
+	GetSchedulerVisualization(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestGetSchedulerVisualizationNoData(t *testing.T) {
+	origGetDB := getDBFunc
+	origTrigger := triggerScrapeNow
+	defer func() {
+		getDBFunc = origGetDB
+		triggerScrapeNow = origTrigger
+	}()
+
+	dbConn := mustOpenSQLite(t)
+	getDBFunc = func(_ string) (*sql.DB, error) { return dbConn, nil }
+	triggerScrapeNow = func(_ context.Context, _ string) ([]string, error) { return nil, nil }
+
+	c, w := newVisualizationContext("/api/v1/metrics/karmada-scheduler/visualization?window=15m")
+	c.Params = gin.Params{{Key: "app_name", Value: "karmada-scheduler"}}
+
+	GetSchedulerVisualization(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestGetSchedulerVisualizationSuccess(t *testing.T) {
+	origGetDB := getDBFunc
+	origTrigger := triggerScrapeNow
+	defer func() {
+		getDBFunc = origGetDB
+		triggerScrapeNow = origTrigger
+	}()
+
+	dbConn := mustOpenSQLite(t)
+	createTestMetricTables(t, dbConn, "karmada_scheduler_testpod")
+
+	now := time.Now().Truncate(time.Second)
+	t1 := now.Add(-20 * time.Second).Format(time.RFC3339)
+	t2 := now.Add(-10 * time.Second).Format(time.RFC3339)
+	insertMetricSample(t, dbConn, "karmada_scheduler_testpod", t1, "workqueue_depth", "current_value", 4)
+	insertMetricSample(t, dbConn, "karmada_scheduler_testpod", t2, "workqueue_depth", "current_value", 6)
+	insertMetricSample(t, dbConn, "karmada_scheduler_testpod", t1, "workqueue_adds_total", "total", 10)
+	insertMetricSample(t, dbConn, "karmada_scheduler_testpod", t2, "workqueue_adds_total", "total", 30)
+
+	getDBFunc = func(_ string) (*sql.DB, error) { return dbConn, nil }
+	triggerScrapeNow = func(_ context.Context, _ string) ([]string, error) { return nil, nil }
+
+	c, w := newVisualizationContext("/api/v1/metrics/karmada-scheduler/visualization?window=15m")
+	c.Params = gin.Params{{Key: "app_name", Value: "karmada-scheduler"}}
+
+	GetSchedulerVisualization(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp SchedulerVisualizationResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response json: %v", err)
+	}
+	if len(resp.Timeseries["workqueue_depth"]) == 0 {
+		t.Fatalf("expected workqueue_depth points")
+	}
+	if len(resp.Timeseries["workqueue_adds_total"]) == 0 {
+		t.Fatalf("expected workqueue_adds_total points")
+	}
+}
+
+func newVisualizationContext(url string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	c.Request = req
+	return c, w
+}
+
+func mustOpenSQLite(t *testing.T) *sql.DB {
+	t.Helper()
+	dbConn, err := sql.Open("sqlite", "file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	dbConn.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		_ = dbConn.Close()
+	})
+	return dbConn
+}
+
+func createTestMetricTables(t *testing.T, dbConn *sql.DB, table string) {
+	t.Helper()
+	sqls := []string{
+		"CREATE TABLE IF NOT EXISTS " + table + " (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, currentTime DATETIME)",
+		"CREATE TABLE IF NOT EXISTS " + table + "_metadata (name TEXT PRIMARY KEY, help TEXT, type TEXT)",
+		"CREATE TABLE IF NOT EXISTS " + table + "_values (id INTEGER PRIMARY KEY AUTOINCREMENT, metric_id INTEGER, value TEXT, measure TEXT)",
+	}
+	for _, stmt := range sqls {
+		if _, err := dbConn.Exec(stmt); err != nil {
+			t.Fatalf("failed to create test table: %v", err)
+		}
+	}
+}
+
+func insertMetricSample(t *testing.T, dbConn *sql.DB, table, ts, metric, measure string, value float64) {
+	t.Helper()
+	metricType := "GAUGE"
+	if measure == "total" {
+		metricType = "COUNTER"
+	}
+	if _, err := dbConn.Exec(
+		"INSERT OR IGNORE INTO "+table+"_metadata (name, help, type) VALUES (?, ?, ?)",
+		metric, "", metricType,
+	); err != nil {
+		t.Fatalf("failed to insert metric metadata: %v", err)
+	}
+	result, err := dbConn.Exec(
+		"INSERT INTO "+table+" (name, currentTime) VALUES (?, ?)",
+		metric, ts,
+	)
+	if err != nil {
+		t.Fatalf("failed to insert metric row: %v", err)
+	}
+	metricID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("failed to get metric id: %v", err)
+	}
+	if _, err = dbConn.Exec(
+		"INSERT INTO "+table+"_values (metric_id, value, measure) VALUES (?, ?, ?)",
+		metricID, value, measure,
+	); err != nil {
+		t.Fatalf("failed to insert metric value: %v", err)
+	}
+}

--- a/cmd/metrics-scraper/app/scrape/aggregation.go
+++ b/cmd/metrics-scraper/app/scrape/aggregation.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scrape
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"time"
+)
+
+// StartAggregationWorkers starts background goroutines that periodically
+// downsample raw metrics into 1-min and 5-min aggregate buckets.
+func StartAggregationWorkers() {
+	go func() {
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			runAggregation("1m", 1*time.Minute)
+		}
+	}()
+
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			runAggregation("5m", 5*time.Minute)
+		}
+	}()
+}
+
+func runAggregation(resolution string, bucketDuration time.Duration) {
+	dbMapLock.RLock()
+	dbs := make(map[string]*sql.DB, len(dbMap))
+	for name, d := range dbMap {
+		dbs[name] = d
+	}
+	dbMapLock.RUnlock()
+
+	for appName, db := range dbs {
+		tables, err := getTablesForApp(db)
+		if err != nil {
+			log.Printf("Aggregation: error getting tables for %s: %v", appName, err)
+			continue
+		}
+		for _, table := range tables {
+			if err := aggregateTable(db, table, resolution, bucketDuration); err != nil {
+				log.Printf("Aggregation: error for table %s resolution %s: %v", table, resolution, err)
+			}
+		}
+	}
+}
+
+func getTablesForApp(db *sql.DB) ([]string, error) {
+	rows, err := db.Query("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE '%_values' AND name NOT LIKE '%_labels' AND name NOT LIKE '%_label_strings' AND name NOT LIKE '%_time_load' AND name NOT LIKE '%_metadata' AND name NOT LIKE '%_aggregates' AND name != 'app_sync' AND name != 'sqlite_sequence'")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			continue
+		}
+		tables = append(tables, name)
+	}
+	return tables, rows.Err()
+}
+
+func aggregateTable(db *sql.DB, table, resolution string, bucketDuration time.Duration) error {
+	now := time.Now().UTC()
+	bucketEnd := now.Truncate(bucketDuration)
+	bucketStart := bucketEnd.Add(-bucketDuration)
+
+	query := fmt.Sprintf(`
+		SELECT m.name, v.measure, AVG(v.value), MAX(v.value), MIN(v.value), COUNT(v.value)
+		FROM %s m
+		INNER JOIN %s_values v ON m.id = v.metric_id
+		WHERE m.currentTime >= ? AND m.currentTime < ?
+		  AND v.measure IN ('current_value', 'total', 'sum', 'count')
+		GROUP BY m.name, v.measure
+	`, table, table)
+
+	rows, err := db.Query(query, bucketStart.Format(time.RFC3339), bucketEnd.Format(time.RFC3339))
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	if _, err := db.Exec(fmt.Sprintf(createAggregatesTableSQL, table)); err != nil {
+		return err
+	}
+	if _, err := db.Exec(fmt.Sprintf(createAggregatesIndexSQL, table, table)); err != nil {
+		return err
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	bucketTimeStr := bucketStart.Format(time.RFC3339)
+	for rows.Next() {
+		var name, measure string
+		var avg, max, min float64
+		var count int
+		if err := rows.Scan(&name, &measure, &avg, &max, &min, &count); err != nil {
+			continue
+		}
+		if _, err = tx.Exec(fmt.Sprintf(insertAggregateSQL, table), name, measure, bucketTimeStr, resolution, avg, max, min, count); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	var retentionCutoff time.Time
+	switch resolution {
+	case "1m":
+		retentionCutoff = now.Add(-1 * time.Hour)
+	case "5m":
+		retentionCutoff = now.Add(-6 * time.Hour)
+	default:
+		retentionCutoff = now
+	}
+	if _, err = tx.Exec(fmt.Sprintf(deleteOldAggregatesSQL, table), resolution, retentionCutoff.Format(time.RFC3339)); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}

--- a/cmd/metrics-scraper/app/scrape/consts.go
+++ b/cmd/metrics-scraper/app/scrape/consts.go
@@ -21,17 +21,21 @@ const (
         CREATE TABLE IF NOT EXISTS %s (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT,
-            help TEXT,
-            type TEXT,
             currentTime DATETIME
         )
     `
+
+	createMetadataTableSQL = `CREATE TABLE IF NOT EXISTS %s_metadata (
+        name TEXT PRIMARY KEY,
+        help TEXT,
+        type TEXT
+    )`
 
 	createValuesTableSQL = `
         CREATE TABLE IF NOT EXISTS %s_values (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             metric_id INTEGER,
-            value TEXT,
+            value REAL,
             measure TEXT,
             FOREIGN KEY (metric_id) REFERENCES %s(id)
         )
@@ -46,12 +50,6 @@ const (
 	insertTimeLoadSQL = `
         INSERT OR REPLACE INTO %s (time_entry) VALUES (?)
     `
-	// 900 is 15 minutes in seconds
-	getOldestTimeSQL = `
-        SELECT time_entry FROM %s
-        ORDER BY time_entry DESC
-        LIMIT 1 OFFSET 900  
-    `
 
 	deleteOldTimeSQL = `DELETE FROM %s WHERE time_entry <= ?`
 
@@ -59,19 +57,68 @@ const (
         DELETE FROM %s WHERE currentTime <= ?
     `
 
+	// Direct time-based deletion for values (avoids slow NOT IN subquery)
 	deleteAssociatedValuesSQL = `
-        DELETE FROM %s_values WHERE metric_id NOT IN (SELECT id FROM %s)
+        DELETE FROM %s_values WHERE metric_id IN (
+            SELECT id FROM %s WHERE currentTime <= ?
+        )
     `
 
-	insertMainSQL = `
-        INSERT INTO %s (name, help, type, currentTime) 
-        VALUES (?, ?, ?, ?)
+	// Direct time-based deletion for labels (avoids slow NOT IN subquery)
+	deleteAssociatedLabelsSQL = `
+        DELETE FROM %s_labels WHERE value_id IN (
+            SELECT v.id FROM %s_values v
+            INNER JOIN %s m ON v.metric_id = m.id
+            WHERE m.currentTime <= ?
+        )
     `
+
+	insertMetadataSQL = `INSERT OR IGNORE INTO %s_metadata (name, help, type) VALUES (?, ?, ?)`
+
+	insertMainSQL = `
+        INSERT INTO %s (name, currentTime)
+        VALUES (?, ?)
+    `
+	createLabelStringsTableSQL = `CREATE TABLE IF NOT EXISTS %s_label_strings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        key TEXT NOT NULL,
+        value TEXT NOT NULL,
+        UNIQUE(key, value)
+    )`
+
 	createLabelsTableSQL = `CREATE TABLE IF NOT EXISTS %s_labels (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         value_id INTEGER,
-        key TEXT,
-        value TEXT,
-        FOREIGN KEY(value_id) REFERENCES %s_values(id)
+        label_string_id INTEGER,
+        FOREIGN KEY(value_id) REFERENCES %s_values(id),
+        FOREIGN KEY(label_string_id) REFERENCES %s_label_strings(id)
     )`
+
+	// Index creation SQL for query performance
+	createMainIndexSQL = `CREATE INDEX IF NOT EXISTS idx_%s_name_time ON %s(name, currentTime)`
+
+	createValuesIndexSQL = `CREATE INDEX IF NOT EXISTS idx_%s_values_metric_id ON %s_values(metric_id)`
+
+	createLabelsIndexSQL = `CREATE INDEX IF NOT EXISTS idx_%s_labels_value_id ON %s_labels(value_id)`
+
+	createLabelStringsIndexSQL = `CREATE INDEX IF NOT EXISTS idx_%s_label_strings_kv ON %s_label_strings(key, value)`
+
+	createAggregatesTableSQL = `CREATE TABLE IF NOT EXISTS %s_aggregates (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL,
+		measure TEXT NOT NULL,
+		bucket_time DATETIME NOT NULL,
+		resolution TEXT NOT NULL,
+		avg_value REAL,
+		max_value REAL,
+		min_value REAL,
+		sample_count INTEGER DEFAULT 1,
+		UNIQUE(name, measure, bucket_time, resolution)
+	)`
+
+	createAggregatesIndexSQL = `CREATE INDEX IF NOT EXISTS idx_%s_aggregates_lookup ON %s_aggregates(name, measure, resolution, bucket_time)`
+
+	insertAggregateSQL = `INSERT OR REPLACE INTO %s_aggregates (name, measure, bucket_time, resolution, avg_value, max_value, min_value, sample_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+
+	deleteOldAggregatesSQL = `DELETE FROM %s_aggregates WHERE resolution = ? AND bucket_time <= ?`
 )

--- a/cmd/metrics-scraper/app/scrape/db.go
+++ b/cmd/metrics-scraper/app/scrape/db.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 )
 
 var (
@@ -53,10 +54,55 @@ func GetDB(appName string) (*sql.DB, error) {
 		return nil, err
 	}
 
-	// Set connection pool settings
-	db.SetMaxOpenConns(1) // Restrict to 1 connection to prevent lock conflicts
-	db.SetMaxIdleConns(1)
+	// Enable WAL mode for concurrent read/write
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to enable WAL mode: %w", err)
+	}
+	if _, err := db.Exec("PRAGMA synchronous=NORMAL"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to set synchronous mode: %w", err)
+	}
+	// Enable incremental auto-vacuum to reclaim space after deletes.
+	// This pragma only takes effect on new databases; for existing ones we must VACUUM.
+	if _, err := db.Exec("PRAGMA auto_vacuum=INCREMENTAL"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to set auto_vacuum: %w", err)
+	}
+	var vacuumMode int
+	if err := db.QueryRow("PRAGMA auto_vacuum").Scan(&vacuumMode); err == nil && vacuumMode == 0 {
+		// Database was created with NONE; apply change via full VACUUM
+		_, _ = db.Exec("VACUUM")
+	}
+
+	// WAL mode allows concurrent readers, increase max connections
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(2)
 
 	dbMap[sanitizedAppName] = db
 	return db, nil
+}
+
+// RunPeriodicMaintenance starts a background goroutine that periodically
+// runs incremental vacuum and WAL checkpoint on all open databases.
+func RunPeriodicMaintenance() {
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			dbMapLock.RLock()
+			dbs := make([]*sql.DB, 0, len(dbMap))
+			for _, d := range dbMap {
+				dbs = append(dbs, d)
+			}
+			dbMapLock.RUnlock()
+
+			for _, d := range dbs {
+				// Reclaim freed pages
+				_, _ = d.Exec("PRAGMA incremental_vacuum(200)")
+				// Checkpoint WAL to keep file size bounded
+				_, _ = d.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+			}
+		}
+	}()
 }

--- a/cmd/metrics-scraper/app/scrape/job.go
+++ b/cmd/metrics-scraper/app/scrape/job.go
@@ -20,15 +20,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclient "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/rest"
 
 	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/db"
 	"github.com/karmada-io/dashboard/pkg/client"
@@ -42,12 +46,48 @@ type SaveRequest struct {
 	result  chan error
 }
 
+const metricsRequestTimeout = 10 * time.Second
+
+// DiscoverComponentPods returns live Kubernetes pod names for a metrics
+// component without depending on the component's metrics database.
+func DiscoverComponentPods(ctx context.Context, appName string) ([]string, []string, error) {
+	if db.GetComponentConfig(appName) == nil {
+		return nil, nil, fmt.Errorf("unsupported metrics component %q", appName)
+	}
+
+	podsByCluster, warnings := getKarmadaPods(ctx, appName)
+	uniqueNames := make(map[string]struct{})
+	for _, pods := range podsByCluster {
+		for _, pod := range pods {
+			uniqueNames[pod.Name] = struct{}{}
+		}
+	}
+	podNames := make([]string, 0, len(uniqueNames))
+	for name := range uniqueNames {
+		podNames = append(podNames, name)
+	}
+	sort.Strings(podNames)
+
+	if len(podNames) == 0 && len(warnings) > 0 {
+		return podNames, warnings, fmt.Errorf("failed to discover %s pods", appName)
+	}
+	return podNames, warnings, nil
+}
+
 // FetchMetrics fetches metrics from all pods of the given app name
 func FetchMetrics(ctx context.Context, appName string, requests chan SaveRequest) (map[string]*db.ParsedData, []string, error) {
 	kubeClient := client.InClusterClient()
+	componentConfig := db.GetComponentConfig(appName)
+	if componentConfig == nil {
+		return nil, nil, fmt.Errorf("unsupported metrics component %q", appName)
+	}
 	podsMap, errors := getKarmadaPods(ctx, appName) // Pass context here
-	if len(podsMap) == 0 && len(errors) > 0 {
-		return nil, errors, fmt.Errorf("no pods found")
+	podCount := 0
+	for _, pods := range podsMap {
+		podCount += len(pods)
+	}
+	if podCount == 0 {
+		return nil, errors, fmt.Errorf("no pods found for component %q", appName)
 	}
 	allMetrics := make(map[string]*db.ParsedData)
 	var mu sync.Mutex
@@ -65,7 +105,7 @@ func FetchMetrics(ctx context.Context, appName string, requests chan SaveRequest
 				var jsonMetrics *db.ParsedData
 				var err error
 				if appName == db.KarmadaAgent {
-					jsonMetrics, err = getKarmadaAgentMetrics(ctx, pod.Name, clusterName, requests)
+					jsonMetrics, err = getKarmadaAgentMetrics(ctx, pod.Name, clusterName)
 					if err != nil {
 						mu.Lock()
 						errors = append(errors, err.Error())
@@ -73,20 +113,10 @@ func FetchMetrics(ctx context.Context, appName string, requests chan SaveRequest
 						return
 					}
 				} else {
-					port := db.SchedulerPort
-					if appName == db.KarmadaControllerManager {
-						port = db.ControllerManagerPort
-					}
-					metricsOutput, err := kubeClient.CoreV1().RESTClient().Get().
-						Namespace(db.Namespace).
-						Resource("pods").
-						SubResource("proxy").
-						Name(fmt.Sprintf("%s:%s", pod.Name, port)).
-						Suffix("metrics").
-						Do(ctx).Raw() // Use the context here
+					metricsOutput, err := getMetricsFromHostClusterPod(ctx, kubeClient, pod, componentConfig)
 					if err != nil {
 						mu.Lock()
-						errors = append(errors, err.Error())
+						errors = append(errors, fmt.Sprintf("pod %s: %v", pod.Name, err))
 						mu.Unlock()
 						return
 					}
@@ -97,17 +127,12 @@ func FetchMetrics(ctx context.Context, appName string, requests chan SaveRequest
 						mu.Unlock()
 						return
 					}
-					// Send save request without waiting
-					select {
-					case requests <- SaveRequest{
-						appName: appName,
-						podName: pod.Name,
-						data:    jsonMetrics,
-						result:  nil, // Not waiting for result
-					}:
-					case <-ctx.Done():
-						return
-					}
+				}
+				if err = persistMetrics(ctx, requests, appName, pod.Name, jsonMetrics); err != nil {
+					mu.Lock()
+					errors = append(errors, fmt.Sprintf("pod %s: failed to persist metrics: %v", pod.Name, err))
+					mu.Unlock()
+					return
 				}
 				mu.Lock()
 				allMetrics[pod.Name] = jsonMetrics
@@ -116,7 +141,126 @@ func FetchMetrics(ctx context.Context, appName string, requests chan SaveRequest
 		}
 	}
 	wg.Wait()
+	if len(allMetrics) == 0 && len(errors) > 0 {
+		return nil, errors, fmt.Errorf("failed to scrape metrics from all %s pods", appName)
+	}
 	return allMetrics, errors, nil
+}
+
+func persistMetrics(ctx context.Context, requests chan SaveRequest, appName, podName string, data *db.ParsedData) error {
+	if requests == nil {
+		return nil
+	}
+
+	result := make(chan error, 1)
+	select {
+	case requests <- SaveRequest{appName: appName, podName: podName, data: data, result: result}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	select {
+	case err := <-result:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func getMetricsFromHostClusterPod(ctx context.Context, kubeClient kubeclient.Interface, pod db.PodInfo, cfg *db.ComponentConfig) ([]byte, error) {
+	if cfg.Scheme == "https" {
+		karmadaConfig, _, err := client.GetKarmadaConfig()
+		if err != nil {
+			return nil, fmt.Errorf("get Karmada client config: %w", err)
+		}
+		return getAuthenticatedPodMetrics(ctx, karmadaConfig, pod, cfg)
+	}
+	return getMetricsFromHostClusterPodProxy(ctx, kubeClient, pod.Name, cfg.Port, cfg.MetricsPath)
+}
+
+func getMetricsFromHostClusterPodProxy(ctx context.Context, kubeClient kubeclient.Interface, podName, port, metricsPath string) ([]byte, error) {
+	path := strings.TrimPrefix(metricsPath, "/")
+	metricsOutput, err := kubeClient.CoreV1().RESTClient().Get().
+		Namespace(db.Namespace).
+		Resource("pods").
+		SubResource("proxy").
+		Name(fmt.Sprintf("%s:%s", podName, port)).
+		Suffix(path).
+		Do(ctx).Raw()
+	if err == nil {
+		return metricsOutput, nil
+	}
+
+	// Some apiservers may not reliably handle pod proxy with "<pod>:<port>".
+	// Fall back to "<pod>/proxy/metrics" before failing.
+	if isPodProxyPortLookupError(err) {
+		return kubeClient.CoreV1().RESTClient().Get().
+			Namespace(db.Namespace).
+			Resource("pods").
+			SubResource("proxy").
+			Name(podName).
+			Suffix(path).
+			Do(ctx).Raw()
+	}
+
+	return nil, err
+}
+
+func getAuthenticatedPodMetrics(ctx context.Context, karmadaConfig *rest.Config, pod db.PodInfo, cfg *db.ComponentConfig) ([]byte, error) {
+	if pod.IP == "" {
+		return nil, fmt.Errorf("pod has no IP address")
+	}
+
+	transportConfig := rest.CopyConfig(karmadaConfig)
+	transportConfig.TLSClientConfig.ServerName = cfg.ServerName
+	if cfg.InsecureSkipVerify {
+		// #nosec G402 -- upstream kube-controller-manager uses an ephemeral
+		// self-signed serving certificate; authentication still uses the Karmada
+		// client credentials and the connection is restricted to the selected pod.
+		transportConfig.TLSClientConfig.Insecure = true
+		transportConfig.TLSClientConfig.CAData = nil
+		transportConfig.TLSClientConfig.CAFile = ""
+		transportConfig.TLSClientConfig.ServerName = ""
+	}
+	httpClient, err := rest.HTTPClientFor(transportConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create authenticated metrics client: %w", err)
+	}
+	httpClient.Timeout = metricsRequestTimeout
+
+	endpoint := url.URL{
+		Scheme: cfg.Scheme,
+		Host:   net.JoinHostPort(pod.IP, cfg.Port),
+		Path:   cfg.MetricsPath,
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create metrics request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", endpoint.Redacted(), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("GET %s returned %s: %s", endpoint.Redacted(), resp.Status, strings.TrimSpace(string(body)))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read metrics response from %s: %w", endpoint.Redacted(), err)
+	}
+	return body, nil
+}
+
+func isPodProxyPortLookupError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "could not find the requested resource") ||
+		strings.Contains(msg, "not found")
 }
 
 func getKarmadaPods(ctx context.Context, appName string) (map[string][]db.PodInfo, []string) {
@@ -143,8 +287,13 @@ func getKarmadaPods(ctx context.Context, appName string) (map[string][]db.PodInf
 			}
 		}
 	} else {
+		cfg := db.GetComponentConfig(appName)
+		if cfg == nil {
+			errors = append(errors, fmt.Sprintf("unsupported metrics component %q", appName))
+			return podsMap, errors
+		}
 		pods, err := kubeClient.CoreV1().Pods(db.Namespace).List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app=%s", appName),
+			LabelSelector: cfg.LabelSelector,
 		})
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("failed to list pods: %v", err))
@@ -152,7 +301,7 @@ func getKarmadaPods(ctx context.Context, appName string) (map[string][]db.PodInf
 		}
 
 		for _, pod := range pods.Items {
-			podsMap[appName] = append(podsMap[appName], db.PodInfo{Name: pod.Name})
+			podsMap[appName] = append(podsMap[appName], db.PodInfo{Name: pod.Name, IP: pod.Status.PodIP})
 		}
 	}
 
@@ -162,28 +311,14 @@ func getKarmadaPods(ctx context.Context, appName string) (map[string][]db.PodInf
 func getClusterPods(ctx context.Context, cluster *v1alpha1.Cluster) ([]db.PodInfo, error) {
 	fmt.Printf("Getting pods for cluster: %s\n", cluster.Name)
 
-	kubeconfigPath := os.Getenv("KUBECONFIG")
-	if kubeconfigPath == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get user home directory: %v", err)
-		}
-		kubeconfigPath = filepath.Join(homeDir, ".kube", "karmada.config")
+	kubeClient := client.InClusterClientForMemberCluster(cluster.Name)
+	if kubeClient == nil {
+		return nil, fmt.Errorf("failed to create kubeclient for cluster %s", cluster.Name)
 	}
 
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build config for cluster %s: %v", cluster.Name, err)
-	}
-
-	config.Host = fmt.Sprintf("%s/apis/cluster.karmada.io/v1alpha1/clusters/%s/proxy", config.Host, cluster.Name)
-
-	kubeClient, err := kubeclient.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubeclient for cluster %s: %v", cluster.Name, err)
-	}
-
-	podList, err := kubeClient.CoreV1().Pods("karmada-system").List(ctx, metav1.ListOptions{})
+	podList, err := kubeClient.CoreV1().Pods("karmada-system").List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app=%s", db.KarmadaAgent),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods for cluster %s: %v", cluster.Name, err)
 	}
@@ -200,43 +335,14 @@ func getClusterPods(ctx context.Context, cluster *v1alpha1.Cluster) ([]db.PodInf
 	return podInfos, nil
 }
 
-func getKarmadaAgentMetrics(ctx context.Context, podName string, clusterName string, requests chan SaveRequest) (*db.ParsedData, error) {
-	kubeClient := client.InClusterKarmadaClient()
-	clusters, err := kubeClient.ClusterV1alpha1().Clusters().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list clusters: %v", err)
-	}
-
-	for _, cluster := range clusters.Items {
-		if strings.EqualFold(string(cluster.Spec.SyncMode), "Pull") {
-			clusterName = cluster.Name
-			break
-		}
-	}
-
+func getKarmadaAgentMetrics(ctx context.Context, podName string, clusterName string) (*db.ParsedData, error) {
 	if clusterName == "" {
-		return nil, fmt.Errorf("no cluster in 'Pull' mode found")
+		return nil, fmt.Errorf("cluster name is required for karmada-agent metrics")
 	}
 
-	kubeconfigPath := os.Getenv("KUBECONFIG")
-	if kubeconfigPath == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get user home directory: %v", err)
-		}
-		kubeconfigPath = filepath.Join(homeDir, ".kube", "karmada.config")
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build config for cluster %s: %v", clusterName, err)
-	}
-
-	config.Host = fmt.Sprintf("%s/apis/cluster.karmada.io/v1alpha1/clusters/%s/proxy", config.Host, clusterName)
-
-	restClient, err := kubeclient.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create REST client for cluster %s: %v", clusterName, err)
+	restClient := client.InClusterClientForMemberCluster(clusterName)
+	if restClient == nil {
+		return nil, fmt.Errorf("failed to create REST client for cluster %s", clusterName)
 	}
 
 	metricsOutput, err := restClient.CoreV1().RESTClient().Get().
@@ -264,18 +370,6 @@ func getKarmadaAgentMetrics(ctx context.Context, podName string, clusterName str
 			return nil, fmt.Errorf("failed to parse metrics to JSON: %v", err)
 		}
 		parsedData = parsedDataPtr
-	}
-
-	// Send save request to the database worker
-	select {
-	case requests <- SaveRequest{
-		appName: db.KarmadaAgent,
-		podName: podName,
-		data:    parsedData,
-		result:  nil, // Not waiting for result
-	}:
-	case <-ctx.Done():
-		return nil, ctx.Err()
 	}
 
 	return parsedData, nil

--- a/cmd/metrics-scraper/app/scrape/job_test.go
+++ b/cmd/metrics-scraper/app/scrape/job_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scrape
+
+import (
+	"bytes"
+	"context"
+	"encoding/pem"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/db"
+)
+
+func TestGetAuthenticatedPodMetricsUsesKarmadaCredentials(t *testing.T) {
+	const token = "metrics-reader-token"
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			http.Error(w, "missing Karmada credentials", http.StatusForbidden)
+			return
+		}
+		if r.URL.Path != "/custom-metrics" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte("# TYPE karmada_build_info gauge\nkarmada_build_info 1\n"))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	host, port, err := net.SplitHostPort(serverURL.Host)
+	if err != nil {
+		t.Fatalf("split test server address: %v", err)
+	}
+	certificate := server.Certificate()
+	caData := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw})
+
+	got, err := getAuthenticatedPodMetrics(
+		context.Background(),
+		&rest.Config{BearerToken: token, TLSClientConfig: rest.TLSClientConfig{CAData: caData}},
+		db.PodInfo{Name: "aggregated-apiserver-0", IP: host},
+		&db.ComponentConfig{Scheme: "https", Port: port, MetricsPath: "/custom-metrics"},
+	)
+	if err != nil {
+		t.Fatalf("getAuthenticatedPodMetrics returned error: %v", err)
+	}
+	if string(got) != "# TYPE karmada_build_info gauge\nkarmada_build_info 1\n" {
+		t.Fatalf("unexpected metrics body %q", got)
+	}
+}
+
+func TestGetAuthenticatedPodMetricsRequiresPodIP(t *testing.T) {
+	_, err := getAuthenticatedPodMetrics(
+		context.Background(),
+		&rest.Config{},
+		db.PodInfo{Name: "pending-pod"},
+		&db.ComponentConfig{Scheme: "https", Port: "443", MetricsPath: "/metrics"},
+	)
+	if err == nil {
+		t.Fatal("expected an error for a pod without an IP")
+	}
+}
+
+func TestParseFiniteMetricValue(t *testing.T) {
+	for _, raw := range []string{"NaN", "+Inf", "-Inf", "not-a-number"} {
+		if value, ok := parseFiniteMetricValue(raw); ok {
+			t.Fatalf("parseFiniteMetricValue(%q) = %v, true; want rejected", raw, value)
+		}
+	}
+	if value, ok := parseFiniteMetricValue(" 12.5 "); !ok || value != 12.5 {
+		t.Fatalf("parseFiniteMetricValue(valid) = %v, %t; want 12.5, true", value, ok)
+	}
+}
+
+func TestGetAuthenticatedPodMetricsIntegration(t *testing.T) {
+	podIP := os.Getenv("METRICS_INTEGRATION_POD_IP")
+	kubeconfig := os.Getenv("METRICS_INTEGRATION_KUBECONFIG")
+	if podIP == "" || kubeconfig == "" {
+		t.Skip("set METRICS_INTEGRATION_POD_IP and METRICS_INTEGRATION_KUBECONFIG to run")
+	}
+
+	karmadaConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("load Karmada kubeconfig: %v", err)
+	}
+	component := os.Getenv("METRICS_INTEGRATION_COMPONENT")
+	if component == "" {
+		component = db.KarmadaAggregatedAPIServer
+	}
+	cfg := db.GetComponentConfig(component)
+	if cfg == nil {
+		t.Fatalf("%s scrape config is missing", component)
+	}
+
+	metrics, err := getAuthenticatedPodMetrics(
+		context.Background(),
+		karmadaConfig,
+		db.PodInfo{Name: "integration-target", IP: podIP},
+		cfg,
+	)
+	if err != nil {
+		t.Fatalf("scrape %s: %v", component, err)
+	}
+	if !bytes.Contains(metrics, []byte("# HELP")) || !bytes.Contains(metrics, []byte("# TYPE")) {
+		t.Fatalf("response is not Prometheus metrics text (length %d)", len(metrics))
+	}
+	t.Logf("scraped %d bytes from %s", len(metrics), component)
+}

--- a/cmd/metrics-scraper/app/scrape/other.go
+++ b/cmd/metrics-scraper/app/scrape/other.go
@@ -21,24 +21,46 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	_ "github.com/glebarez/sqlite" // Import the SQLite driver
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 
 	"github.com/karmada-io/dashboard/cmd/metrics-scraper/app/db"
 )
 
-var dbMutex sync.Mutex
+var (
+	dbMutexMap      = make(map[string]*sync.Mutex)
+	dbMutexLock     sync.Mutex
+	scrapeCounter   uint64
+	scrapeCounterMu sync.Mutex
+)
+
+func getDBMutex(appName string) *sync.Mutex {
+	dbMutexLock.Lock()
+	defer dbMutexLock.Unlock()
+
+	if mu, ok := dbMutexMap[appName]; ok {
+		return mu
+	}
+
+	mu := &sync.Mutex{}
+	dbMutexMap[appName] = mu
+	return mu
+}
 
 func saveToDBWithConnection(db *sql.DB, appName, podName string, data *db.ParsedData) (err error) {
 	sanitizedPodName := strings.ReplaceAll(podName, "-", "_")
 	log.Printf("Saving data for app '%s', pod '%s' (sanitized: '%s')", appName, podName, sanitizedPodName)
 
-	dbMutex.Lock()
-	defer dbMutex.Unlock()
+	mu := getDBMutex(appName)
+	mu.Lock()
+	defer mu.Unlock()
 
 	tx, err := db.Begin()
 	if err != nil {
@@ -64,13 +86,41 @@ func saveToDBWithConnection(db *sql.DB, appName, podName string, data *db.Parsed
 		return err
 	}
 
+	if _, err = tx.Exec(fmt.Sprintf(createMetadataTableSQL, sanitizedPodName)); err != nil {
+		log.Printf("Error creating metadata table: %v", err)
+		return err
+	}
+
 	if _, err = tx.Exec(fmt.Sprintf(createValuesTableSQL, sanitizedPodName, sanitizedPodName)); err != nil {
 		log.Printf("Error creating values table: %v", err)
 		return err
 	}
 
-	if _, err = tx.Exec(fmt.Sprintf(createLabelsTableSQL, sanitizedPodName, sanitizedPodName)); err != nil {
+	if _, err = tx.Exec(fmt.Sprintf(createLabelStringsTableSQL, sanitizedPodName)); err != nil {
+		log.Printf("Error creating label_strings table: %v", err)
+		return err
+	}
+
+	if _, err = tx.Exec(fmt.Sprintf(createLabelsTableSQL, sanitizedPodName, sanitizedPodName, sanitizedPodName)); err != nil {
 		log.Printf("Error creating labels table: %v", err)
+		return err
+	}
+
+	// Create indexes for query performance
+	if _, err = tx.Exec(fmt.Sprintf(createMainIndexSQL, sanitizedPodName, sanitizedPodName)); err != nil {
+		log.Printf("Error creating main index: %v", err)
+		return err
+	}
+	if _, err = tx.Exec(fmt.Sprintf(createValuesIndexSQL, sanitizedPodName, sanitizedPodName)); err != nil {
+		log.Printf("Error creating values index: %v", err)
+		return err
+	}
+	if _, err = tx.Exec(fmt.Sprintf(createLabelsIndexSQL, sanitizedPodName, sanitizedPodName)); err != nil {
+		log.Printf("Error creating labels index: %v", err)
+		return err
+	}
+	if _, err = tx.Exec(fmt.Sprintf(createLabelStringsIndexSQL, sanitizedPodName, sanitizedPodName)); err != nil {
+		log.Printf("Error creating label_strings index: %v", err)
 		return err
 	}
 
@@ -96,54 +146,73 @@ func saveToDBWithConnection(db *sql.DB, appName, podName string, data *db.Parsed
 		return err
 	}
 
-	if err = tx.Commit(); err != nil {
-		log.Printf("Error committing transaction: %v", err)
-		return err
-	}
-
 	log.Println("Data inserted successfully")
 	return nil
 }
 
 func cleanupOldData(tx *sql.Tx, timeLoadTableName, sanitizedPodName string) error {
-	var oldestTime string
-	err := tx.QueryRow(fmt.Sprintf(getOldestTimeSQL, timeLoadTableName)).Scan(&oldestTime)
-	if err != nil && err != sql.ErrNoRows {
-		log.Printf("Error getting oldest time entry: %v", err)
+	// Use time-based TTL: delete everything older than 5 minutes
+	cutoffTime := time.Now().Add(-15 * time.Minute).Format(time.RFC3339)
+
+	result, err := tx.Exec(fmt.Sprintf(deleteOldTimeSQL, timeLoadTableName), cutoffTime)
+	if err != nil {
+		log.Printf("Error deleting old time entries: %v", err)
 		return err
 	}
-
-	if oldestTime != "" {
-		result, err := tx.Exec(fmt.Sprintf(deleteOldTimeSQL, timeLoadTableName), oldestTime)
-		if err != nil {
-			log.Printf("Error deleting old time entries: %v", err)
-			return err
-		}
-		rowsAffected, _ := result.RowsAffected()
+	rowsAffected, _ := result.RowsAffected()
+	if rowsAffected > 0 {
 		log.Printf("Deleted %d old time entries from %s", rowsAffected, timeLoadTableName)
 
-		result, err = tx.Exec(fmt.Sprintf(deleteAssociatedMetricsSQL, sanitizedPodName), oldestTime)
+		// Delete labels first (depends on values which depends on metrics)
+		result, err = tx.Exec(fmt.Sprintf(deleteAssociatedLabelsSQL, sanitizedPodName, sanitizedPodName, sanitizedPodName), cutoffTime)
 		if err != nil {
-			log.Printf("Error deleting associated metrics: %v", err)
+			log.Printf("Error deleting associated labels: %v", err)
 			return err
 		}
-		rowsAffected, _ = result.RowsAffected()
-		log.Printf("Deleted %d associated metrics from %s", rowsAffected, sanitizedPodName)
+		labelsAffected, _ := result.RowsAffected()
+		log.Printf("Deleted %d associated labels from %s_labels", labelsAffected, sanitizedPodName)
 
-		result, err = tx.Exec(fmt.Sprintf(deleteAssociatedValuesSQL, sanitizedPodName, sanitizedPodName))
+		// Delete values (depends on metrics)
+		result, err = tx.Exec(fmt.Sprintf(deleteAssociatedValuesSQL, sanitizedPodName, sanitizedPodName), cutoffTime)
 		if err != nil {
 			log.Printf("Error deleting associated values: %v", err)
 			return err
 		}
-		rowsAffected, _ = result.RowsAffected()
-		log.Printf("Deleted %d associated values from %s_values", rowsAffected, sanitizedPodName)
+		valuesAffected, _ := result.RowsAffected()
+		log.Printf("Deleted %d associated values from %s_values", valuesAffected, sanitizedPodName)
+
+		// Delete metrics last
+		result, err = tx.Exec(fmt.Sprintf(deleteAssociatedMetricsSQL, sanitizedPodName), cutoffTime)
+		if err != nil {
+			log.Printf("Error deleting associated metrics: %v", err)
+			return err
+		}
+		metricsAffected, _ := result.RowsAffected()
+		log.Printf("Deleted %d associated metrics from %s", metricsAffected, sanitizedPodName)
 	}
 	return nil
 }
 
 func insertMetricsData(tx *sql.Tx, data *db.ParsedData, sanitizedPodName string) error {
+	scrapeCounterMu.Lock()
+	scrapeCounter++
+	currentScrape := scrapeCounter
+	scrapeCounterMu.Unlock()
+
 	for metricName, metricData := range data.Metrics {
-		result, err := tx.Exec(fmt.Sprintf(insertMainSQL, sanitizedPodName), metricName, metricData.Help, metricData.Type, data.CurrentTime)
+		tier := db.GetMetricTier(metricName)
+
+		// Skip low-tier metrics on non-sampled scrapes (keep every 3rd)
+		if tier == db.TierLow && currentScrape%3 != 0 {
+			continue
+		}
+
+		if _, err := tx.Exec(fmt.Sprintf(insertMetadataSQL, sanitizedPodName), metricName, metricData.Help, metricData.Type); err != nil {
+			log.Printf("Error inserting metadata for metric %s: %v", metricName, err)
+			return err
+		}
+
+		result, err := tx.Exec(fmt.Sprintf(insertMainSQL, sanitizedPodName), metricName, data.CurrentTime)
 		if err != nil {
 			log.Printf("Error inserting data for metric %s: %v", metricName, err)
 			return err
@@ -156,7 +225,16 @@ func insertMetricsData(tx *sql.Tx, data *db.ParsedData, sanitizedPodName string)
 		}
 
 		for _, value := range metricData.Values {
-			valueIDResult, err := tx.Exec(fmt.Sprintf("INSERT INTO %s_values (metric_id, value, measure) VALUES (?, ?, ?)", sanitizedPodName), metricID, value.Value, value.Measure)
+			// Skip histogram bucket detail rows — keep only sum and count
+			if value.Measure == "cumulative_count" {
+				continue
+			}
+
+			numericValue, ok := parseFiniteMetricValue(value.Value)
+			if !ok {
+				continue
+			}
+			valueIDResult, err := tx.Exec(fmt.Sprintf("INSERT INTO %s_values (metric_id, value, measure) VALUES (?, ?, ?)", sanitizedPodName), metricID, numericValue, value.Measure)
 			if err != nil {
 				log.Printf("Error inserting value for metric %s: %v", metricName, err)
 				return err
@@ -168,15 +246,36 @@ func insertMetricsData(tx *sql.Tx, data *db.ParsedData, sanitizedPodName string)
 			}
 
 			for labelKey, labelValue := range value.Labels {
-				_, err = tx.Exec(fmt.Sprintf("INSERT INTO %s_labels (value_id, key, value) VALUES (?, ?, ?)", sanitizedPodName), valueID, labelKey, labelValue)
+				_, err = tx.Exec(fmt.Sprintf("INSERT OR IGNORE INTO %s_label_strings (key, value) VALUES (?, ?)", sanitizedPodName), labelKey, labelValue)
 				if err != nil {
-					log.Printf("Error inserting label for value of metric %s: %v", metricName, err)
+					log.Printf("Error interning label for metric %s: %v", metricName, err)
+					return err
+				}
+
+				var labelStringID int64
+				err = tx.QueryRow(fmt.Sprintf("SELECT id FROM %s_label_strings WHERE key = ? AND value = ?", sanitizedPodName), labelKey, labelValue).Scan(&labelStringID)
+				if err != nil {
+					log.Printf("Error getting interned label ID for metric %s: %v", metricName, err)
+					return err
+				}
+
+				_, err = tx.Exec(fmt.Sprintf("INSERT INTO %s_labels (value_id, label_string_id) VALUES (?, ?)", sanitizedPodName), valueID, labelStringID)
+				if err != nil {
+					log.Printf("Error inserting label ref for metric %s: %v", metricName, err)
 					return err
 				}
 			}
 		}
 	}
 	return nil
+}
+
+func parseFiniteMetricValue(raw string) (float64, bool) {
+	value, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, false
+	}
+	return value, true
 }
 
 func isJSON(data []byte) bool {
@@ -206,7 +305,7 @@ func startDatabaseWorker(requests chan SaveRequest) {
 }
 
 func parseMetricsToJSON(metricsOutput string) (*db.ParsedData, error) {
-	var parser expfmt.TextParser
+	parser := expfmt.NewTextParser(model.UTF8Validation)
 	metricFamilies, err := parser.TextToMetricFamilies(strings.NewReader(metricsOutput))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing metrics: %w", err)

--- a/cmd/metrics-scraper/app/scrape/scrape.go
+++ b/cmd/metrics-scraper/app/scrape/scrape.go
@@ -19,6 +19,7 @@ package scrape
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -31,17 +32,28 @@ import (
 )
 
 var (
-	requests chan SaveRequest
-	sqldb    *sql.DB
-	syncMap  sync.Map
+	requestsMap map[string]chan SaveRequest
+	sqldb       *sql.DB
+	syncMap     sync.Map
+	// scrapeInterval controls how frequently each app fetcher triggers a scrape cycle.
+	scrapeInterval = 10 * time.Second
 	// Add contexts and cancel functions for each app
 	appContexts    map[string]context.Context
 	appCancelFuncs map[string]context.CancelFunc
 	contextMutex   sync.Mutex
 )
 
+func getRequestsChannel(appName string) (chan SaveRequest, bool) {
+	if requestsMap == nil {
+		return nil, false
+	}
+
+	requests, ok := requestsMap[appName]
+	return requests, ok
+}
+
 func startAppMetricsFetcher(appName string) {
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(scrapeInterval)
 	defer ticker.Stop()
 
 	for {
@@ -66,15 +78,19 @@ func startAppMetricsFetcher(appName string) {
 
 			syncTrigger, ok := syncTriggerVal.(int)
 			if !ok || syncTrigger != 1 {
-				return
+				continue
 			}
 
-			go func(ctx context.Context) {
-				_, errors, err := FetchMetrics(ctx, appName, requests)
-				if err != nil {
-					log.Printf("Error fetching metrics for %s: %v, errors: %v\n", appName, err, errors)
-				}
-			}(ctx)
+			requests, ok := getRequestsChannel(appName)
+			if !ok {
+				log.Printf("Request channel not found for %s", appName)
+				continue
+			}
+
+			_, errors, err := FetchMetrics(ctx, appName, requests)
+			if err != nil {
+				log.Printf("Error fetching metrics for %s: %v, errors: %v\n", appName, err, errors)
+			}
 		}
 	}
 }
@@ -83,7 +99,7 @@ func startAppMetricsFetcher(appName string) {
 func CheckAppStatus(c *gin.Context) {
 	statusMap := make(map[string]bool)
 
-	// Get status for all registered apps
+	// Get status for all registered apps (same list as InitDatabase)
 	for _, app := range []string{
 		db.KarmadaScheduler,
 		db.KarmadaControllerManager,
@@ -91,6 +107,13 @@ func CheckAppStatus(c *gin.Context) {
 		db.KarmadaSchedulerEstimator + "-member1",
 		db.KarmadaSchedulerEstimator + "-member2",
 		db.KarmadaSchedulerEstimator + "-member3",
+		db.KarmadaAggregatedAPIServer,
+		db.KarmadaAPIServer,
+		db.KarmadaDescheduler,
+		db.KarmadaKubeControllerManager,
+		db.KarmadaMetricsAdapter,
+		db.KarmadaSearch,
+		db.KarmadaWebhook,
 	} {
 		syncValue, exists := syncMap.Load(app)
 		if !exists {
@@ -122,9 +145,11 @@ func HandleSyncOperation(c *gin.Context, appName string, syncValue int, queryTyp
 		// Cancel all existing contexts and create new ones if turning on
 		contextMutex.Lock()
 		for app := range appContexts {
-			currentSyncValue, _ := syncMap.Load(app)
-			if currentSyncValue == syncValue {
-				continue // Skip if already in the desired state
+			currentSyncValue, ok := syncMap.Load(app)
+			if ok {
+				if val, isInt := currentSyncValue.(int); isInt && val == syncValue {
+					continue // Skip if already in the desired state
+				}
 			}
 
 			if cancel, exists := appCancelFuncs[app]; exists {
@@ -150,11 +175,13 @@ func HandleSyncOperation(c *gin.Context, appName string, syncValue int, queryTyp
 		c.JSON(http.StatusOK, gin.H{"message": message})
 	} else {
 		// Update specific app
-		currentSyncValue, _ := syncMap.Load(appName)
-		if currentSyncValue == syncValue {
-			message := fmt.Sprintf("Sync is already %s for %s", queryType, appName)
-			c.JSON(http.StatusOK, gin.H{"message": message})
-			return
+		currentSyncValue, ok := syncMap.Load(appName)
+		if ok {
+			if val, isInt := currentSyncValue.(int); isInt && val == syncValue {
+				message := fmt.Sprintf("Sync is already %s for %s", queryType, appName)
+				c.JSON(http.StatusOK, gin.H{"message": message})
+				return
+			}
 		}
 
 		_, err := sqldb.Exec("UPDATE app_sync SET sync_trigger = ? WHERE app_name = ?", syncValue, appName)
@@ -190,7 +217,12 @@ func HandleSyncOperation(c *gin.Context, appName string, syncValue int, queryTyp
 }
 
 // InitDatabase initializes the database and starts the metrics fetchers.
-func InitDatabase() {
+func InitDatabase(interval time.Duration) {
+	if interval > 0 {
+		scrapeInterval = interval
+	}
+	log.Printf("Metrics scrape interval set to %s", scrapeInterval)
+
 	// Initialize contexts and cancel functions
 	appContexts = make(map[string]context.Context)
 	appCancelFuncs = make(map[string]context.CancelFunc)
@@ -202,6 +234,13 @@ func InitDatabase() {
 		db.KarmadaSchedulerEstimator + "-member1",
 		db.KarmadaSchedulerEstimator + "-member2",
 		db.KarmadaSchedulerEstimator + "-member3",
+		db.KarmadaAggregatedAPIServer,
+		db.KarmadaAPIServer,
+		db.KarmadaDescheduler,
+		db.KarmadaKubeControllerManager,
+		db.KarmadaMetricsAdapter,
+		db.KarmadaSearch,
+		db.KarmadaWebhook,
 	}
 
 	// Create database connection
@@ -239,11 +278,36 @@ func InitDatabase() {
 		syncMap.Store(appName, 1)
 	}
 
-	requests = make(chan SaveRequest, len(appNames))
-	go startDatabaseWorker(requests)
+	requestsMap = make(map[string]chan SaveRequest, len(appNames))
+	for _, appName := range appNames {
+		requests := make(chan SaveRequest, len(appNames))
+		requestsMap[appName] = requests
+		go startDatabaseWorker(requests)
+	}
 
 	// Start metrics fetchers with context
 	for _, app := range appNames {
 		go startAppMetricsFetcher(app)
 	}
+
+	// Start periodic database maintenance (vacuum + WAL checkpoint)
+	RunPeriodicMaintenance()
+
+	// Start aggregation workers for downsampling
+	StartAggregationWorkers()
+}
+
+// TriggerScrapeNow triggers an immediate scrape for a single app and stores the result.
+func TriggerScrapeNow(ctx context.Context, appName string) ([]string, error) {
+	requests, ok := getRequestsChannel(appName)
+	if !ok {
+		return nil, errors.New("metrics scraper is not initialized for app")
+	}
+
+	_, scrapeErrors, err := FetchMetrics(ctx, appName, requests)
+	if err != nil {
+		return scrapeErrors, err
+	}
+
+	return scrapeErrors, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,8 +114,71 @@ func GetDashboardConfig() DashboardConfig {
 	if config.MenuConfigs == nil {
 		config.MenuConfigs = []MenuConfig{}
 	}
+	if config.MetricsDashboards == nil {
+		config.MetricsDashboards = []MetricsDashboard{}
+	}
 
 	return config
+}
+
+// GetMetricsDashboards returns the persisted metrics dashboards (never nil).
+func GetMetricsDashboards() []MetricsDashboard {
+	if dashboardConfig.MetricsDashboards == nil {
+		return []MetricsDashboard{}
+	}
+	dashboards := make([]MetricsDashboard, len(dashboardConfig.MetricsDashboards))
+	copy(dashboards, dashboardConfig.MetricsDashboards)
+	return dashboards
+}
+
+// UpsertMetricsDashboard inserts or replaces the metrics dashboard for a single
+// component and persists it to the dashboard ConfigMap. It reads the ConfigMap
+// fresh and merges only the metrics dashboards, so other config fields are never
+// clobbered by a stale in-memory cache.
+func UpsertMetricsDashboard(k8sClient kubernetes.Interface, dashboard MetricsDashboard) error {
+	ctx := context.TODO()
+	configMap, err := k8sClient.CoreV1().ConfigMaps(configNamespace).Get(ctx, configName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Failed to get ConfigMap %s: %v", configName, err)
+		return err
+	}
+
+	configKey := GetConfigKey()
+	var current DashboardConfig
+	if raw, ok := configMap.Data[configKey]; ok && raw != "" {
+		if err = yaml.Unmarshal([]byte(raw), &current); err != nil {
+			klog.Errorf("Failed to unmarshal ConfigMap %s: %v", configName, err)
+			return err
+		}
+	}
+
+	replaced := false
+	for i := range current.MetricsDashboards {
+		if current.MetricsDashboards[i].Component == dashboard.Component {
+			current.MetricsDashboards[i] = dashboard
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		current.MetricsDashboards = append(current.MetricsDashboards, dashboard)
+	}
+
+	buff, err := yaml.Marshal(current)
+	if err != nil {
+		klog.Errorf("Failed to marshal dashboard config: %v", err)
+		return err
+	}
+	if configMap.Data == nil {
+		configMap.Data = map[string]string{}
+	}
+	configMap.Data[configKey] = string(buff)
+	if _, err = k8sClient.CoreV1().ConfigMaps(configNamespace).Update(ctx, configMap, metav1.UpdateOptions{}); err != nil {
+		klog.Errorf("Failed to update ConfigMap %s: %v", configName, err)
+		return err
+	}
+	dashboardConfig = current
+	return nil
 }
 
 // UpdateDashboardConfig updates the dashboard configuration in the Kubernetes ConfigMap.

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -42,10 +42,42 @@ type MenuConfig struct {
 	Children   []MenuConfig `yaml:"children" json:"children,omitempty"`
 }
 
+// MetricLabelFilter represents a single label matcher used by a metric panel query.
+type MetricLabelFilter struct {
+	Key   string `yaml:"key" json:"key"`
+	Value string `yaml:"value" json:"value"`
+}
+
+// MetricPanelQuery represents the query definition backing a metric panel.
+type MetricPanelQuery struct {
+	Metric       string              `yaml:"metric" json:"metric"`
+	Aggregation  string              `yaml:"aggregation" json:"aggregation"`
+	LabelFilters []MetricLabelFilter `yaml:"label_filters,omitempty" json:"labelFilters,omitempty"`
+}
+
+// MetricPanel represents a single chart panel on the metrics dashboard.
+type MetricPanel struct {
+	ID         string            `yaml:"id" json:"id"`
+	MetricName string            `yaml:"metric_name" json:"metricName"`
+	ChartType  string            `yaml:"chart_type" json:"chartType"`
+	Title      string            `yaml:"title" json:"title"`
+	Visible    bool              `yaml:"visible" json:"visible"`
+	Query      *MetricPanelQuery `yaml:"query,omitempty" json:"query,omitempty"`
+	Order      *int              `yaml:"order,omitempty" json:"order,omitempty"`
+}
+
+// MetricsDashboard represents the persisted panel layout for a single component.
+type MetricsDashboard struct {
+	Version   int           `yaml:"version" json:"version"`
+	Component string        `yaml:"component" json:"component"`
+	Panels    []MetricPanel `yaml:"panels" json:"panels"`
+}
+
 // DashboardConfig represents the configuration structure for the Karmada dashboard.
 type DashboardConfig struct {
-	DockerRegistries []DockerRegistry `yaml:"docker_registries" json:"docker_registries"`
-	ChartRegistries  []ChartRegistry  `yaml:"chart_registries" json:"chart_registries"`
-	MenuConfigs      []MenuConfig     `yaml:"menu_configs" json:"menu_configs"`
-	PathPrefix       string           `yaml:"path_prefix" json:"path_prefix"`
+	DockerRegistries  []DockerRegistry   `yaml:"docker_registries" json:"docker_registries"`
+	ChartRegistries   []ChartRegistry    `yaml:"chart_registries" json:"chart_registries"`
+	MenuConfigs       []MenuConfig       `yaml:"menu_configs" json:"menu_configs"`
+	PathPrefix        string             `yaml:"path_prefix" json:"path_prefix"`
+	MetricsDashboards []MetricsDashboard `yaml:"metrics_dashboards,omitempty" json:"metrics_dashboards,omitempty"`
 }


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

- collects and aggregates metrics from Karmada control-plane components
- stores component metric samples for time-window queries
- adds metric exploration, pod discovery, visualization, and dashboard configuration APIs

This is PR 1 of 3 for component metrics support and contains only the metrics-scraper backend scope.

## Which issue(s) this PR fixes

None

## Special notes for reviewers

The single commit includes a DCO Signed-off-by trailer matching the commit author.