### PR TITLE
feat(dashboard): add component metrics visualization

### DIFF
--- a/ui/DESIGN.md
+++ b/ui/DESIGN.md
@@ -1,0 +1,310 @@
+# Design System Inspired by Vercel
+
+## 1. Visual Theme & Atmosphere
+
+Vercel's website is the visual thesis of developer infrastructure made invisible — a design system so restrained it borders on philosophical. The page is overwhelmingly white (`#ffffff`) with near-black (`#171717`) text, creating a gallery-like emptiness where every element earns its pixel. This isn't minimalism as decoration; it's minimalism as engineering principle. The Geist design system treats the interface like a compiler treats code — every unnecessary token is stripped away until only structure remains.
+
+The custom Geist font family is the crown jewel. Geist Sans uses aggressive negative letter-spacing (-2.4px to -2.88px at display sizes), creating headlines that feel compressed, urgent, and engineered — like code that's been minified for production. At body sizes, the tracking relaxes but the geometric precision persists. Geist Mono completes the system as the monospace companion for code, terminal output, and technical labels. Both fonts enable OpenType `"liga"` (ligatures) globally, adding a layer of typographic sophistication that rewards close reading.
+
+What distinguishes Vercel from other monochrome design systems is its shadow-as-border philosophy. Instead of traditional CSS borders, Vercel uses `box-shadow: 0px 0px 0px 1px rgba(0,0,0,0.08)` — a zero-offset, zero-blur, 1px-spread shadow that creates a border-like line without the box model implications. This technique allows borders to exist in the shadow layer, enabling smoother transitions, rounded corners without clipping, and a subtler visual weight than traditional borders. The entire depth system is built on layered, multi-value shadow stacks where each layer serves a specific purpose: one for the border, one for soft elevation, one for ambient depth.
+
+**Key Characteristics:**
+- Geist Sans with extreme negative letter-spacing (-2.4px to -2.88px at display) — text as compressed infrastructure
+- Geist Mono for code and technical labels with OpenType `"liga"` globally
+- Shadow-as-border technique: `box-shadow 0px 0px 0px 1px` replaces traditional borders throughout
+- Multi-layer shadow stacks for nuanced depth (border + elevation + ambient in single declarations)
+- Near-pure white canvas with `#171717` text — not quite black, creating micro-contrast softness
+- Workflow-specific accent colors: Ship Red (`#ff5b4f`), Preview Pink (`#de1d8d`), Develop Blue (`#0a72ef`)
+- Focus ring system using `hsla(212, 100%, 48%, 1)` — a saturated blue for accessibility
+- Pill badges (9999px) with tinted backgrounds for status indicators
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Vercel Black** (`#171717`): Primary text, headings, dark surface backgrounds. Not pure black — the slight warmth prevents harshness.
+- **Pure White** (`#ffffff`): Page background, card surfaces, button text on dark.
+- **True Black** (`#000000`): Secondary use, `--geist-console-text-color-default`, used in specific console/code contexts.
+
+### Workflow Accent Colors
+- **Ship Red** (`#ff5b4f`): `--ship-text`, the "ship to production" workflow step — warm, urgent coral-red.
+- **Preview Pink** (`#de1d8d`): `--preview-text`, the preview deployment workflow — vivid magenta-pink.
+- **Develop Blue** (`#0a72ef`): `--develop-text`, the development workflow — bright, focused blue.
+
+### Console / Code Colors
+- **Console Blue** (`#0070f3`): `--geist-console-text-color-blue`, syntax highlighting blue.
+- **Console Purple** (`#7928ca`): `--geist-console-text-color-purple`, syntax highlighting purple.
+- **Console Pink** (`#eb367f`): `--geist-console-text-color-pink`, syntax highlighting pink.
+
+### Interactive
+- **Link Blue** (`#0072f5`): Primary link color with underline decoration.
+- **Focus Blue** (`hsla(212, 100%, 48%, 1)`): `--ds-focus-color`, focus ring on interactive elements.
+- **Ring Blue** (`rgba(147, 197, 253, 0.5)`): `--tw-ring-color`, Tailwind ring utility.
+
+### Neutral Scale
+- **Gray 900** (`#171717`): Primary text, headings, nav text.
+- **Gray 600** (`#4d4d4d`): Secondary text, description copy.
+- **Gray 500** (`#666666`): Tertiary text, muted links.
+- **Gray 400** (`#808080`): Placeholder text, disabled states.
+- **Gray 100** (`#ebebeb`): Borders, card outlines, dividers.
+- **Gray 50** (`#fafafa`): Subtle surface tint, inner shadow highlight.
+
+### Surface & Overlay
+- **Overlay Backdrop** (`hsla(0, 0%, 98%, 1)`): `--ds-overlay-backdrop-color`, modal/dialog backdrop.
+- **Selection Text** (`hsla(0, 0%, 95%, 1)`): `--geist-selection-text-color`, text selection highlight.
+- **Badge Blue Bg** (`#ebf5ff`): Pill badge background, tinted blue surface.
+- **Badge Blue Text** (`#0068d6`): Pill badge text, darker blue for readability.
+
+### Shadows & Depth
+- **Border Shadow** (`rgba(0, 0, 0, 0.08) 0px 0px 0px 1px`): The signature — replaces traditional borders.
+- **Subtle Elevation** (`rgba(0, 0, 0, 0.04) 0px 2px 2px`): Minimal lift for cards.
+- **Card Stack** (`rgba(0,0,0,0.08) 0px 0px 0px 1px, rgba(0,0,0,0.04) 0px 2px 2px, rgba(0,0,0,0.04) 0px 8px 8px -8px, #fafafa 0px 0px 0px 1px`): Full multi-layer card shadow.
+- **Ring Border** (`rgb(235, 235, 235) 0px 0px 0px 1px`): Light gray ring-border for tabs and images.
+
+## 3. Typography Rules
+
+### Font Family
+- **Primary**: `Geist`, with fallbacks: `Arial, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol`
+- **Monospace**: `Geist Mono`, with fallbacks: `ui-monospace, SFMono-Regular, Roboto Mono, Menlo, Monaco, Liberation Mono, DejaVu Sans Mono, Courier New`
+- **OpenType Features**: `"liga"` enabled globally on all Geist text; `"tnum"` for tabular numbers on specific captions.
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Geist | 48px (3.00rem) | 600 | 1.00–1.17 (tight) | -2.4px to -2.88px | Maximum compression, billboard impact |
+| Section Heading | Geist | 40px (2.50rem) | 600 | 1.20 (tight) | -2.4px | Feature section titles |
+| Sub-heading Large | Geist | 32px (2.00rem) | 600 | 1.25 (tight) | -1.28px | Card headings, sub-sections |
+| Sub-heading | Geist | 32px (2.00rem) | 400 | 1.50 | -1.28px | Lighter sub-headings |
+| Card Title | Geist | 24px (1.50rem) | 600 | 1.33 | -0.96px | Feature cards |
+| Card Title Light | Geist | 24px (1.50rem) | 500 | 1.33 | -0.96px | Secondary card headings |
+| Body Large | Geist | 20px (1.25rem) | 400 | 1.80 (relaxed) | normal | Introductions, feature descriptions |
+| Body | Geist | 18px (1.13rem) | 400 | 1.56 | normal | Standard reading text |
+| Body Small | Geist | 16px (1.00rem) | 400 | 1.50 | normal | Standard UI text |
+| Body Medium | Geist | 16px (1.00rem) | 500 | 1.50 | normal | Navigation, emphasized text |
+| Body Semibold | Geist | 16px (1.00rem) | 600 | 1.50 | -0.32px | Strong labels, active states |
+| Button / Link | Geist | 14px (0.88rem) | 500 | 1.43 | normal | Buttons, links, captions |
+| Button Small | Geist | 14px (0.88rem) | 400 | 1.00 (tight) | normal | Compact buttons |
+| Caption | Geist | 12px (0.75rem) | 400–500 | 1.33 | normal | Metadata, tags |
+| Mono Body | Geist Mono | 16px (1.00rem) | 400 | 1.50 | normal | Code blocks |
+| Mono Caption | Geist Mono | 13px (0.81rem) | 500 | 1.54 | normal | Code labels |
+| Mono Small | Geist Mono | 12px (0.75rem) | 500 | 1.00 (tight) | normal | `text-transform: uppercase`, technical labels |
+| Micro Badge | Geist | 7px (0.44rem) | 700 | 1.00 (tight) | normal | `text-transform: uppercase`, tiny badges |
+
+### Principles
+- **Compression as identity**: Geist Sans at display sizes uses -2.4px to -2.88px letter-spacing — the most aggressive negative tracking of any major design system. This creates text that feels _minified_, like code optimized for production. The tracking progressively relaxes as size decreases: -1.28px at 32px, -0.96px at 24px, -0.32px at 16px, and normal at 14px.
+- **Ligatures everywhere**: Every Geist text element enables OpenType `"liga"`. Ligatures aren't decorative — they're structural, creating tighter, more efficient glyph combinations.
+- **Three weights, strict roles**: 400 (body/reading), 500 (UI/interactive), 600 (headings/emphasis). No bold (700) except for tiny micro-badges. This narrow weight range creates hierarchy through size and tracking, not weight.
+- **Mono for identity**: Geist Mono in uppercase with `"tnum"` or `"liga"` serves as the "developer console" voice — compact technical labels that connect the marketing site to the product.
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary White (Shadow-bordered)**
+- Background: `#ffffff`
+- Text: `#171717`
+- Padding: 0px 6px (minimal — content-driven width)
+- Radius: 6px (subtly rounded)
+- Shadow: `rgb(235, 235, 235) 0px 0px 0px 1px` (ring-border)
+- Hover: background shifts to `var(--ds-gray-1000)` (dark)
+- Focus: `2px solid var(--ds-focus-color)` outline + `var(--ds-focus-ring)` shadow
+- Use: Standard secondary button
+
+**Primary Dark (Inferred from Geist system)**
+- Background: `#171717`
+- Text: `#ffffff`
+- Padding: 8px 16px
+- Radius: 6px
+- Use: Primary CTA ("Start Deploying", "Get Started")
+
+**Pill Button / Badge**
+- Background: `#ebf5ff` (tinted blue)
+- Text: `#0068d6`
+- Padding: 0px 10px
+- Radius: 9999px (full pill)
+- Font: 12px weight 500
+- Use: Status badges, tags, feature labels
+
+**Large Pill (Navigation)**
+- Background: transparent or `#171717`
+- Radius: 64px–100px
+- Use: Tab navigation, section selectors
+
+### Cards & Containers
+- Background: `#ffffff`
+- Border: via shadow — `rgba(0, 0, 0, 0.08) 0px 0px 0px 1px`
+- Radius: 8px (standard), 12px (featured/image cards)
+- Shadow stack: `rgba(0,0,0,0.08) 0px 0px 0px 1px, rgba(0,0,0,0.04) 0px 2px 2px, #fafafa 0px 0px 0px 1px`
+- Image cards: `1px solid #ebebeb` with 12px top radius
+- Hover: subtle shadow intensification
+
+### Inputs & Forms
+- Radio: standard styling with focus `var(--ds-gray-200)` background
+- Focus shadow: `1px 0 0 0 var(--ds-gray-alpha-600)`
+- Focus outline: `2px solid var(--ds-focus-color)` — consistent blue focus ring
+- Border: via shadow technique, not traditional border
+
+### Navigation
+- Clean horizontal nav on white, sticky
+- Vercel logotype left-aligned, 262x52px
+- Links: Geist 14px weight 500, `#171717` text
+- Active: weight 600 or underline
+- CTA: dark pill buttons ("Start Deploying", "Contact Sales")
+- Mobile: hamburger menu collapse
+- Product dropdowns with multi-level menus
+
+### Image Treatment
+- Product screenshots with `1px solid #ebebeb` border
+- Top-rounded images: `12px 12px 0px 0px` radius
+- Dashboard/code preview screenshots dominate feature sections
+- Soft gradient backgrounds behind hero images (pastel multi-color)
+
+### Distinctive Components
+
+**Workflow Pipeline**
+- Three-step horizontal pipeline: Develop → Preview → Ship
+- Each step has its own accent color: Blue → Pink → Red
+- Connected with lines/arrows
+- The visual metaphor for Vercel's core value proposition
+
+**Trust Bar / Logo Grid**
+- Company logos (Perplexity, ChatGPT, Cursor, etc.) in grayscale
+- Horizontal scroll or grid layout
+- Subtle `#ebebeb` border separation
+
+**Metric Cards**
+- Large number display (e.g., "10x faster")
+- Geist 48px weight 600 for the metric
+- Description below in gray body text
+- Shadow-bordered card container
+
+## 5. Layout Principles
+
+### Spacing System
+- Base unit: 8px
+- Scale: 1px, 2px, 3px, 4px, 5px, 6px, 8px, 10px, 12px, 14px, 16px, 32px, 36px, 40px
+- Notable gap: jumps from 16px to 32px — no 20px or 24px in primary scale
+
+### Grid & Container
+- Max content width: approximately 1200px
+- Hero: centered single-column with generous top padding
+- Feature sections: 2–3 column grids for cards
+- Full-width dividers using `border-bottom: 1px solid #171717`
+- Code/dashboard screenshots as full-width or contained with border
+
+### Whitespace Philosophy
+- **Gallery emptiness**: Massive vertical padding between sections (80px–120px+). The white space IS the design — it communicates that Vercel has nothing to prove and nothing to hide.
+- **Compressed text, expanded space**: The aggressive negative letter-spacing on headlines is counterbalanced by generous surrounding whitespace. The text is dense; the space around it is vast.
+- **Section rhythm**: White sections alternate with white sections — there's no color variation between sections. Separation comes from borders (shadow-borders) and spacing alone.
+
+### Border Radius Scale
+- Micro (2px): Inline code snippets, small spans
+- Subtle (4px): Small containers
+- Standard (6px): Buttons, links, functional elements
+- Comfortable (8px): Cards, list items
+- Image (12px): Featured cards, image containers (top-rounded)
+- Large (64px): Tab navigation pills
+- XL (100px): Large navigation links
+- Full Pill (9999px): Badges, status pills, tags
+- Circle (50%): Menu toggle, avatar containers
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow | Page background, text blocks |
+| Ring (Level 1) | `rgba(0,0,0,0.08) 0px 0px 0px 1px` | Shadow-as-border for most elements |
+| Light Ring (Level 1b) | `rgb(235,235,235) 0px 0px 0px 1px` | Lighter ring for tabs, images |
+| Subtle Card (Level 2) | Ring + `rgba(0,0,0,0.04) 0px 2px 2px` | Standard cards with minimal lift |
+| Full Card (Level 3) | Ring + Subtle + `rgba(0,0,0,0.04) 0px 8px 8px -8px` + inner `#fafafa` ring | Featured cards, highlighted panels |
+| Focus (Accessibility) | `2px solid hsla(212, 100%, 48%, 1)` outline | Keyboard focus on all interactive elements |
+
+**Shadow Philosophy**: Vercel has arguably the most sophisticated shadow system in modern web design. Rather than using shadows for elevation in the traditional Material Design sense, Vercel uses multi-value shadow stacks where each layer has a distinct architectural purpose: one creates the "border" (0px spread, 1px), another adds ambient softness (2px blur), another handles depth at distance (8px blur with negative spread), and an inner ring (`#fafafa`) creates the subtle highlight that makes the card "glow" from within. This layered approach means cards feel built, not floating.
+
+### Decorative Depth
+- Hero gradient: soft, pastel multi-color gradient wash behind hero content (barely visible, atmospheric)
+- Section borders: `1px solid #171717` (full dark line) between major sections
+- No background color variation — depth comes entirely from shadow layering and border contrast
+
+## 7. Do's and Don'ts
+
+### Do
+- Use Geist Sans with aggressive negative letter-spacing at display sizes (-2.4px to -2.88px at 48px)
+- Use shadow-as-border (`0px 0px 0px 1px rgba(0,0,0,0.08)`) instead of traditional CSS borders
+- Enable `"liga"` on all Geist text — ligatures are structural, not optional
+- Use the three-weight system: 400 (body), 500 (UI), 600 (headings)
+- Apply workflow accent colors (Red/Pink/Blue) only in their workflow context
+- Use multi-layer shadow stacks for cards (border + elevation + ambient + inner highlight)
+- Keep the color palette achromatic — grays from `#171717` to `#ffffff` are the system
+- Use `#171717` instead of `#000000` for primary text — the micro-warmth matters
+
+### Don't
+- Don't use positive letter-spacing on Geist Sans — it's always negative or zero
+- Don't use weight 700 (bold) on body text — 600 is the maximum, used only for headings
+- Don't use traditional CSS `border` on cards — use the shadow-border technique
+- Don't introduce warm colors (oranges, yellows, greens) into the UI chrome
+- Don't apply the workflow accent colors (Ship Red, Preview Pink, Develop Blue) decoratively
+- Don't use heavy shadows (> 0.1 opacity) — the shadow system is whisper-level
+- Don't increase body text letter-spacing — Geist is designed to run tight
+- Don't use pill radius (9999px) on primary action buttons — pills are for badges/tags only
+- Don't skip the inner `#fafafa` ring in card shadows — it's the glow that makes the system work
+
+## 8. Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Mobile Small | <400px | Tight single column, minimal padding |
+| Mobile | 400–600px | Standard mobile, stacked layout |
+| Tablet Small | 600–768px | 2-column grids begin |
+| Tablet | 768–1024px | Full card grids, expanded padding |
+| Desktop Small | 1024–1200px | Standard desktop layout |
+| Desktop | 1200–1400px | Full layout, maximum content width |
+| Large Desktop | >1400px | Centered, generous margins |
+
+### Touch Targets
+- Buttons use comfortable padding (8px–16px vertical)
+- Navigation links at 14px with adequate spacing
+- Pill badges have 10px horizontal padding for tap targets
+- Mobile menu toggle uses 50% radius circular button
+
+### Collapsing Strategy
+- Hero: display 48px → scales down, maintains negative tracking proportionally
+- Navigation: horizontal links + CTAs → hamburger menu
+- Feature cards: 3-column → 2-column → single column stacked
+- Code screenshots: maintain aspect ratio, may horizontally scroll
+- Trust bar logos: grid → horizontal scroll
+- Footer: multi-column → stacked single column
+- Section spacing: 80px+ → 48px on mobile
+
+### Image Behavior
+- Dashboard screenshots maintain border treatment at all sizes
+- Hero gradient softens/simplifies on mobile
+- Product screenshots use responsive images with consistent border radius
+- Full-width sections maintain edge-to-edge treatment
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Primary CTA: Vercel Black (`#171717`)
+- Background: Pure White (`#ffffff`)
+- Heading text: Vercel Black (`#171717`)
+- Body text: Gray 600 (`#4d4d4d`)
+- Border (shadow): `rgba(0, 0, 0, 0.08) 0px 0px 0px 1px`
+- Link: Link Blue (`#0072f5`)
+- Focus ring: Focus Blue (`hsla(212, 100%, 48%, 1)`)
+
+### Example Component Prompts
+- "Create a hero section on white background. Headline at 48px Geist weight 600, line-height 1.00, letter-spacing -2.4px, color #171717. Subtitle at 20px Geist weight 400, line-height 1.80, color #4d4d4d. Dark CTA button (#171717, 6px radius, 8px 16px padding) and ghost button (white, shadow-border rgba(0,0,0,0.08) 0px 0px 0px 1px, 6px radius)."
+- "Design a card: white background, no CSS border. Use shadow stack: rgba(0,0,0,0.08) 0px 0px 0px 1px, rgba(0,0,0,0.04) 0px 2px 2px, #fafafa 0px 0px 0px 1px. Radius 8px. Title at 24px Geist weight 600, letter-spacing -0.96px. Body at 16px weight 400, #4d4d4d."
+- "Build a pill badge: #ebf5ff background, #0068d6 text, 9999px radius, 0px 10px padding, 12px Geist weight 500."
+- "Create navigation: white sticky header. Geist 14px weight 500 for links, #171717 text. Dark pill CTA 'Start Deploying' right-aligned. Shadow-border on bottom: rgba(0,0,0,0.08) 0px 0px 0px 1px."
+- "Design a workflow section showing three steps: Develop (text color #0a72ef), Preview (#de1d8d), Ship (#ff5b4f). Each step: 14px Geist Mono uppercase label + 24px Geist weight 600 title + 16px weight 400 description in #4d4d4d."
+
+### Iteration Guide
+1. Always use shadow-as-border instead of CSS border — `0px 0px 0px 1px rgba(0,0,0,0.08)` is the foundation
+2. Letter-spacing scales with font size: -2.4px at 48px, -1.28px at 32px, -0.96px at 24px, normal at 14px
+3. Three weights only: 400 (read), 500 (interact), 600 (announce)
+4. Color is functional, never decorative — workflow colors (Red/Pink/Blue) mark pipeline stages only
+5. The inner `#fafafa` ring in card shadows is what gives Vercel cards their subtle inner glow
+6. Geist Mono uppercase for technical labels, Geist Sans for everything else

--- a/ui/PRODUCT.md
+++ b/ui/PRODUCT.md
@@ -1,0 +1,30 @@
+# Product
+
+## Register
+
+product
+
+## Users
+Karmada dashboard is used by platform engineers, SREs, and cluster administrators operating multi-cluster Kubernetes fleets. They typically work in an operations context, often switching between incident triage, routine inspection, and policy/resource management. Their primary job is to understand control-plane health and quickly act on cluster, policy, and workload changes.
+
+## Product Purpose
+Karmada Dashboard provides a web control plane for Karmada multi-cluster management. It centralizes visibility and operations for control-plane status, member clusters, policies, and resources so operators can make safe, fast decisions without relying only on CLI flows. Success means users can reliably detect status issues, locate affected scopes, and complete common management actions with low cognitive load.
+
+## Brand Personality
+Pragmatic, trustworthy, and precise. The UI tone should feel operationally calm and technically credible, with clear hierarchy and no decorative noise. It should communicate confidence during normal operation and clarity during degraded states.
+
+## Anti-references
+- Consumer-style marketing aesthetics that prioritize decoration over information density.
+- Heavy visual effects (glassmorphism, oversized gradients, ornamental motion) that reduce readability.
+- Inconsistent admin surfaces where each page invents its own interaction model.
+- Ambiguous status presentation that hides failures behind neutral styling.
+
+## Design Principles
+- Operational clarity first: expose the most decision-critical signals early and clearly.
+- Consistency over novelty: shared patterns for tables, filters, status, and actions across pages.
+- Progressive disclosure: summarize first, then reveal detail when users need to drill down.
+- State-complete interfaces: loading, empty, error, and success states are explicit and actionable.
+- International-ready and accessible by default: i18n-ready copy, keyboard-visible focus, and readable contrast.
+
+## Accessibility & Inclusion
+Target WCAG AA contrast for text and controls. Preserve visible focus indicators for keyboard navigation. Keep motion minimal and functional, with no dependency on animation for understanding status. Ensure key operational information is conveyed by text, not color alone, and keep copy translatable for multilingual operators.

--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -30,6 +30,9 @@
   "dependencies": {
     "@ant-design/cssinjs": "^2.1.2",
     "@chatui/core": "^3.8.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@karmada/chatui": "workspace:*",
     "@karmada/i18n-tool": "workspace:*",
     "@karmada/terminal": "workspace:*",
@@ -55,6 +58,7 @@
     "react-helmet-async": "^3.0.0",
     "react-i18next": "^17.0.8",
     "react-router-dom": "^7.14.2",
+    "recharts": "^3.8.1",
     "sockjs-client": "^1.6.1",
     "tailwind-merge": "^3.6.0",
     "yaml": "^2.9.0",

--- a/ui/apps/dashboard/src/components/auth/index.tsx
+++ b/ui/apps/dashboard/src/components/auth/index.tsx
@@ -26,6 +26,7 @@ import { Me, MeResponse } from '@/services/auth.ts';
 import { karmadaClient } from '@/services';
 import { useQuery } from '@tanstack/react-query';
 import { karmadaMemberClusterClient } from "@/services/base.ts";
+import { metricsScraperClient } from "@/services/metrics.ts";
 
 export interface AuthUser {
   name?: string;
@@ -69,6 +70,9 @@ const AuthProvider = ({ children }: { children: ReactNode }) => {
           'Authorization'
         ] = `Bearer ${token}`;
         karmadaMemberClusterClient.defaults.headers.common[
+          'Authorization'
+        ] = `Bearer ${token}`;
+        metricsScraperClient.defaults.headers.common[
           'Authorization'
         ] = `Bearer ${token}`;
         const ret = await Me();

--- a/ui/apps/dashboard/src/components/data-table/index.tsx
+++ b/ui/apps/dashboard/src/components/data-table/index.tsx
@@ -1,0 +1,255 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Empty, Table as AntdTable } from 'antd';
+import type { TableProps } from 'antd';
+import type { AnyObject } from 'antd/es/_util/type';
+import type { KeyboardEvent } from 'react';
+import type { ReactNode } from 'react';
+import { cn } from '@/utils/cn';
+
+type TableColumn<RecordType extends AnyObject> = NonNullable<
+  TableProps<RecordType>['columns']
+>[number];
+
+const MIN_COLUMN_WIDTH = 116;
+const MAX_INFERRED_WIDTH = 360;
+
+function getTitleText(title: TableColumn<AnyObject>['title']): string {
+  if (typeof title === 'string' || typeof title === 'number') {
+    return String(title);
+  }
+  return '';
+}
+
+function getColumnKey(column: TableColumn<AnyObject>): string {
+  const dataIndex = 'dataIndex' in column ? column.dataIndex : undefined;
+  const rawKey = column.key ?? dataIndex;
+  if (Array.isArray(rawKey)) {
+    return rawKey.join('.');
+  }
+  return rawKey ? String(rawKey) : '';
+}
+
+function getDisplayLength(text: string) {
+  return Array.from(text).reduce((total, char) => {
+    return total + (char.charCodeAt(0) > 255 ? 2 : 1);
+  }, 0);
+}
+
+function inferColumnWidth(column: TableColumn<AnyObject>) {
+  if ('width' in column && column.width) {
+    return undefined;
+  }
+
+  const key = getColumnKey(column).toLowerCase();
+  const title = getTitleText(column.title);
+  const titleWidth = getDisplayLength(title) * 8 + 48;
+  let semanticWidth = MIN_COLUMN_WIDTH;
+
+  if (/^(op|action|actions)$/.test(key) || /操作|actions?/i.test(title)) {
+    semanticWidth = 168;
+  } else if (/name|namespace|cluster|workload|service|config|secret|role/.test(key)) {
+    semanticWidth = 180;
+  } else if (/label|annotation|image|message|subject|selector|rule|resource|host|address/.test(key)) {
+    semanticWidth = 260;
+  } else if (/time|date|age|creation/.test(key) || /时间|age/i.test(title)) {
+    semanticWidth = 172;
+  } else if (/status|ready|phase|mode|type|kind/.test(key) || /状态|模式|类型/.test(title)) {
+    semanticWidth = 132;
+  }
+
+  return Math.min(
+    MAX_INFERRED_WIDTH,
+    Math.max(MIN_COLUMN_WIDTH, semanticWidth, titleWidth),
+  );
+}
+
+function getColumnKind(column: TableColumn<AnyObject>) {
+  const key = getColumnKey(column).toLowerCase();
+  const title = getTitleText(column.title);
+
+  if (/^(op|action|actions)$/.test(key) || /操作|actions?/i.test(title)) {
+    return 'action';
+  }
+  if (/name|namespace|cluster|workload|service|config|secret|role/.test(key)) {
+    return 'identity';
+  }
+  if (/status|ready|phase/.test(key) || /状态|ready|phase/i.test(title)) {
+    return 'status';
+  }
+  if (/time|date|age|creation/.test(key) || /时间|age/i.test(title)) {
+    return 'time';
+  }
+  return 'default';
+}
+
+function getPrimitiveCellTitle(value: unknown): string | undefined {
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return String(value);
+  }
+  return undefined;
+}
+
+function getDataByIndex(record: AnyObject, dataIndex: unknown) {
+  if (!dataIndex) return undefined;
+  const path = Array.isArray(dataIndex) ? dataIndex : String(dataIndex).split('.');
+  return path.reduce<unknown>((current, key) => {
+    if (!current || typeof current !== 'object') return undefined;
+    return (current as Record<string, unknown>)[String(key)];
+  }, record);
+}
+
+function enhanceColumns<RecordType extends AnyObject>(
+  columns?: TableProps<RecordType>['columns'],
+): TableProps<RecordType>['columns'] {
+  if (!columns) return columns;
+
+  return columns.map((column) => {
+    const children =
+      'children' in column && column.children
+        ? enhanceColumns(column.children as TableProps<RecordType>['columns'])
+        : undefined;
+    const dataIndex = 'dataIndex' in column ? column.dataIndex : undefined;
+    const inferredMinWidth = inferColumnWidth(column as TableColumn<AnyObject>);
+    const kind = getColumnKind(column as TableColumn<AnyObject>);
+    const className = cn(
+      'karmada-table-column',
+      `karmada-table-column-${kind}`,
+      column.className,
+    );
+
+    return {
+      ...column,
+      ...(children ? { children } : {}),
+      className,
+      ellipsis:
+        column.ellipsis === undefined && kind !== 'action'
+          ? { showTitle: false }
+          : column.ellipsis,
+      minWidth:
+        'minWidth' in column && column.minWidth !== undefined
+          ? column.minWidth
+          : inferredMinWidth,
+      fixed:
+        kind === 'action' && column.fixed === undefined ? 'right' : column.fixed,
+      width:
+        kind === 'action' && !('width' in column && column.width)
+          ? 168
+          : column.width,
+      onCell: (record: RecordType, rowIndex?: number) => {
+        const cellProps = column.onCell?.(record, rowIndex) ?? {};
+        const title = getPrimitiveCellTitle(
+          getDataByIndex(record as AnyObject, dataIndex),
+        );
+        return title && !cellProps.title
+          ? {
+              ...cellProps,
+              title,
+            }
+          : cellProps;
+      },
+    } as TableColumn<RecordType>;
+  });
+}
+
+function emptyText(): ReactNode {
+  return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />;
+}
+
+export default function DataTable<RecordType extends AnyObject = AnyObject>(
+  props: TableProps<RecordType>,
+) {
+  const {
+    className,
+    columns,
+    locale,
+    onRow,
+    pagination,
+    rowClassName,
+    scroll,
+    showSorterTooltip,
+    size,
+    sticky,
+    tableLayout,
+    ...restProps
+  } = props;
+
+  return (
+    <AntdTable<RecordType>
+      className={cn('karmada-data-table', className)}
+      columns={enhanceColumns(columns)}
+      locale={{
+        emptyText: emptyText(),
+        ...locale,
+      }}
+      pagination={
+        pagination === false
+          ? false
+          : {
+              showSizeChanger: true,
+              showQuickJumper: true,
+              position: ['bottomRight'],
+              showTotal: (total, range) => `${range[0]}-${range[1]} / ${total}`,
+              ...pagination,
+            }
+      }
+      onRow={(record, index) => {
+        const rowProps = onRow?.(record, index) ?? {};
+        const rowClickHandler = rowProps.onClick;
+        return {
+          ...rowProps,
+          className: cn('karmada-data-table-row', rowProps.className),
+          tabIndex: rowClickHandler ? (rowProps.tabIndex ?? 0) : rowProps.tabIndex,
+          onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
+            rowProps.onKeyDown?.(event);
+            if (
+              rowClickHandler &&
+              !event.defaultPrevented &&
+              (event.key === 'Enter' || event.key === ' ')
+            ) {
+              event.preventDefault();
+              (rowClickHandler as unknown as (event: KeyboardEvent<HTMLElement>) => void)(
+                event,
+              );
+            }
+          },
+        };
+      }}
+      rowClassName={(record, index, indent) =>
+        cn(
+          typeof rowClassName === 'function'
+            ? rowClassName(record, index, indent)
+            : rowClassName,
+        )
+      }
+      scroll={{
+        x: 'max-content',
+        scrollToFirstRowOnChange: true,
+        ...scroll,
+      }}
+      showSorterTooltip={showSorterTooltip ?? { target: 'sorter-icon' }}
+      size={size ?? 'middle'}
+      sticky={sticky ?? true}
+      tableLayout={tableLayout ?? 'auto'}
+      {...restProps}
+    />
+  );
+}

--- a/ui/apps/dashboard/src/components/icons/index.tsx
+++ b/ui/apps/dashboard/src/components/icons/index.tsx
@@ -77,6 +77,7 @@ import {
   HardDrive,
   Cloud,
   PanelsTopLeft,
+  Activity,
 
 } from 'lucide-react';
 
@@ -127,6 +128,7 @@ export const Icons = {
   storage: HardDrive,
   cloud: Cloud,
   control: SlidersHorizontal,
+  metrics: Activity,
 
   gitHub: ({ ...props }: LucideProps) => (
     <svg

--- a/ui/apps/dashboard/src/components/overview-workbench/index.module.less
+++ b/ui/apps/dashboard/src/components/overview-workbench/index.module.less
@@ -1,0 +1,355 @@
+.workbench {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hero {
+  position: relative;
+  display: flex;
+  min-height: 116px;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  overflow: hidden;
+  padding: 18px 20px;
+  border: 1px solid #d7e0eb;
+  border-radius: var(--karmada-radius-panel);
+  background:
+    linear-gradient(135deg, rgba(31, 111, 235, 0.08), rgba(255, 255, 255, 0) 52%),
+    linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: auto 18px 0 auto;
+  width: 220px;
+  height: 5px;
+  background: linear-gradient(90deg, #1f6feb, rgba(31, 111, 235, 0.12));
+}
+
+.heroText {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+
+.scope {
+  margin-bottom: 8px;
+  color: var(--karmada-color-primary-strong);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.title {
+  margin: 0;
+  color: var(--karmada-color-text);
+  font-size: 24px;
+  font-weight: 680;
+  line-height: 1.18;
+  letter-spacing: 0;
+  text-wrap: balance;
+}
+
+.subtitle {
+  max-width: 720px;
+  margin: 8px 0 0;
+  color: var(--karmada-color-text-secondary);
+  font-size: 13px;
+  font-weight: 450;
+  line-height: 1.6;
+}
+
+.statusPill {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 1px solid #cfd8e4;
+  border-radius: var(--karmada-radius-control);
+  background: #ffffff;
+  color: var(--karmada-color-text);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.statusDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentcolor;
+  box-shadow: 0 0 0 3px rgba(107, 114, 128, 0.12);
+}
+
+.toneSuccess {
+  color: #18794e;
+  border-color: rgba(24, 121, 78, 0.28);
+  background: #f1faf5;
+}
+
+.toneWarning {
+  color: #9a6700;
+  border-color: rgba(183, 121, 31, 0.32);
+  background: #fff8e8;
+}
+
+.toneDanger {
+  color: #b42318;
+  border-color: rgba(194, 65, 12, 0.3);
+  background: #fff3ed;
+}
+
+.toneNeutral {
+  color: #5f6b7a;
+  border-color: #d4dce7;
+  background: #f6f8fb;
+}
+
+.toneInfo {
+  color: var(--karmada-color-primary-strong);
+  border-color: rgba(31, 111, 235, 0.28);
+  background: var(--karmada-color-primary-soft);
+}
+
+.primaryGrid,
+.metricGroups {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(360px, 0.84fr);
+  gap: 12px;
+}
+
+.metricGroups {
+  align-items: stretch;
+}
+
+.metricGroupsSingle {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.metricGroupsSingle .metricGrid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.panel {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--karmada-color-border);
+  border-radius: var(--karmada-radius-panel);
+  background: #ffffff;
+}
+
+.panelHeader {
+  display: flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px 10px;
+  border-bottom: 1px solid #e8edf4;
+  background: #fbfcfe;
+}
+
+.panelTitle {
+  margin: 0;
+  color: var(--karmada-color-text);
+  font-size: 13px;
+  font-weight: 680;
+  line-height: 1.35;
+}
+
+.panelDescription {
+  max-width: 560px;
+  margin: 4px 0 0;
+  color: var(--karmada-color-text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.infoGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  margin: 0;
+}
+
+.infoItem {
+  min-width: 0;
+  padding: 14px;
+  border-right: 1px solid #edf1f6;
+  border-bottom: 1px solid #edf1f6;
+}
+
+.infoItem:nth-child(3n) {
+  border-right: 0;
+}
+
+.infoItem:nth-last-child(-n + 3) {
+  border-bottom: 0;
+}
+
+.itemLabel {
+  display: block;
+  margin: 0;
+  color: var(--karmada-color-text-secondary);
+  font-size: 12px;
+  font-weight: 560;
+  line-height: 1.35;
+}
+
+.itemValue {
+  margin: 7px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--karmada-color-text);
+  font-size: 15px;
+  font-weight: 680;
+  line-height: 1.36;
+}
+
+.itemMeta {
+  margin: 6px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--karmada-color-text-tertiary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.utilizationList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+}
+
+.utilizationItem {
+  min-width: 0;
+  padding: 0 0 12px;
+  border-bottom: 1px solid #edf1f6;
+}
+
+.utilizationItem:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.utilizationHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.utilizationValue {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--karmada-color-text);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 680;
+  line-height: 1.35;
+  text-align: right;
+}
+
+.metricGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+}
+
+.metricItem {
+  min-width: 0;
+  padding: 14px;
+  border-right: 1px solid #edf1f6;
+  border-bottom: 1px solid #edf1f6;
+}
+
+.metricItem:nth-child(2n) {
+  border-right: 0;
+}
+
+.metricItem:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
+.metricValue {
+  overflow-wrap: anywhere;
+  color: var(--karmada-color-text);
+  font-size: 26px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 680;
+  line-height: 1.08;
+}
+
+@media (max-width: 1180px) {
+  .primaryGrid,
+  .metricGroups {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .hero {
+    flex-direction: column;
+    min-height: 0;
+    gap: 14px;
+    padding: 16px;
+  }
+
+  .title {
+    font-size: 21px;
+  }
+
+  .infoGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .metricGroupsSingle .metricGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .infoItem,
+  .infoItem:nth-child(3n),
+  .infoItem:nth-last-child(-n + 3),
+  .metricItem,
+  .metricItem:nth-child(2n),
+  .metricItem:nth-last-child(-n + 2) {
+    border-right: 0;
+    border-bottom: 1px solid #edf1f6;
+  }
+
+  .infoItem:last-child,
+  .metricItem:last-child {
+    border-bottom: 0;
+  }
+}
+
+@media (max-width: 520px) {
+  .workbench {
+    gap: 12px;
+  }
+
+  .panelHeader,
+  .infoItem,
+  .metricItem,
+  .utilizationList {
+    padding-inline: 12px;
+  }
+
+  .metricGrid,
+  .metricGroupsSingle .metricGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .metricValue {
+    font-size: 23px;
+  }
+}

--- a/ui/apps/dashboard/src/components/overview-workbench/index.tsx
+++ b/ui/apps/dashboard/src/components/overview-workbench/index.tsx
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type { ReactNode } from 'react';
+import { Progress } from 'antd';
+import styles from './index.module.less';
+
+type OverviewTone = 'success' | 'warning' | 'danger' | 'neutral' | 'info';
+
+export interface OverviewStatus {
+  label: ReactNode;
+  tone?: OverviewTone;
+}
+
+export interface OverviewInfoItem {
+  key: string;
+  label: ReactNode;
+  value: ReactNode;
+  meta?: ReactNode;
+}
+
+export interface OverviewMetricItem {
+  key: string;
+  label: ReactNode;
+  value: ReactNode;
+  meta?: ReactNode;
+}
+
+export interface OverviewMetricGroup {
+  key: string;
+  title: ReactNode;
+  description?: ReactNode;
+  items: OverviewMetricItem[];
+}
+
+export interface OverviewUtilizationItem {
+  key: string;
+  label: ReactNode;
+  value: ReactNode;
+  percent?: number | null;
+  meta?: ReactNode;
+  tone?: OverviewTone;
+}
+
+export interface OverviewWorkbenchProps {
+  scopeLabel: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  status: OverviewStatus;
+  infoTitle: ReactNode;
+  infoItems: OverviewInfoItem[];
+  utilizationTitle?: ReactNode;
+  utilizationItems?: OverviewUtilizationItem[];
+  metricGroups?: OverviewMetricGroup[];
+}
+
+const toneClassMap: Record<OverviewTone, string> = {
+  success: styles.toneSuccess,
+  warning: styles.toneWarning,
+  danger: styles.toneDanger,
+  neutral: styles.toneNeutral,
+  info: styles.toneInfo,
+};
+
+const progressColorMap: Record<OverviewTone, string> = {
+  success: '#18794e',
+  warning: '#b7791f',
+  danger: '#c2410c',
+  neutral: '#6b7280',
+  info: '#1f6feb',
+};
+
+function normalizePercent(percent?: number | null) {
+  if (percent === undefined || percent === null || Number.isNaN(percent)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, percent));
+}
+
+export default function OverviewWorkbench({
+  scopeLabel,
+  title,
+  subtitle,
+  status,
+  infoTitle,
+  infoItems,
+  utilizationTitle,
+  utilizationItems = [],
+  metricGroups = [],
+}: OverviewWorkbenchProps) {
+  const hasUtilization = utilizationItems.length > 0;
+  const hasMetrics = metricGroups.length > 0;
+  const statusTone = status.tone ?? 'neutral';
+
+  return (
+    <div className={styles.workbench}>
+      <section className={styles.hero}>
+        <div className={styles.heroText}>
+          <div className={styles.scope}>{scopeLabel}</div>
+          <h2 className={styles.title}>{title}</h2>
+          {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
+        </div>
+        <div className={`${styles.statusPill} ${toneClassMap[statusTone]}`}>
+          <span className={styles.statusDot} />
+          <span>{status.label}</span>
+        </div>
+      </section>
+
+      <section className={styles.primaryGrid}>
+        <article className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <h3 className={styles.panelTitle}>{infoTitle}</h3>
+          </div>
+          <dl className={styles.infoGrid}>
+            {infoItems.map((item) => (
+              <div key={item.key} className={styles.infoItem}>
+                <dt className={styles.itemLabel}>{item.label}</dt>
+                <dd className={styles.itemValue}>{item.value}</dd>
+                {item.meta && <dd className={styles.itemMeta}>{item.meta}</dd>}
+              </div>
+            ))}
+          </dl>
+        </article>
+
+        {hasUtilization && (
+          <article className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <h3 className={styles.panelTitle}>{utilizationTitle}</h3>
+            </div>
+            <div className={styles.utilizationList}>
+              {utilizationItems.map((item) => {
+                const tone = item.tone ?? 'info';
+                const percent = normalizePercent(item.percent);
+                return (
+                  <div key={item.key} className={styles.utilizationItem}>
+                    <div className={styles.utilizationHead}>
+                      <span className={styles.itemLabel}>{item.label}</span>
+                      <span className={styles.utilizationValue}>{item.value}</span>
+                    </div>
+                    <Progress
+                      percent={percent}
+                      showInfo={false}
+                      size="small"
+                      strokeColor={progressColorMap[tone]}
+                      railColor="#e8edf4"
+                    />
+                    {item.meta && <div className={styles.itemMeta}>{item.meta}</div>}
+                  </div>
+                );
+              })}
+            </div>
+          </article>
+        )}
+      </section>
+
+      {hasMetrics && (
+        <section
+          className={`${styles.metricGroups} ${
+            metricGroups.length === 1 ? styles.metricGroupsSingle : ''
+          }`}
+        >
+          {metricGroups.map((group) => (
+            <article key={group.key} className={styles.panel}>
+              <div className={styles.panelHeader}>
+                <div>
+                  <h3 className={styles.panelTitle}>{group.title}</h3>
+                  {group.description && (
+                    <p className={styles.panelDescription}>{group.description}</p>
+                  )}
+                </div>
+              </div>
+              <div className={styles.metricGrid}>
+                {group.items.map((item) => (
+                  <div key={item.key} className={styles.metricItem}>
+                    <div className={styles.metricValue}>{item.value}</div>
+                    <div className={styles.itemLabel}>{item.label}</div>
+                    {item.meta && <div className={styles.itemMeta}>{item.meta}</div>}
+                  </div>
+                ))}
+              </div>
+            </article>
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/ui/apps/dashboard/src/layout/index.module.less
+++ b/ui/apps/dashboard/src/layout/index.module.less
@@ -1,0 +1,36 @@
+.shell {
+  position: relative;
+  background: var(--karmada-color-bg);
+}
+
+.shell::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.4), transparent 220px);
+}
+
+.sider {
+  position: relative;
+  z-index: 1;
+  border-right: 1px solid var(--karmada-color-shell-border);
+  box-shadow: 6px 0 18px rgba(20, 27, 43, 0.08);
+}
+
+.mainPane {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  height: 100%;
+  background: transparent;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  flex: 1 1 auto;
+  height: calc(100dvh - 48px);
+  overflow: hidden;
+}

--- a/ui/apps/dashboard/src/layout/sidebar.module.less
+++ b/ui/apps/dashboard/src/layout/sidebar.module.less
@@ -1,0 +1,282 @@
+.sidebar {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), transparent 190px),
+    linear-gradient(90deg, rgba(31, 111, 235, 0.1), transparent 120px),
+    var(--karmada-color-shell);
+  color: var(--karmada-color-shell-text);
+}
+
+.sidebar::before {
+  content: '';
+  position: absolute;
+  inset: 48px 0 auto 0;
+  height: 1px;
+  pointer-events: none;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(225, 231, 240, 0.16) 16%,
+    rgba(225, 231, 240, 0.06) 74%,
+    transparent
+  );
+}
+
+.sidebarBrand {
+  height: 48px;
+  flex: 0 0 48px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--karmada-color-shell-border);
+  box-sizing: border-box;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.sidebarBrandCollapsed {
+  justify-content: center;
+  padding: 0;
+}
+
+.logoFrame {
+  width: 31px;
+  height: 31px;
+  flex: 0 0 31px;
+  border: 1px solid rgba(225, 231, 240, 0.18);
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.98);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.78);
+}
+
+.logo {
+  width: 21px;
+  height: auto;
+  display: block;
+}
+
+.brandText {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  line-height: 1.12;
+}
+
+.brandName {
+  color: #ffffff;
+  font-size: 13.5px;
+  font-weight: 680;
+}
+
+.brandSubline {
+  margin-top: 2px;
+  color: var(--karmada-color-shell-muted);
+  font-size: 11px;
+  font-weight: 560;
+}
+
+.menuScroll {
+  position: relative;
+  min-width: 0;
+  flex: 1;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 12px 0 16px;
+}
+
+.menuScroll::-webkit-scrollbar {
+  width: 10px;
+}
+
+.menuScroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.menuScroll::-webkit-scrollbar-thumb {
+  border: 3px solid transparent;
+  border-radius: 8px;
+  background: rgba(142, 154, 171, 0.38);
+  background-clip: padding-box;
+}
+
+.menuScroll::-webkit-scrollbar-thumb:hover {
+  background: rgba(174, 186, 204, 0.5);
+  background-clip: padding-box;
+}
+
+.memberContext {
+  margin: 12px 12px 0;
+  padding: 8px 9px;
+  overflow: hidden;
+  border: 1px solid rgba(225, 231, 240, 0.12);
+  border-radius: var(--karmada-radius-control);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.03)),
+    rgba(255, 255, 255, 0.03);
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.menu {
+  width: 100% !important;
+  max-width: 100%;
+  overflow-x: hidden;
+  border-inline-end: 0 !important;
+  background: transparent !important;
+
+  :global(.ant-menu-submenu-title),
+  :global(.ant-menu-item) {
+    position: relative;
+    display: flex;
+    align-items: center;
+    color: var(--karmada-color-shell-text);
+    font-size: 13px;
+    font-weight: 560;
+    letter-spacing: 0;
+    overflow: hidden;
+    box-sizing: border-box;
+  }
+
+  :global(.ant-menu-title-content) {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  :global(.ant-menu-sub.ant-menu-inline) {
+    max-width: calc(100% - 28px);
+    margin: 3px 10px 8px 18px;
+    padding: 4px 0 5px 7px;
+    overflow-x: hidden;
+    border-left: 1px solid rgba(225, 231, 240, 0.1);
+    border-radius: var(--karmada-radius-control);
+    background: rgba(7, 11, 18, 0.22) !important;
+  }
+
+  :global(.ant-menu-sub.ant-menu-inline .ant-menu-item) {
+    margin-inline: 0 !important;
+    width: calc(100% - 4px) !important;
+    height: 32px;
+    margin-block: 1px !important;
+    padding-inline-end: 10px;
+    box-sizing: border-box;
+    color: #aeb9c8;
+    font-size: 12.5px;
+  }
+
+  :global(.ant-menu-submenu-title::after),
+  :global(.ant-menu-item::after) {
+    display: none;
+  }
+
+  :global(.ant-menu-submenu-title:hover),
+  :global(.ant-menu-item:hover) {
+    background: rgba(225, 231, 240, 0.085) !important;
+    color: #ffffff !important;
+  }
+
+  :global(.ant-menu-submenu-title:active),
+  :global(.ant-menu-item:active) {
+    transform: translateY(1px);
+  }
+
+  :global(.ant-menu-submenu-open > .ant-menu-submenu-title) {
+    background: rgba(225, 231, 240, 0.045) !important;
+    color: #ffffff !important;
+  }
+
+  :global(.ant-menu-item-selected) {
+    background:
+      linear-gradient(90deg, rgba(31, 111, 235, 0.28), rgba(31, 111, 235, 0.11)),
+      rgba(31, 111, 235, 0.14) !important;
+    color: #ffffff !important;
+    border: 1px solid rgba(97, 151, 245, 0.28);
+    box-shadow:
+      inset 3px 0 0 #6ea4ff,
+      0 8px 18px rgba(7, 11, 18, 0.18);
+  }
+
+  :global(.ant-menu-item-icon) {
+    flex: 0 0 auto;
+    color: var(--karmada-color-shell-muted);
+    opacity: 0.9;
+    transition:
+      color 0.2s ease,
+      opacity 0.2s ease,
+      transform 0.2s ease;
+  }
+
+  :global(.ant-menu-submenu-title:hover .ant-menu-item-icon),
+  :global(.ant-menu-item:hover .ant-menu-item-icon) {
+    color: #c9d5e6;
+    opacity: 1;
+    transform: translateX(1px);
+  }
+
+  :global(.ant-menu-item-selected .ant-menu-item-icon) {
+    color: #9fc4ff;
+    opacity: 1;
+  }
+
+  :global(.ant-menu-submenu-arrow) {
+    color: var(--karmada-color-shell-muted);
+    inset-inline-end: 14px;
+  }
+
+  :global(.ant-menu-submenu-selected) > :global(.ant-menu-submenu-title) {
+    color: #ffffff !important;
+  }
+
+  :global(.ant-menu-inline-collapsed) {
+    width: 100% !important;
+  }
+
+  :global(.ant-menu-inline-collapsed > .ant-menu-item),
+  :global(.ant-menu-inline-collapsed > .ant-menu-submenu > .ant-menu-submenu-title) {
+    width: 44px !important;
+    height: 40px !important;
+    margin: 4px auto !important;
+    padding-inline: 0 !important;
+    justify-content: center;
+  }
+
+  :global(.ant-menu-inline-collapsed .ant-menu-item-icon) {
+    margin-inline-end: 0 !important;
+    transform: none !important;
+  }
+}
+
+.versionLink {
+  position: relative;
+  flex: 0 0 46px;
+  margin: 0 10px 10px;
+  width: auto !important;
+  border: 1px solid rgba(225, 231, 240, 0.1) !important;
+  border-radius: var(--karmada-radius-control);
+  background: rgba(7, 11, 18, 0.42) !important;
+  color: var(--karmada-color-shell-muted) !important;
+  font-variant-numeric: tabular-nums;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+
+  &:hover {
+    border-color: rgba(225, 231, 240, 0.18) !important;
+    background: rgba(32, 38, 50, 0.72) !important;
+    color: #ffffff !important;
+  }
+}
+
+.versionLabel {
+  color: var(--karmada-color-shell-muted);
+}
+
+.versionValue {
+  color: var(--karmada-color-shell-text);
+}

--- a/ui/apps/dashboard/src/pages/metrics/charts/MetricAreaChart.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/charts/MetricAreaChart.tsx
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useId } from 'react';
+import { theme } from 'antd';
+import { Area, AreaChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+
+import type { MetricChartProps } from './index';
+
+const DEFAULT_HEIGHT = 320;
+const HEADER_HEIGHT = 40;
+
+function formatNumber(value: number, fractionDigits = 3) {
+  if (!Number.isFinite(value)) return '0';
+  return value.toLocaleString(undefined, { maximumFractionDigits: fractionDigits });
+}
+
+function formatTimestamp(value: string) {
+  return new Date(value).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function getLatestValue(data: MetricChartProps['data']) {
+  for (let index = data.length - 1; index >= 0; index -= 1) {
+    const point = data[index];
+    if (typeof point?.value === 'number' && Number.isFinite(point.value)) {
+      return point.value;
+    }
+  }
+  return undefined;
+}
+
+const MetricAreaChart = ({
+  data,
+  title,
+  color,
+  valueFormatter = (value) => formatNumber(value),
+  axisFormatter = (value) => formatNumber(value, 1),
+  width,
+  height = DEFAULT_HEIGHT,
+}: MetricChartProps) => {
+  const { token } = theme.useToken();
+  const gradientId = useId().replace(/:/g, '');
+  const latestValue = getLatestValue(data);
+  const chartHeight = Math.max(height - HEADER_HEIGHT, 180);
+
+  return (
+    <div className="flex flex-col gap-3" style={{ width }}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
+          <span className="text-sm font-medium" style={{ color: token.colorTextHeading }}>
+            {title}
+          </span>
+        </div>
+        <span className="text-sm font-medium" style={{ color: token.colorText }}>
+          {typeof latestValue === 'number' ? valueFormatter(latestValue) : '--'}
+        </span>
+      </div>
+
+      <div
+        className="w-full min-w-0 overflow-hidden rounded-md px-1 pt-2"
+        style={{ backgroundColor: token.colorFillQuaternary }}
+      >
+        {data.length === 0 ? (
+          <div
+            className="flex items-center justify-center text-sm"
+            style={{ height: chartHeight, color: token.colorTextTertiary }}
+          >
+            No data available
+          </div>
+        ) : (
+          <AreaChart width={Math.max(width - 8, 0)} height={chartHeight} data={data} margin={{ left: 4, right: 4, top: 6, bottom: 2 }}>
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={color} stopOpacity={0.2} />
+                <stop offset="95%" stopColor={color} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid vertical={false} strokeDasharray="2 6" stroke={token.colorBorderSecondary} />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatTimestamp}
+              minTickGap={28}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <YAxis
+              width={54}
+              tickFormatter={axisFormatter}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <Tooltip
+              cursor={{ stroke: token.colorBorder, strokeDasharray: '4 4' }}
+              contentStyle={{
+                borderRadius: 8,
+                border: `1px solid ${token.colorBorderSecondary}`,
+                boxShadow: token.boxShadowSecondary,
+                background: token.colorBgElevated,
+              }}
+              labelStyle={{ color: token.colorTextSecondary, fontSize: 12 }}
+              labelFormatter={(timestamp) => new Date(timestamp as string).toLocaleString()}
+              formatter={(tooltipValue) => [valueFormatter(Number(tooltipValue)), title]}
+            />
+            <Area
+              type="monotoneX"
+              dataKey="value"
+              stroke={color}
+              fill={`url(#${gradientId})`}
+              fillOpacity={1}
+              strokeWidth={2}
+              connectNulls
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MetricAreaChart;

--- a/ui/apps/dashboard/src/pages/metrics/charts/MetricBarChart.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/charts/MetricBarChart.tsx
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { theme } from 'antd';
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+
+import type { MetricChartProps } from './index';
+
+const DEFAULT_HEIGHT = 320;
+const HEADER_HEIGHT = 40;
+
+function formatNumber(value: number, fractionDigits = 3) {
+  if (!Number.isFinite(value)) return '0';
+  return value.toLocaleString(undefined, { maximumFractionDigits: fractionDigits });
+}
+
+function formatTimestamp(value: string) {
+  return new Date(value).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function getLatestValue(data: MetricChartProps['data']) {
+  for (let index = data.length - 1; index >= 0; index -= 1) {
+    const point = data[index];
+    if (typeof point?.value === 'number' && Number.isFinite(point.value)) {
+      return point.value;
+    }
+  }
+  return undefined;
+}
+
+const MetricBarChart = ({
+  data,
+  title,
+  color,
+  valueFormatter = (value) => formatNumber(value),
+  axisFormatter = (value) => formatNumber(value, 1),
+  width,
+  height = DEFAULT_HEIGHT,
+}: MetricChartProps) => {
+  const { token } = theme.useToken();
+  const latestValue = getLatestValue(data);
+  const chartHeight = Math.max(height - HEADER_HEIGHT, 180);
+
+  return (
+    <div className="flex flex-col gap-3" style={{ width }}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
+          <span className="text-sm font-medium" style={{ color: token.colorTextHeading }}>
+            {title}
+          </span>
+        </div>
+        <span className="text-sm font-medium" style={{ color: token.colorText }}>
+          {typeof latestValue === 'number' ? valueFormatter(latestValue) : '--'}
+        </span>
+      </div>
+
+      <div
+        className="w-full min-w-0 overflow-hidden rounded-md px-1 pt-2"
+        style={{ backgroundColor: token.colorFillQuaternary }}
+      >
+        {data.length === 0 ? (
+          <div
+            className="flex items-center justify-center text-sm"
+            style={{ height: chartHeight, color: token.colorTextTertiary }}
+          >
+            No data available
+          </div>
+        ) : (
+          <BarChart width={Math.max(width - 8, 0)} height={chartHeight} data={data} margin={{ left: 4, right: 4, top: 6, bottom: 2 }}>
+            <CartesianGrid vertical={false} strokeDasharray="2 6" stroke={token.colorBorderSecondary} />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatTimestamp}
+              minTickGap={28}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <YAxis
+              width={54}
+              tickFormatter={axisFormatter}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <Tooltip
+              cursor={{ fill: token.colorFillQuaternary }}
+              contentStyle={{
+                borderRadius: 8,
+                border: `1px solid ${token.colorBorderSecondary}`,
+                boxShadow: token.boxShadowSecondary,
+                background: token.colorBgElevated,
+              }}
+              labelStyle={{ color: token.colorTextSecondary, fontSize: 12 }}
+              labelFormatter={(timestamp) => new Date(timestamp as string).toLocaleString()}
+              formatter={(tooltipValue) => [valueFormatter(Number(tooltipValue)), title]}
+            />
+            <Bar dataKey="value" fill={color} fillOpacity={0.8} radius={[2, 2, 0, 0]} isAnimationActive={false} />
+          </BarChart>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MetricBarChart;

--- a/ui/apps/dashboard/src/pages/metrics/charts/MetricGaugeChart.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/charts/MetricGaugeChart.tsx
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useId, useMemo } from 'react';
+import { theme } from 'antd';
+
+import type { MetricGaugeChartProps } from './index';
+
+const DEFAULT_HEIGHT = 320;
+const HEADER_HEIGHT = 44;
+
+function formatNumber(value: number, fractionDigits = 2) {
+  if (!Number.isFinite(value)) return '0';
+  return value.toLocaleString(undefined, { maximumFractionDigits: fractionDigits });
+}
+
+const MetricGaugeChart = ({
+  title,
+  color,
+  valueFormatter = (value) => formatNumber(value),
+  width,
+  height = DEFAULT_HEIGHT,
+  min = 0,
+  max = 100,
+  currentValue,
+}: MetricGaugeChartProps) => {
+  const { token } = theme.useToken();
+  const gradientId = useId().replace(/:/g, '');
+  const safeMax = max <= min ? min + 1 : max;
+  const progress = Math.min(Math.max((currentValue - min) / (safeMax - min), 0), 1);
+  const chartWidth = Math.max(width - 24, 160);
+  const chartHeight = Math.max(height - HEADER_HEIGHT, 180);
+
+  const { backgroundArc, valueArc, cx, cy, radius, strokeWidth } = useMemo(() => {
+    const localCx = chartWidth / 2;
+    const localCy = chartHeight * 0.72;
+    const localRadius = Math.min(chartWidth * 0.34, chartHeight * 0.5);
+    const angle = progress * 180;
+    const endAngle = Math.PI - (angle * Math.PI) / 180;
+    const arcX2 = localCx + localRadius * Math.cos(endAngle);
+    const arcY2 = localCy - localRadius * Math.sin(endAngle);
+
+    return {
+      backgroundArc: `M ${localCx - localRadius} ${localCy} A ${localRadius} ${localRadius} 0 0 1 ${localCx + localRadius} ${localCy}`,
+      valueArc:
+        angle > 0
+          ? `M ${localCx - localRadius} ${localCy} A ${localRadius} ${localRadius} 0 0 1 ${arcX2} ${arcY2}`
+          : undefined,
+      cx: localCx,
+      cy: localCy,
+      radius: localRadius,
+      strokeWidth: Math.max(12, Math.min(18, chartWidth * 0.04)),
+    };
+  }, [chartHeight, chartWidth, progress]);
+
+  return (
+    <div className="flex flex-col gap-3" style={{ width }}>
+      <div className="flex items-center gap-2">
+        <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
+        <span className="text-sm font-medium" style={{ color: token.colorTextHeading }}>
+          {title}
+        </span>
+      </div>
+
+      <div className="overflow-hidden rounded-md px-3 py-4" style={{ backgroundColor: token.colorFillQuaternary }}>
+        <svg width={chartWidth} height={chartHeight} viewBox={`0 0 ${chartWidth} ${chartHeight}`} role="img" aria-label={title}>
+          <defs>
+            <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stopColor={token.colorError} />
+              <stop offset="55%" stopColor={token.colorWarning} />
+              <stop offset="100%" stopColor={color} />
+            </linearGradient>
+          </defs>
+
+          <path
+            d={backgroundArc}
+            fill="none"
+            stroke={token.colorBorderSecondary}
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+          />
+          {valueArc ? (
+            <path
+              d={valueArc}
+              fill="none"
+              stroke={`url(#${gradientId})`}
+              strokeWidth={strokeWidth}
+              strokeLinecap="round"
+            />
+          ) : null}
+
+          <text x={cx} y={cy + 10} textAnchor="middle" fontSize="28" fontWeight="600" fill={token.colorTextHeading}>
+            {valueFormatter(currentValue)}
+          </text>
+          <text x={cx - radius} y={cy + 30} textAnchor="start" fontSize="12" fill={token.colorTextSecondary}>
+            {valueFormatter(min)}
+          </text>
+          <text x={cx + radius} y={cy + 30} textAnchor="end" fontSize="12" fill={token.colorTextSecondary}>
+            {valueFormatter(safeMax)}
+          </text>
+        </svg>
+      </div>
+    </div>
+  );
+};
+
+export default MetricGaugeChart;

--- a/ui/apps/dashboard/src/pages/metrics/charts/MetricLineChart.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/charts/MetricLineChart.tsx
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { theme } from 'antd';
+import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis } from 'recharts';
+
+import type { MetricChartProps } from './index';
+
+const DEFAULT_HEIGHT = 320;
+const HEADER_HEIGHT = 40;
+
+function formatNumber(value: number, fractionDigits = 3) {
+  if (!Number.isFinite(value)) return '0';
+  return value.toLocaleString(undefined, { maximumFractionDigits: fractionDigits });
+}
+
+function formatTimestamp(value: string) {
+  return new Date(value).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function getLatestValue(data: MetricChartProps['data']) {
+  for (let index = data.length - 1; index >= 0; index -= 1) {
+    const point = data[index];
+    if (typeof point?.value === 'number' && Number.isFinite(point.value)) {
+      return point.value;
+    }
+  }
+  return undefined;
+}
+
+const MetricLineChart = ({
+  data,
+  title,
+  color,
+  valueFormatter = (value) => formatNumber(value),
+  axisFormatter = (value) => formatNumber(value, 1),
+  width,
+  height = DEFAULT_HEIGHT,
+}: MetricChartProps) => {
+  const { token } = theme.useToken();
+  const latestValue = getLatestValue(data);
+  const chartHeight = Math.max(height - HEADER_HEIGHT, 180);
+
+  return (
+    <div className="flex flex-col gap-3" style={{ width }}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
+          <span className="text-sm font-medium" style={{ color: token.colorTextHeading }}>
+            {title}
+          </span>
+        </div>
+        <span className="text-sm font-medium" style={{ color: token.colorText }}>
+          {typeof latestValue === 'number' ? valueFormatter(latestValue) : '--'}
+        </span>
+      </div>
+
+      <div
+        className="w-full min-w-0 overflow-hidden rounded-md px-1 pt-2"
+        style={{ backgroundColor: token.colorFillQuaternary }}
+      >
+        {data.length === 0 ? (
+          <div
+            className="flex items-center justify-center text-sm"
+            style={{ height: chartHeight, color: token.colorTextTertiary }}
+          >
+            No data available
+          </div>
+        ) : (
+          <LineChart width={Math.max(width - 8, 0)} height={chartHeight} data={data} margin={{ left: 4, right: 4, top: 6, bottom: 2 }}>
+            <CartesianGrid vertical={false} strokeDasharray="2 6" stroke={token.colorBorderSecondary} />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatTimestamp}
+              minTickGap={28}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <YAxis
+              width={54}
+              tickFormatter={axisFormatter}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <Tooltip
+              cursor={{ stroke: token.colorBorder, strokeDasharray: '4 4' }}
+              contentStyle={{
+                borderRadius: 8,
+                border: `1px solid ${token.colorBorderSecondary}`,
+                boxShadow: token.boxShadowSecondary,
+                background: token.colorBgElevated,
+              }}
+              labelStyle={{ color: token.colorTextSecondary, fontSize: 12 }}
+              labelFormatter={(timestamp) => new Date(timestamp as string).toLocaleString()}
+              formatter={(tooltipValue) => [valueFormatter(Number(tooltipValue)), title]}
+            />
+            <Line
+              type="monotoneX"
+              dataKey="value"
+              stroke={color}
+              dot={false}
+              activeDot={{ r: 3, fill: color, stroke: token.colorBgContainer, strokeWidth: 1 }}
+              strokeWidth={2}
+              connectNulls
+              isAnimationActive={false}
+            />
+          </LineChart>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MetricLineChart;

--- a/ui/apps/dashboard/src/pages/metrics/charts/index.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/charts/index.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MetricAreaChart from './MetricAreaChart';
+import MetricBarChart from './MetricBarChart';
+import MetricGaugeChart from './MetricGaugeChart';
+import MetricLineChart from './MetricLineChart';
+
+export interface MetricChartProps {
+  data: Array<{ timestamp: string; value: number }>;
+  title: string;
+  color: string;
+  valueFormatter?: (value: number) => string;
+  axisFormatter?: (value: number) => string;
+  width: number;
+  height?: number;
+}
+
+export interface MetricGaugeChartProps extends MetricChartProps {
+  min?: number;
+  max?: number;
+  currentValue: number;
+}
+
+export type ChartType = 'line' | 'area' | 'bar' | 'gauge';
+
+export interface ChartFactoryProps extends MetricChartProps {
+  chartType: ChartType;
+  min?: number;
+  max?: number;
+  currentValue?: number;
+}
+
+function getLatestMetricValue(data: MetricChartProps['data']) {
+  for (let index = data.length - 1; index >= 0; index -= 1) {
+    const point = data[index];
+    if (typeof point?.value === 'number' && Number.isFinite(point.value)) {
+      return point.value;
+    }
+  }
+  return undefined;
+}
+
+export const ChartFactory = ({ chartType, currentValue, min, max, ...props }: ChartFactoryProps) => {
+  switch (chartType) {
+    case 'line':
+      return <MetricLineChart {...props} />;
+    case 'area':
+      return <MetricAreaChart {...props} />;
+    case 'bar':
+      return <MetricBarChart {...props} />;
+    case 'gauge':
+      return (
+        <MetricGaugeChart
+          {...props}
+          min={min}
+          max={max}
+          currentValue={currentValue ?? getLatestMetricValue(props.data) ?? 0}
+        />
+      );
+    default:
+      return null;
+  }
+};
+
+export { default as MetricAreaChart } from './MetricAreaChart';
+export { default as MetricBarChart } from './MetricBarChart';
+export { default as MetricGaugeChart } from './MetricGaugeChart';
+export { default as MetricLineChart } from './MetricLineChart';
+
+export default ChartFactory;

--- a/ui/apps/dashboard/src/pages/metrics/components/DashboardToolbar.module.less
+++ b/ui/apps/dashboard/src/pages/metrics/components/DashboardToolbar.module.less
@@ -1,0 +1,49 @@
+.toolbar {
+  justify-content: flex-end;
+}
+
+.toolbar :global(.ant-btn) {
+  font-weight: 650;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease;
+}
+
+.toolbar :global(.ant-btn:hover) {
+  transform: translateY(-1px);
+}
+
+.toolbar :global(.ant-btn:active) {
+  transform: translateY(0) scale(0.98);
+}
+
+.secondaryButton {
+  border-color: rgba(23, 109, 99, 0.16) !important;
+  color: #176d63 !important;
+  background: rgba(255, 255, 255, 0.72) !important;
+  box-shadow: 0 8px 18px rgba(23, 109, 99, 0.08);
+}
+
+.secondaryButton:hover {
+  border-color: rgba(23, 109, 99, 0.34) !important;
+  box-shadow: 0 12px 24px rgba(23, 109, 99, 0.12);
+}
+
+.primaryButton {
+  border-color: #176d63 !important;
+  background: #176d63 !important;
+  box-shadow: 0 10px 24px rgba(23, 109, 99, 0.22);
+}
+
+.primaryButton:hover {
+  border-color: #11564f !important;
+  background: #11564f !important;
+  box-shadow: 0 14px 30px rgba(23, 109, 99, 0.26);
+}
+
+.dangerButton {
+  background: rgba(255, 255, 255, 0.72) !important;
+  box-shadow: 0 8px 18px rgba(151, 65, 53, 0.08);
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/DashboardToolbar.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/components/DashboardToolbar.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Popconfirm, Space, Tooltip } from 'antd';
+import {
+  Check,
+  Compass,
+  Copy,
+  Pencil,
+  Plus,
+  RotateCcw,
+} from 'lucide-react';
+
+import styles from './DashboardToolbar.module.less';
+
+interface DashboardToolbarProps {
+  editMode: boolean;
+  hasCustomConfig: boolean;
+  onToggleEdit: () => void;
+  onAddPanel: () => void;
+  onReset: () => void;
+  onExplore?: () => void;
+  onCopy?: () => void;
+  exporting?: boolean;
+}
+
+export default function DashboardToolbar({
+  editMode,
+  hasCustomConfig,
+  onToggleEdit,
+  onAddPanel,
+  onReset,
+  onExplore,
+  onCopy,
+  exporting,
+}: DashboardToolbarProps) {
+  return (
+    <Space size="small" className={styles.toolbar} wrap>
+      <Tooltip title="Explore metrics with DSL query">
+        <Button
+          size="middle"
+          className={styles.secondaryButton}
+          icon={<Compass size={16} />}
+          onClick={onExplore}
+        />
+      </Tooltip>
+      {editMode && (
+        <>
+          <Tooltip title="Add panel">
+            <Button
+              type="primary"
+              size="middle"
+              className={styles.primaryButton}
+              icon={<Plus size={16} />}
+              onClick={onAddPanel}
+            />
+          </Tooltip>
+          {hasCustomConfig && (
+            <Popconfirm
+              title="Reset to default?"
+              description="This will remove all customizations and show all metrics."
+              onConfirm={onReset}
+              okText="Reset"
+              cancelText="Cancel"
+            >
+              <Tooltip title="Reset to default">
+                <Button
+                  size="middle"
+                  className={styles.dangerButton}
+                  icon={<RotateCcw size={16} />}
+                  danger
+                />
+              </Tooltip>
+            </Popconfirm>
+          )}
+        </>
+      )}
+      {onCopy && (
+        <Tooltip title="Copy current component metrics JSON">
+          <Button
+            size="middle"
+            className={styles.secondaryButton}
+            icon={<Copy size={16} />}
+            loading={exporting}
+            onClick={onCopy}
+          />
+        </Tooltip>
+      )}
+      <Tooltip title={editMode ? 'Done editing' : 'Customize dashboard'}>
+        <Button
+          size="middle"
+          className={editMode ? styles.primaryButton : styles.secondaryButton}
+          type={editMode ? 'primary' : 'default'}
+          icon={editMode ? <Check size={16} /> : <Pencil size={16} />}
+          onClick={onToggleEdit}
+        />
+      </Tooltip>
+    </Space>
+  );
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/DragPanel.module.less
+++ b/ui/apps/dashboard/src/pages/metrics/components/DragPanel.module.less
@@ -1,0 +1,43 @@
+.dragPanel {
+  position: relative;
+}
+
+.withHandle :global(.ant-card-head-title) {
+  padding-left: 34px;
+}
+
+.dragHandle {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 20;
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(35, 48, 44, 0.1);
+  border-radius: 9px;
+  color: rgba(23, 33, 31, 0.54);
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 8px 18px rgba(45, 58, 55, 0.12);
+  cursor: grab;
+  backdrop-filter: blur(10px);
+  transition:
+    transform 160ms ease,
+    color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.dragHandle:hover {
+  border-color: rgba(23, 109, 99, 0.28);
+  color: #176d63;
+  box-shadow: 0 12px 24px rgba(23, 109, 99, 0.16);
+  transform: translateY(-1px);
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+  transform: translateY(0) scale(0.97);
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/DragPanel.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/components/DragPanel.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical } from 'lucide-react';
+import type { CSSProperties, ReactNode } from 'react';
+
+import { cn } from '@/utils/cn';
+import styles from './DragPanel.module.less';
+
+interface DragPanelProps {
+  id: string;
+  children: ReactNode;
+  disabled?: boolean;
+}
+
+export default function DragPanel({ id, children, disabled }: DragPanelProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, disabled });
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    position: 'relative',
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(styles.dragPanel, !disabled && styles.withHandle)}
+      style={style}
+      {...attributes}
+    >
+      {!disabled && (
+        <div {...listeners} className={styles.dragHandle}>
+          <GripVertical size={14} />
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/LazyChart.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/components/LazyChart.tsx
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Skeleton, Spin } from 'antd';
+
+interface LazyChartProps {
+  children: ReactNode;
+  height?: number;
+  /** Whether data is still loading */
+  loading?: boolean;
+  /** Extra margin around viewport to pre-render (default 200px) */
+  rootMargin?: string;
+}
+
+/**
+ * LazyChart only renders its children (expensive chart SVGs) when the container
+ * enters the viewport. Once rendered, it stays rendered to avoid flicker on
+ * scroll back. Uses IntersectionObserver with rootMargin for pre-loading.
+ * Shows independent loading skeleton when data is being fetched.
+ */
+export default function LazyChart({ children, height = 252, loading = false, rootMargin = '200px' }: LazyChartProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [hasBeenVisible, setHasBeenVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || hasBeenVisible) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setHasBeenVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasBeenVisible, rootMargin]);
+
+  const placeholder = (
+    <div style={{ height, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      {loading ? (
+        <Spin tip="Loading..." size="small">
+          <div style={{ width: '100%', height: height - 32, padding: 16 }}>
+            <Skeleton active paragraph={{ rows: 4 }} title={false} />
+          </div>
+        </Spin>
+      ) : (
+        <Skeleton.Node active style={{ width: '100%', height: height - 16 }}>
+          <div style={{ width: 48, height: 48 }} />
+        </Skeleton.Node>
+      )}
+    </div>
+  );
+
+  return (
+    <div ref={ref} style={{ minHeight: height, contentVisibility: 'auto', containIntrinsicSize: `auto ${height}px` }}>
+      {hasBeenVisible && !loading ? children : placeholder}
+    </div>
+  );
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/MetricExplorer.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/components/MetricExplorer.tsx
@@ -1,0 +1,419 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Card,
+  Drawer,
+  Empty,
+  Input,
+  Select,
+  Spin,
+  Tag,
+  Typography,
+  theme,
+} from 'antd';
+import { useQuery } from '@tanstack/react-query';
+import { Area, AreaChart, CartesianGrid, Line, LineChart, Bar, BarChart, Tooltip, XAxis, YAxis } from 'recharts';
+import { Plus, X } from 'lucide-react';
+
+import {
+  ExploreMetric,
+  KarmadaComponentKey,
+  LabelFilter,
+  MetricCatalogItem,
+} from '@/services/metrics';
+import type { AggregationType, ChartType, PanelConfig } from '../dashboard-config';
+import { generatePanelId } from '../dashboard-config';
+
+const { Text } = Typography;
+
+interface MetricExplorerProps {
+  open: boolean;
+  onClose: () => void;
+  onAddToDashboard: (panel: PanelConfig) => void;
+  catalog: MetricCatalogItem[];
+  component: KarmadaComponentKey;
+  pod: string;
+}
+
+const aggregationOptions = [
+  { value: 'sum', label: 'Sum — total across all series' },
+  { value: 'avg', label: 'Avg — average across series' },
+  { value: 'max', label: 'Max — maximum value' },
+  { value: 'min', label: 'Min — minimum value' },
+  { value: 'rate', label: 'Rate — per-second rate of change' },
+];
+
+const chartTypeOptions: { value: ChartType; label: string }[] = [
+  { value: 'line', label: '📈 Line' },
+  { value: 'area', label: '📊 Area' },
+  { value: 'bar', label: '📉 Bar' },
+  { value: 'gauge', label: '🎯 Gauge' },
+];
+
+function formatTimestamp(value: string) {
+  return new Date(value).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+export default function MetricExplorer({
+  open,
+  onClose,
+  onAddToDashboard,
+  catalog,
+  component,
+  pod,
+}: MetricExplorerProps) {
+  const { token } = theme.useToken();
+  const [selectedMetric, setSelectedMetric] = useState<string>('');
+  const [aggregation, setAggregation] = useState<AggregationType>('sum');
+  const [chartType, setChartType] = useState<ChartType>('line');
+  const [labelFilters, setLabelFilters] = useState<LabelFilter[]>([]);
+  const [panelTitle, setPanelTitle] = useState('');
+
+  // Reset when drawer closes
+  useEffect(() => {
+    if (!open) {
+      setSelectedMetric('');
+      setAggregation('sum');
+      setChartType('line');
+      setLabelFilters([]);
+      setPanelTitle('');
+    }
+  }, [open]);
+
+  // Update chart type and title when metric changes
+  useEffect(() => {
+    if (selectedMetric) {
+      const item = catalog.find((m) => m.name === selectedMetric);
+      if (item) {
+        setChartType(item.suggestedChart);
+        setPanelTitle(item.name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()));
+      }
+    }
+  }, [selectedMetric, catalog]);
+
+  const {
+    data: exploreData,
+    isLoading: exploring,
+    error: exploreError,
+  } = useQuery({
+    queryKey: ['metricExplore', component, selectedMetric, aggregation, JSON.stringify(labelFilters), pod],
+    queryFn: () =>
+      ExploreMetric(component, {
+        metric: selectedMetric,
+        aggregation,
+        labels: labelFilters.length > 0 ? labelFilters : undefined,
+        window: '15m',
+        pod,
+      }),
+    enabled: open && !!selectedMetric,
+    refetchInterval: 10_000,
+  });
+
+  const availableLabels = useMemo(
+    () => exploreData?.availableLabels ?? {},
+    [exploreData?.availableLabels],
+  );
+
+  const addLabelFilter = useCallback(() => {
+    const keys = Object.keys(availableLabels);
+    if (keys.length === 0) return;
+    setLabelFilters((prev) => [...prev, { key: keys[0], value: '' }]);
+  }, [availableLabels]);
+
+  const updateLabelFilter = useCallback((index: number, updates: Partial<LabelFilter>) => {
+    setLabelFilters((prev) =>
+      prev.map((f, i) => (i === index ? { ...f, ...updates } : f)),
+    );
+  }, []);
+
+  const removeLabelFilter = useCallback((index: number) => {
+    setLabelFilters((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleAddToDashboard = () => {
+    const panel: PanelConfig = {
+      id: generatePanelId(),
+      metricName: selectedMetric,
+      chartType,
+      title: panelTitle || selectedMetric,
+      visible: true,
+      query: {
+        metric: selectedMetric,
+        aggregation,
+        labelFilters: labelFilters.filter((f) => f.key && f.value),
+      },
+    };
+    onAddToDashboard(panel);
+    onClose();
+  };
+
+  const renderPreviewChart = () => {
+    if (!exploreData?.timeseries?.length) {
+      return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No data for this query" />;
+    }
+
+    const data = exploreData.timeseries.map((p) => ({
+      timestamp: p.timestamp,
+      value: p.value,
+    }));
+
+    const chartWidth = 520;
+    const chartHeight = 200;
+    const commonProps = {
+      width: chartWidth,
+      height: chartHeight,
+      data,
+      margin: { left: 4, right: 4, top: 6, bottom: 2 },
+    };
+
+    const xAxis = (
+      <XAxis
+        dataKey="timestamp"
+        tickFormatter={formatTimestamp}
+        minTickGap={28}
+        axisLine={false}
+        tickLine={false}
+        tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+      />
+    );
+    const yAxis = (
+      <YAxis
+        width={54}
+        axisLine={false}
+        tickLine={false}
+        tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+      />
+    );
+    const tooltip = (
+      <Tooltip
+        contentStyle={{
+          borderRadius: 8,
+          border: `1px solid ${token.colorBorderSecondary}`,
+          background: token.colorBgElevated,
+        }}
+        labelFormatter={(ts) => new Date(ts as string).toLocaleString()}
+      />
+    );
+    const grid = <CartesianGrid vertical={false} strokeDasharray="2 6" stroke={token.colorBorderSecondary} />;
+
+    if (chartType === 'bar') {
+      return (
+        <BarChart {...commonProps}>
+          {grid}{xAxis}{yAxis}{tooltip}
+          <Bar dataKey="value" fill={token.colorPrimary} fillOpacity={0.8} radius={[2, 2, 0, 0]} isAnimationActive={false} />
+        </BarChart>
+      );
+    }
+    if (chartType === 'line') {
+      return (
+        <LineChart {...commonProps}>
+          {grid}{xAxis}{yAxis}{tooltip}
+          <Line type="monotoneX" dataKey="value" stroke={token.colorPrimary} dot={false} strokeWidth={2} isAnimationActive={false} />
+        </LineChart>
+      );
+    }
+    // Default: area
+    return (
+      <AreaChart {...commonProps}>
+        {grid}{xAxis}{yAxis}{tooltip}
+        <Area type="monotoneX" dataKey="value" stroke={token.colorPrimary} fill={token.colorPrimaryBg} strokeWidth={2} isAnimationActive={false} />
+      </AreaChart>
+    );
+  };
+
+  return (
+    <Drawer
+      title="Metric Explorer"
+      open={open}
+      onClose={onClose}
+      width={640}
+      extra={
+        <Button
+          type="primary"
+          icon={<Plus size={14} />}
+          disabled={!selectedMetric || !exploreData?.timeseries?.length}
+          onClick={handleAddToDashboard}
+        >
+          Add to Dashboard
+        </Button>
+      }
+    >
+      <div className="space-y-4">
+        {/* Query Builder */}
+        <Card size="small" title="Query Builder">
+          <div className="space-y-3">
+            {/* Metric selector */}
+            <div>
+              <Text type="secondary" className="text-xs block mb-1">Metric</Text>
+              <Select
+                showSearch
+                placeholder="Search and select a metric..."
+                optionFilterProp="label"
+                value={selectedMetric || undefined}
+                onChange={setSelectedMetric}
+                style={{ width: '100%' }}
+                options={catalog.map((m) => ({
+                  value: m.name,
+                  label: `${m.name} (${m.prometheusType})`,
+                }))}
+              />
+              {selectedMetric && (
+                <Text type="secondary" className="text-xs mt-1 block">
+                  {catalog.find((m) => m.name === selectedMetric)?.help || ''}
+                </Text>
+              )}
+            </div>
+
+            {/* Aggregation */}
+            <div>
+              <Text type="secondary" className="text-xs block mb-1">Aggregation</Text>
+              <Select
+                value={aggregation}
+                onChange={setAggregation}
+                style={{ width: '100%' }}
+                options={aggregationOptions}
+              />
+            </div>
+
+            {/* Chart type */}
+            <div>
+              <Text type="secondary" className="text-xs block mb-1">Chart Type</Text>
+              <Select
+                value={chartType}
+                onChange={setChartType}
+                style={{ width: 200 }}
+                options={chartTypeOptions}
+              />
+            </div>
+
+            {/* Label filters */}
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <Text type="secondary" className="text-xs">Label Filters</Text>
+                <Button
+                  size="small"
+                  type="dashed"
+                  icon={<Plus size={12} />}
+                  onClick={addLabelFilter}
+                  disabled={Object.keys(availableLabels).length === 0}
+                >
+                  Add Filter
+                </Button>
+              </div>
+              {labelFilters.map((filter, index) => (
+                <div key={index} className="flex items-center gap-2 mb-2">
+                  <Select
+                    size="small"
+                    value={filter.key}
+                    onChange={(key) => updateLabelFilter(index, { key, value: '' })}
+                    style={{ width: 160 }}
+                    options={Object.keys(availableLabels).map((k) => ({ value: k, label: k }))}
+                  />
+                  <Text type="secondary">=</Text>
+                  <Select
+                    size="small"
+                    value={filter.value || undefined}
+                    onChange={(value) => updateLabelFilter(index, { value })}
+                    style={{ width: 200 }}
+                    placeholder="Select value..."
+                    showSearch
+                    options={(availableLabels[filter.key] ?? []).map((v) => ({ value: v, label: v }))}
+                  />
+                  <Button
+                    size="small"
+                    type="text"
+                    danger
+                    icon={<X size={12} />}
+                    onClick={() => removeLabelFilter(index)}
+                  />
+                </div>
+              ))}
+              {Object.keys(availableLabels).length === 0 && selectedMetric && !exploring && (
+                <Text type="secondary" className="text-xs">No labels available for this metric</Text>
+              )}
+            </div>
+
+            {/* Panel title */}
+            <div>
+              <Text type="secondary" className="text-xs block mb-1">Panel Title</Text>
+              <Input
+                value={panelTitle}
+                onChange={(e) => setPanelTitle(e.target.value)}
+                placeholder="Enter panel title..."
+              />
+            </div>
+          </div>
+        </Card>
+
+        {/* Preview */}
+        <Card
+          size="small"
+          title="Preview"
+          extra={
+            exploring ? <Spin size="small" /> : (
+              exploreData?.timeseries?.length ? (
+                <Tag color="green">{exploreData.timeseries.length} points</Tag>
+              ) : null
+            )
+          }
+        >
+          {!selectedMetric ? (
+            <div className="flex items-center justify-center h-[200px]">
+              <Text type="secondary">Select a metric to preview</Text>
+            </div>
+          ) : exploring ? (
+            <div className="flex items-center justify-center h-[200px]">
+              <Spin />
+            </div>
+          ) : exploreError ? (
+            <div className="flex items-center justify-center h-[200px]">
+              <Text type="danger">Query failed: {(exploreError as Error).message}</Text>
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-md" style={{ background: token.colorFillQuaternary, padding: '8px' }}>
+              {renderPreviewChart()}
+            </div>
+          )}
+        </Card>
+
+        {/* Active query summary */}
+        {selectedMetric && exploreData && (
+          <Card size="small" title="Query DSL">
+            <pre className="text-xs overflow-auto" style={{ background: token.colorFillQuaternary, padding: 8, borderRadius: 6 }}>
+{JSON.stringify(
+  {
+    metric: selectedMetric,
+    aggregation,
+    labelFilters: labelFilters.filter((f) => f.key && f.value),
+    chartType,
+  },
+  null,
+  2,
+)}
+            </pre>
+          </Card>
+        )}
+      </div>
+    </Drawer>
+  );
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/PanelEditor.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/components/PanelEditor.tsx
@@ -1,0 +1,200 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+import { Modal, Form, Input, Select, Typography } from 'antd';
+import type { MetricCatalogItem } from '@/services/metrics';
+import type { PanelConfig, ChartType } from '../dashboard-config';
+import { generatePanelId } from '../dashboard-config';
+
+const { Text } = Typography;
+
+interface PanelEditorProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (panels: PanelConfig[]) => void;
+  catalog: MetricCatalogItem[];
+  editingPanel?: PanelConfig | null;
+  existingMetricNames?: string[];
+}
+
+const buildTitle = (name: string) =>
+  name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+const chartTypeOptions = [
+  { value: 'line', label: '📈 Line Chart' },
+  { value: 'area', label: '📊 Area Chart' },
+  { value: 'bar', label: '📉 Bar Chart' },
+  { value: 'gauge', label: '🎯 Gauge' },
+];
+
+export default function PanelEditor({
+  open,
+  onClose,
+  onSave,
+  catalog,
+  editingPanel,
+  existingMetricNames = [],
+}: PanelEditorProps) {
+  const [form] = Form.useForm();
+  const [selectedMetric, setSelectedMetric] = useState<MetricCatalogItem | null>(null);
+
+  const isEditing = Boolean(editingPanel);
+  const existingSet = new Set(existingMetricNames);
+
+  useEffect(() => {
+    if (open) {
+      if (editingPanel) {
+        form.setFieldsValue({
+          metricName: editingPanel.metricName,
+          chartType: editingPanel.chartType,
+          title: editingPanel.title,
+        });
+        const found = catalog.find((m) => m.name === editingPanel.metricName);
+        setSelectedMetric(found ?? null);
+      } else {
+        form.resetFields();
+        setSelectedMetric(null);
+      }
+    }
+  }, [open, editingPanel, form, catalog]);
+
+  const handleMetricChange = (metricName: string) => {
+    const item = catalog.find((m) => m.name === metricName);
+    setSelectedMetric(item ?? null);
+    if (item) {
+      form.setFieldsValue({
+        chartType: item.suggestedChart,
+        title: buildTitle(item.name),
+      });
+    }
+  };
+
+  const handleSave = () => {
+    form.validateFields().then((values) => {
+      if (isEditing) {
+        const panel: PanelConfig = {
+          id: editingPanel?.id ?? generatePanelId(),
+          metricName: values.metricName,
+          chartType: values.chartType as ChartType,
+          title: values.title,
+          visible: true,
+        };
+        onSave([panel]);
+        onClose();
+        return;
+      }
+
+      const metricNames: string[] = values.metricNames ?? [];
+      const panels: PanelConfig[] = metricNames.map((name) => {
+        const item = catalog.find((m) => m.name === name);
+        return {
+          id: generatePanelId(),
+          metricName: name,
+          chartType: (item?.suggestedChart ?? 'line') as ChartType,
+          title: buildTitle(name),
+          visible: true,
+        };
+      });
+      onSave(panels);
+      onClose();
+    });
+  };
+
+  return (
+    <Modal
+      title={isEditing ? 'Edit Panel' : 'Add Panel'}
+      open={open}
+      onOk={handleSave}
+      onCancel={onClose}
+      okText={isEditing ? 'Update' : 'Add'}
+      width={560}
+      destroyOnClose
+    >
+      <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
+        {isEditing ? (
+          <>
+            <Form.Item
+              name="metricName"
+              label="Metric"
+              rules={[{ required: true, message: 'Please select a metric' }]}
+            >
+              <Select
+                showSearch
+                placeholder="Search and select a metric..."
+                optionFilterProp="label"
+                onChange={handleMetricChange}
+                options={catalog.map((m) => ({
+                  value: m.name,
+                  label: m.name,
+                }))}
+              />
+            </Form.Item>
+
+            {selectedMetric && (
+              <div style={{ marginBottom: 16, padding: '8px 12px', background: '#f5f5f5', borderRadius: 6 }}>
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  {selectedMetric.help || 'No description available'}
+                </Text>
+                <br />
+                <Text type="secondary" style={{ fontSize: 11 }}>
+                  Type: <strong>{selectedMetric.prometheusType}</strong> | Group:{' '}
+                  <strong>{selectedMetric.group}</strong>
+                </Text>
+              </div>
+            )}
+
+            <Form.Item
+              name="chartType"
+              label="Chart Type"
+              rules={[{ required: true, message: 'Please select a chart type' }]}
+            >
+              <Select options={chartTypeOptions} />
+            </Form.Item>
+
+            <Form.Item
+              name="title"
+              label="Panel Title"
+              rules={[{ required: true, message: 'Please enter a title' }]}
+            >
+              <Input placeholder="Enter panel title" />
+            </Form.Item>
+          </>
+        ) : (
+          <Form.Item
+            name="metricNames"
+            label="Metric"
+            rules={[{ required: true, message: 'Please select at least one metric' }]}
+            extra="Already added metrics are disabled. You can select multiple metrics at once."
+          >
+            <Select
+              mode="multiple"
+              showSearch
+              allowClear
+              placeholder="Search and select metrics..."
+              optionFilterProp="label"
+              options={catalog.map((m) => ({
+                value: m.name,
+                label: m.name,
+                disabled: existingSet.has(m.name),
+              }))}
+            />
+          </Form.Item>
+        )}
+      </Form>
+    </Modal>
+  );
+}

--- a/ui/apps/dashboard/src/pages/metrics/components/index.ts
+++ b/ui/apps/dashboard/src/pages/metrics/components/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as DashboardToolbar } from './DashboardToolbar';
+export { default as DragPanel } from './DragPanel';
+export { default as LazyChart } from './LazyChart';
+export { default as MetricExplorer } from './MetricExplorer';
+export { default as PanelEditor } from './PanelEditor';

--- a/ui/apps/dashboard/src/pages/metrics/dashboard-config.test.ts
+++ b/ui/apps/dashboard/src/pages/metrics/dashboard-config.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { MetricCatalogItem } from '@/services/metrics';
+
+import {
+  DEFAULT_METRIC_NAMES_BY_COMPONENT,
+  buildDefaultConfig,
+  getConfiguredMetricNames,
+  selectDefaultCatalogMetrics,
+  serializeComponentDashboardConfig,
+  type DashboardConfig,
+} from './dashboard-config.ts';
+
+const COMPONENTS = [
+  'karmada-scheduler',
+  'karmada-controller-manager',
+  'karmada-agent',
+  'karmada-aggregated-apiserver',
+  'karmada-apiserver',
+  'karmada-descheduler',
+  'karmada-kube-controller-manager',
+  'karmada-metrics-adapter',
+  'karmada-scheduler-estimator-member1',
+  'karmada-scheduler-estimator-member2',
+  'karmada-scheduler-estimator-member3',
+  'karmada-search',
+  'karmada-webhook',
+] as const;
+
+const INTERNAL_METRIC_PREFIXES = [
+  'go_',
+  'process_',
+  'promhttp_',
+  'grpc_',
+  'rest_client_',
+  'certwatcher_',
+];
+
+function catalogItem(name: string): MetricCatalogItem {
+  return {
+    name,
+    help: '',
+    prometheusType: 'gauge',
+    suggestedChart: 'line',
+    group: 'test',
+  };
+}
+
+test('every dashboard component has non-internal defaults', () => {
+  assert.deepEqual(
+    Object.keys(DEFAULT_METRIC_NAMES_BY_COMPONENT).sort(),
+    [...COMPONENTS].sort(),
+  );
+
+  for (const component of COMPONENTS) {
+    const defaults = DEFAULT_METRIC_NAMES_BY_COMPONENT[component];
+    assert.ok(defaults.length > 0, `${component} has no defaults`);
+    for (const metricName of defaults) {
+      assert.equal(
+        INTERNAL_METRIC_PREFIXES.some((prefix) =>
+          metricName.startsWith(prefix),
+        ),
+        false,
+        `${component} unexpectedly defaults to ${metricName}`,
+      );
+    }
+  }
+});
+
+test('default metrics preserve allowlist order and require catalog presence', () => {
+  const selected = selectDefaultCatalogMetrics(
+    'karmada-kube-controller-manager',
+    [
+      catalogItem('go_gc_duration_seconds'),
+      catalogItem('workqueue_depth'),
+      catalogItem('node_collector_update_node_health_duration_seconds'),
+      catalogItem('node_collector_update_all_nodes_health_duration_seconds'),
+    ],
+  );
+
+  assert.deepEqual(
+    selected.map((item) => item.name),
+    [
+      'node_collector_update_all_nodes_health_duration_seconds',
+      'node_collector_update_node_health_duration_seconds',
+      'workqueue_depth',
+    ],
+  );
+});
+
+test('internal metrics are never selected by an automatic fallback', () => {
+  const config = buildDefaultConfig('karmada-webhook', [
+    catalogItem('go_gc_duration_seconds'),
+    catalogItem('process_resident_memory_bytes'),
+  ]);
+  assert.deepEqual(config.panels, []);
+});
+
+test('explicit user configuration keeps internal metrics', () => {
+  const config: DashboardConfig = {
+    version: 1,
+    component: 'karmada-webhook',
+    panels: [
+      {
+        id: 'go-gc',
+        metricName: 'go_gc_duration_seconds',
+        chartType: 'line',
+        title: 'Go GC Duration',
+        visible: true,
+      },
+    ],
+  };
+
+  assert.deepEqual(getConfiguredMetricNames(config), [
+    'go_gc_duration_seconds',
+  ]);
+});
+
+test('component export contains only the selected dashboard', () => {
+  const config: DashboardConfig = {
+    version: 1,
+    component: 'karmada-apiserver',
+    panels: [
+      {
+        id: 'request-total',
+        metricName: 'apiserver_request_total',
+        chartType: 'line',
+        title: 'API Server Requests',
+        visible: true,
+      },
+    ],
+  };
+
+  assert.deepEqual(JSON.parse(serializeComponentDashboardConfig(config)), {
+    metrics_dashboards: [config],
+  });
+});

--- a/ui/apps/dashboard/src/pages/metrics/dashboard-config.ts
+++ b/ui/apps/dashboard/src/pages/metrics/dashboard-config.ts
@@ -1,0 +1,380 @@
+/**
+ * Copyright 2024 The Karmada Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  KarmadaComponentKey,
+  MetricCatalogItem,
+} from '@/services/metrics';
+
+export type ChartType = 'line' | 'area' | 'bar' | 'gauge';
+export type AggregationType = 'sum' | 'avg' | 'max' | 'min' | 'rate';
+
+export interface LabelFilter {
+  key: string;
+  value: string;
+}
+
+export interface MetricQuery {
+  metric: string;
+  aggregation: AggregationType;
+  labelFilters?: LabelFilter[];
+}
+
+export interface PanelConfig {
+  id: string;
+  metricName: string;
+  chartType: ChartType;
+  title: string;
+  visible: boolean;
+  query?: MetricQuery;
+  /** Grid position (order index) */
+  order?: number;
+}
+
+export interface DashboardConfig {
+  version: number;
+  component: string;
+  panels: PanelConfig[];
+}
+
+const STORAGE_PREFIX = 'karmada-metrics-dashboard:';
+const CONFIG_VERSION = 1;
+const DEFAULT_PANEL_LIMIT = 12;
+
+/**
+ * Ordered, component-specific defaults. Only metrics in both this allowlist
+ * and the live catalog become automatic panels. Runtime/process metrics stay
+ * available in the catalog so an explicit user configuration can add them.
+ */
+export const DEFAULT_METRIC_NAMES_BY_COMPONENT = {
+  'karmada-scheduler': [
+    'karmada_scheduler_schedule_attempts_total',
+    'karmada_scheduler_queue_incoming_bindings_total',
+    'karmada_scheduler_e2e_scheduling_duration_seconds',
+    'karmada_scheduler_scheduling_algorithm_duration_seconds',
+    'karmada_scheduler_framework_extension_point_duration_seconds',
+    'karmada_scheduler_plugin_execution_duration_seconds',
+    'scheduler_pending_bindings',
+    'leader_election_master_status',
+    'workqueue_depth',
+    'workqueue_retries_total',
+    'workqueue_longest_running_processor_seconds',
+    'karmada_build_info',
+  ],
+  'karmada-controller-manager': [
+    'cluster_ready_state',
+    'cluster_ready_node_number',
+    'cluster_node_number',
+    'cluster_cpu_allocatable_number',
+    'cluster_cpu_allocated_number',
+    'cluster_memory_allocatable_bytes',
+    'cluster_memory_allocated_bytes',
+    'cluster_pod_allocatable_number',
+    'cluster_pod_allocated_number',
+    'cluster_sync_status_duration_seconds',
+    'policy_apply_attempts_total',
+    'resource_apply_policy_duration_seconds',
+  ],
+  'karmada-agent': [
+    'cluster_ready_state',
+    'cluster_ready_node_number',
+    'cluster_node_number',
+    'cluster_cpu_allocatable_number',
+    'cluster_cpu_allocated_number',
+    'cluster_memory_allocatable_bytes',
+    'cluster_memory_allocated_bytes',
+    'cluster_pod_allocatable_number',
+    'cluster_pod_allocated_number',
+    'cluster_sync_status_duration_seconds',
+    'sync_workload_duration_seconds',
+    'workqueue_depth',
+  ],
+  'karmada-aggregated-apiserver': [
+    'apiserver_request_total',
+    'apiserver_request_duration_seconds',
+    'apiserver_current_inflight_requests',
+    'apiserver_longrunning_requests',
+    'apiserver_request_sli_duration_seconds',
+    'apiserver_response_sizes',
+    'apiserver_storage_objects',
+    'apiserver_storage_size_bytes',
+    'apiserver_storage_db_total_size_in_bytes',
+    'apiserver_tls_handshake_errors_total',
+    'apiserver_delegated_authz_request_total',
+    'apiserver_delegated_authz_request_duration_seconds',
+  ],
+  'karmada-apiserver': [
+    'apiserver_request_total',
+    'apiserver_request_duration_seconds',
+    'apiserver_current_inflight_requests',
+    'apiserver_current_inqueue_requests',
+    'apiserver_longrunning_requests',
+    'apiserver_flowcontrol_current_executing_requests',
+    'apiserver_flowcontrol_current_inqueue_requests',
+    'apiserver_flowcontrol_request_wait_duration_seconds',
+    'apiserver_admission_controller_admission_duration_seconds',
+    'apiserver_storage_objects',
+    'apiserver_storage_size_bytes',
+    'apiserver_tls_handshake_errors_total',
+  ],
+  'karmada-descheduler': [
+    'leader_election_master_status',
+    'workqueue_depth',
+    'workqueue_adds_total',
+    'workqueue_retries_total',
+    'workqueue_queue_duration_seconds',
+    'workqueue_work_duration_seconds',
+    'workqueue_longest_running_processor_seconds',
+    'workqueue_unfinished_work_seconds',
+    'karmada_build_info',
+  ],
+  'karmada-kube-controller-manager': [
+    'node_collector_update_all_nodes_health_duration_seconds',
+    'node_collector_update_node_health_duration_seconds',
+    'garbagecollector_controller_resources_sync_error_total',
+    'ttl_after_finished_controller_job_deletion_duration_seconds',
+    'leader_election_master_status',
+    'workqueue_depth',
+    'workqueue_adds_total',
+    'workqueue_retries_total',
+    'workqueue_longest_running_processor_seconds',
+    'workqueue_unfinished_work_seconds',
+  ],
+  'karmada-metrics-adapter': [
+    'apiserver_request_total',
+    'apiserver_request_duration_seconds',
+    'apiserver_request_sli_duration_seconds',
+    'apiserver_request_slo_duration_seconds',
+    'apiserver_request_filter_duration_seconds',
+    'apiserver_current_inflight_requests',
+    'workqueue_depth',
+    'workqueue_adds_total',
+    'workqueue_retries_total',
+    'karmada_build_info',
+  ],
+  'karmada-scheduler-estimator-member1': [
+    'karmada_scheduler_estimator_estimating_request_total',
+    'karmada_scheduler_estimator_estimating_algorithm_duration_seconds',
+    'karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds',
+    'karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds',
+    'karmada_build_info',
+  ],
+  'karmada-scheduler-estimator-member2': [
+    'karmada_scheduler_estimator_estimating_request_total',
+    'karmada_scheduler_estimator_estimating_algorithm_duration_seconds',
+    'karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds',
+    'karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds',
+    'karmada_build_info',
+  ],
+  'karmada-scheduler-estimator-member3': [
+    'karmada_scheduler_estimator_estimating_request_total',
+    'karmada_scheduler_estimator_estimating_algorithm_duration_seconds',
+    'karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds',
+    'karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds',
+    'karmada_build_info',
+  ],
+  'karmada-search': [
+    'apiserver_request_total',
+    'apiserver_request_duration_seconds',
+    'apiserver_current_inflight_requests',
+    'apiserver_longrunning_requests',
+    'apiserver_request_sli_duration_seconds',
+    'apiserver_request_slo_duration_seconds',
+    'apiserver_request_filter_duration_seconds',
+    'apiserver_storage_objects',
+    'apiserver_storage_size_bytes',
+    'etcd_request_duration_seconds',
+    'etcd_requests_total',
+    'workqueue_depth',
+  ],
+  'karmada-webhook': [
+    'controller_runtime_webhook_requests_total',
+    'controller_runtime_webhook_latency_seconds',
+    'controller_runtime_webhook_requests_in_flight',
+    'controller_runtime_webhook_panics_total',
+    'controller_runtime_conversion_webhook_panics_total',
+    'karmada_build_info',
+  ],
+} satisfies Record<KarmadaComponentKey, readonly string[]>;
+
+export function getDefaultMetricNamesForComponent(
+  component: string,
+): readonly string[] {
+  return (
+    DEFAULT_METRIC_NAMES_BY_COMPONENT[component as KarmadaComponentKey] ?? []
+  );
+}
+
+/**
+ * Generate a unique panel ID
+ */
+export function generatePanelId(): string {
+  return `panel-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Load dashboard config from localStorage for a specific component.
+ * Returns null if no config exists.
+ */
+export function loadDashboardConfig(component: string): DashboardConfig | null {
+  try {
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}${component}`);
+    if (!raw) return null;
+    const config = JSON.parse(raw) as DashboardConfig;
+    if (config.version !== CONFIG_VERSION) return null;
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save dashboard config to localStorage for a specific component.
+ */
+export function saveDashboardConfig(config: DashboardConfig): void {
+  localStorage.setItem(
+    `${STORAGE_PREFIX}${config.component}`,
+    JSON.stringify(config),
+  );
+}
+
+/**
+ * Reset (delete) the dashboard config for a component.
+ */
+export function resetDashboardConfig(component: string): void {
+  localStorage.removeItem(`${STORAGE_PREFIX}${component}`);
+}
+
+/**
+ * Create a PanelConfig from a MetricCatalogItem with sensible defaults.
+ */
+export function createPanelFromCatalogItem(
+  item: MetricCatalogItem,
+): PanelConfig {
+  return {
+    id: generatePanelId(),
+    metricName: item.name,
+    chartType: item.suggestedChart,
+    title: item.name
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, (c) => c.toUpperCase()),
+    visible: true,
+  };
+}
+
+/**
+ * Pick a compact default metric subset centered on Karmada control-plane health.
+ */
+export function selectDefaultCatalogMetrics(
+  component: string,
+  catalog: MetricCatalogItem[],
+): MetricCatalogItem[] {
+  const catalogByName = new Map(catalog.map((item) => [item.name, item]));
+  return getDefaultMetricNamesForComponent(component)
+    .map((name) => catalogByName.get(name))
+    .filter((item): item is MetricCatalogItem => item !== undefined)
+    .slice(0, DEFAULT_PANEL_LIMIT);
+}
+
+/**
+ * Build a compact default config from catalog.
+ */
+export function buildDefaultConfig(
+  component: string,
+  catalog: MetricCatalogItem[],
+): DashboardConfig {
+  return {
+    version: CONFIG_VERSION,
+    component,
+    panels: selectDefaultCatalogMetrics(component, catalog).map(
+      createPanelFromCatalogItem,
+    ),
+  };
+}
+
+/**
+ * Add a panel to the config and save.
+ */
+export function addPanel(
+  config: DashboardConfig,
+  panel: PanelConfig,
+): DashboardConfig {
+  const updated = {
+    ...config,
+    panels: [...config.panels, panel],
+  };
+  saveDashboardConfig(updated);
+  return updated;
+}
+
+/**
+ * Remove a panel by ID and save.
+ */
+export function removePanel(
+  config: DashboardConfig,
+  panelId: string,
+): DashboardConfig {
+  const updated = {
+    ...config,
+    panels: config.panels.filter((p) => p.id !== panelId),
+  };
+  saveDashboardConfig(updated);
+  return updated;
+}
+
+/**
+ * Update a panel by ID and save.
+ */
+export function updatePanel(
+  config: DashboardConfig,
+  panelId: string,
+  updates: Partial<PanelConfig>,
+): DashboardConfig {
+  const updated = {
+    ...config,
+    panels: config.panels.map((p) =>
+      p.id === panelId ? { ...p, ...updates } : p,
+    ),
+  };
+  saveDashboardConfig(updated);
+  return updated;
+}
+
+/**
+ * Reorder panels and save.
+ */
+export function reorderPanels(
+  config: DashboardConfig,
+  panels: PanelConfig[],
+): DashboardConfig {
+  const updated = { ...config, panels };
+  saveDashboardConfig(updated);
+  return updated;
+}
+
+/**
+ * Get the list of metric names from the config (for API filtering).
+ */
+export function getConfiguredMetricNames(config: DashboardConfig): string[] {
+  return config.panels.filter((p) => p.visible).map((p) => p.metricName);
+}
+
+/** Serialize one component dashboard in the ConfigMap-compatible JSON shape. */
+export function serializeComponentDashboardConfig(
+  config: DashboardConfig,
+): string {
+  return JSON.stringify({ metrics_dashboards: [config] }, null, 2);
+}

--- a/ui/apps/dashboard/src/pages/metrics/index.module.less
+++ b/ui/apps/dashboard/src/pages/metrics/index.module.less
@@ -1,0 +1,435 @@
+.metricsPage {
+  --metrics-panel: rgba(255, 255, 255, 0.82);
+  --metrics-ink: #17211f;
+  --metrics-muted: #66736f;
+  --metrics-line: rgba(34, 48, 44, 0.1);
+  --metrics-accent: #176d63;
+
+  position: relative;
+  min-height: 100%;
+  overflow: hidden;
+  color: var(--metrics-ink);
+  background: transparent;
+}
+
+.metricsPage > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 20px;
+  border: 1px solid var(--metrics-line);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(46, 60, 56, 0.06);
+}
+
+.heroCopy {
+  min-width: 0;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 8px;
+  color: var(--metrics-accent);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pageTitle {
+  margin: 0 !important;
+  color: var(--metrics-ink) !important;
+  font-size: clamp(24px, 3vw, 32px) !important;
+  font-weight: 700 !important;
+  line-height: 1.1 !important;
+  text-wrap: balance;
+}
+
+.heroMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.heroMeta span {
+  display: inline-flex;
+  min-height: 28px;
+  align-items: center;
+  padding: 5px 10px;
+  border: 1px solid rgba(23, 109, 99, 0.13);
+  border-radius: 8px;
+  color: var(--metrics-muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.refreshButton {
+  border-color: rgba(23, 109, 99, 0.18) !important;
+  color: var(--metrics-accent) !important;
+  font-weight: 650;
+  background: rgba(255, 255, 255, 0.76) !important;
+  box-shadow: 0 8px 18px rgba(23, 109, 99, 0.08);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease !important;
+}
+
+.refreshButton:hover {
+  border-color: rgba(23, 109, 99, 0.36) !important;
+  box-shadow: 0 12px 26px rgba(23, 109, 99, 0.12);
+  transform: translateY(-1px);
+}
+
+.refreshButton:active {
+  transform: translateY(0) scale(0.98);
+}
+
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.summaryItem {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--metrics-line);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(46, 60, 56, 0.05);
+}
+
+.summaryLabel {
+  display: block;
+  color: var(--metrics-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.summaryValue {
+  display: block;
+  margin-top: 4px;
+  color: var(--metrics-ink);
+  font-size: 24px;
+  font-weight: 760;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.scopeCard {
+  margin-top: 14px;
+  border: 1px solid var(--metrics-line);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(46, 60, 56, 0.05);
+}
+
+.scopeCard :global(.ant-card-body) {
+  padding: 16px;
+}
+
+.scopeGrid {
+  display: grid;
+  grid-template-columns:
+    minmax(220px, 1.15fr) minmax(128px, 0.56fr) minmax(240px, 1fr)
+    auto;
+  gap: 14px;
+  align-items: end;
+}
+
+.controlField {
+  display: grid;
+  min-width: 0;
+  gap: 7px;
+}
+
+.controlLabel {
+  color: var(--metrics-muted) !important;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.componentSelect,
+.windowSelect,
+.podSelect {
+  width: 100%;
+  min-width: 0;
+}
+
+.componentSelect :global(.ant-select-selection-item),
+.windowSelect :global(.ant-select-selection-item),
+.podSelect :global(.ant-select-selection-item) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scopeMeta {
+  min-width: 170px;
+  padding: 8px 0 6px 14px;
+  border-left: 1px solid var(--metrics-line);
+  text-align: right;
+}
+
+.metaLine {
+  display: block;
+  overflow: hidden;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inlineAlert {
+  margin-top: 14px;
+  border-radius: 12px;
+}
+
+.metricsSection {
+  margin-top: 20px;
+}
+
+.metricGroups {
+  display: grid;
+  gap: 24px;
+  margin-top: 18px;
+}
+
+.metricGroup {
+  display: grid;
+  gap: 14px;
+}
+
+.groupHeading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 2px;
+}
+
+.groupTitle {
+  color: var(--metrics-ink) !important;
+  font-size: 18px;
+  font-weight: 760;
+}
+
+.groupCount {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.prefixGroups {
+  display: grid;
+  gap: 18px;
+}
+
+.prefixGroup {
+  display: grid;
+  gap: 10px;
+}
+
+.prefixHeading {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: baseline;
+}
+
+.prefixTitle {
+  color: #26312e !important;
+  font-size: 13px;
+  font-weight: 720;
+}
+
+.prefixDescription {
+  max-width: 62ch;
+  font-size: 12px;
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+
+.chartGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.chartCard {
+  position: relative;
+  min-height: 344px;
+  overflow: hidden;
+  border: 1px solid var(--metrics-line);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(45, 58, 55, 0.06);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.chartCard:hover {
+  border-color: rgba(23, 109, 99, 0.22);
+  box-shadow: 0 6px 16px rgba(45, 58, 55, 0.1);
+  transform: translateY(-2px);
+}
+
+.chartCard :global(.ant-card-head) {
+  min-height: 72px;
+  border-bottom: 1px solid rgba(35, 48, 44, 0.08);
+  padding: 0 16px;
+}
+
+.chartCard :global(.ant-card-body) {
+  padding: 14px 14px 16px;
+}
+
+.chartHeader {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.chartTitleRow {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.chartName {
+  min-width: 0;
+}
+
+.chartTitle {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--metrics-ink) !important;
+  font-size: 14px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.latestValue {
+  flex: 0 0 auto;
+  color: var(--metrics-ink) !important;
+  font-size: 15px;
+  font-weight: 760;
+  font-variant-numeric: tabular-nums;
+}
+
+.chartRange {
+  display: block;
+  overflow: hidden;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.panelActions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+  padding: 3px;
+  border: 1px solid rgba(35, 48, 44, 0.08);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 8px 18px rgba(45, 58, 55, 0.1);
+  backdrop-filter: blur(10px);
+}
+
+.chartCanvas {
+  width: 100%;
+  height: 252px;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgba(35, 48, 44, 0.06);
+  border-radius: 12px;
+  padding: 8px 8px 0 0;
+  background:
+    linear-gradient(
+      180deg,
+      rgba(247, 250, 249, 0.95),
+      rgba(240, 245, 243, 0.74)
+    ),
+    radial-gradient(
+      circle at 14% 0%,
+      rgba(23, 109, 99, 0.08),
+      transparent 13rem
+    );
+}
+
+.emptyCard {
+  border: 1px dashed rgba(35, 48, 44, 0.16);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+@media (max-width: 1180px) {
+  .scopeGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .scopeMeta {
+    grid-column: 1 / -1;
+    min-width: 0;
+    padding: 10px 0 0;
+    border-top: 1px solid var(--metrics-line);
+    border-left: 0;
+    text-align: left;
+  }
+
+  .chartGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .hero {
+    grid-template-columns: 1fr;
+    padding: 18px;
+  }
+
+  .heroActions {
+    justify-content: flex-start;
+  }
+
+  .summaryGrid,
+  .scopeGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .pageTitle {
+    font-size: 30px !important;
+  }
+
+  .chartCard {
+    min-height: 336px;
+  }
+}

--- a/ui/apps/dashboard/src/pages/metrics/index.tsx
+++ b/ui/apps/dashboard/src/pages/metrics/index.tsx
@@ -1,0 +1,1291 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import axios from 'axios';
+import {
+  Alert,
+  Button,
+  Card,
+  Empty,
+  Popconfirm,
+  Select,
+  Space,
+  Tooltip as AntTooltip,
+  Typography,
+  message,
+  theme,
+} from 'antd';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
+
+import Panel from '@/components/panel';
+import { Icons } from '@/components/icons';
+import {
+  GetComponentPods,
+  GetSchedulerVisualization,
+  GetMetricsDashboards,
+  KARMADA_COMPONENTS,
+  KarmadaComponentKey,
+  MetricCatalogItem,
+  SchedulerVisualizationResponse,
+} from '@/services/metrics';
+
+import {
+  DashboardToolbar,
+  DragPanel,
+  LazyChart,
+  MetricExplorer,
+  PanelEditor,
+} from './components';
+import {
+  addPanel,
+  buildDefaultConfig,
+  getConfiguredMetricNames,
+  getDefaultMetricNamesForComponent,
+  removePanel,
+  reorderPanels,
+  resetDashboardConfig,
+  selectDefaultCatalogMetrics,
+  serializeComponentDashboardConfig,
+  saveDashboardConfig,
+  updatePanel,
+  type DashboardConfig,
+  type PanelConfig,
+} from './dashboard-config';
+import styles from './index.module.less';
+
+const { Title, Text } = Typography;
+
+const defaultWindow = '15m';
+
+type ChartType = 'line' | 'area' | 'bar' | 'gauge';
+
+type SeriesKey = string;
+
+interface ChartPointRow {
+  timestamp: string;
+  [key: string]: string | number | undefined;
+}
+
+interface ChartConfig {
+  key: SeriesKey;
+  title: string;
+  color: string;
+  chart: ChartType;
+  panelId?: string;
+  valueFormatter?: (value: number) => string;
+  axisFormatter?: (value: number) => string;
+}
+
+const CHART_COLORS = [
+  '#2f6fdf',
+  '#16877a',
+  '#b86f28',
+  '#7161c9',
+  '#bf4f7f',
+  '#2f8b57',
+  '#bd4d46',
+  '#7a63d2',
+  '#178ea7',
+  '#c28722',
+  '#bd5f95',
+  '#229c8c',
+  '#c66c2d',
+];
+
+function formatNumber(value: number, fractionDigits = 3) {
+  if (!Number.isFinite(value)) return '0';
+  return value.toLocaleString(undefined, {
+    maximumFractionDigits: fractionDigits,
+  });
+}
+
+function formatOps(value: number) {
+  if (!Number.isFinite(value)) return '0 ops/s';
+  return `${formatNumber(value)} ops/s`;
+}
+
+function shortOps(value: number) {
+  if (!Number.isFinite(value)) return '0';
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+  return formatNumber(value, 1);
+}
+
+function getAutoFormatter(metricName: string): {
+  valueFormatter?: (v: number) => string;
+  axisFormatter?: (v: number) => string;
+} {
+  if (metricName.includes('_bytes'))
+    return { valueFormatter: formatBytes, axisFormatter: shortBytes };
+  if (metricName.includes('_seconds') || metricName.includes('_duration')) {
+    return { valueFormatter: formatSeconds, axisFormatter: shortSeconds };
+  }
+  if (metricName.endsWith('_total') || metricName.includes('Rate')) {
+    return { valueFormatter: formatOps, axisFormatter: shortOps };
+  }
+  return {};
+}
+
+function metricNameToTitle(name: string): string {
+  return name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatBytes(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  return `${value.toFixed(2)} ${units[unitIndex]}`;
+}
+
+function shortBytes(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0';
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)}G`;
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)}M`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)}K`;
+  return formatNumber(bytes, 0);
+}
+
+function formatSeconds(value: number) {
+  if (!Number.isFinite(value)) return '0 s';
+  if (value < 0.001) return `${(value * 1000).toFixed(2)} ms`;
+  if (value < 1) return `${(value * 1000).toFixed(1)} ms`;
+  return `${value.toFixed(3)} s`;
+}
+
+function shortSeconds(value: number) {
+  if (!Number.isFinite(value)) return '0';
+  if (value < 0.001) return `${(value * 1000).toFixed(1)}ms`;
+  if (value < 1) return `${(value * 1000).toFixed(0)}ms`;
+  return `${value.toFixed(2)}s`;
+}
+
+function formatTimestamp(value: string) {
+  return new Date(value).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+function formatDateTime(value: string | number) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ` +
+    `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+  );
+}
+
+function mapVisualizationRows(
+  data?: SchedulerVisualizationResponse,
+): ChartPointRow[] {
+  if (!data?.timeseries) return [];
+
+  const rowMap = new Map<string, ChartPointRow>();
+
+  Object.entries(data.timeseries).forEach(([seriesName, points]) => {
+    if (!Array.isArray(points) || points.length === 0) return;
+
+    points.forEach((point) => {
+      const row = rowMap.get(point.timestamp) ?? { timestamp: point.timestamp };
+      row[seriesName] = point.value;
+      rowMap.set(point.timestamp, row);
+    });
+  });
+
+  return Array.from(rowMap.values()).sort((a, b) =>
+    a.timestamp.localeCompare(b.timestamp),
+  );
+}
+
+function getLatestSeriesValue(rows: ChartPointRow[], key: SeriesKey) {
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const value = rows[i][key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function getSeriesBounds(rows: ChartPointRow[], key: SeriesKey) {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  rows.forEach((row) => {
+    const value = row[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      min = Math.min(min, value);
+      max = Math.max(max, value);
+    }
+  });
+
+  if (min === Number.POSITIVE_INFINITY || max === Number.NEGATIVE_INFINITY) {
+    return undefined;
+  }
+  return { min, max };
+}
+
+function buildChartConfigFromCatalog(
+  item: MetricCatalogItem,
+  index: number,
+): ChartConfig {
+  const formatters = getAutoFormatter(item.name);
+  return {
+    key: item.name,
+    title: metricNameToTitle(item.name),
+    color: CHART_COLORS[index % CHART_COLORS.length],
+    chart: item.suggestedChart,
+    valueFormatter: formatters.valueFormatter,
+    axisFormatter: formatters.axisFormatter,
+  };
+}
+
+const MetricsPage = () => {
+  const queryClient = useQueryClient();
+  const { token } = theme.useToken();
+
+  const [activeComponent, setActiveComponent] = useState<KarmadaComponentKey>(
+    KARMADA_COMPONENTS[0].key,
+  );
+  const [visualizationPod, setVisualizationPod] = useState<string>('all');
+  const [hasInitializedPodSelection, setHasInitializedPodSelection] =
+    useState<boolean>(false);
+  const [editMode, setEditMode] = useState(false);
+  // "committedConfig" drives API queries; "draftConfig" is used during editing
+  const [committedConfig, setCommittedConfig] =
+    useState<DashboardConfig | null>(null);
+  const [draftConfig, setDraftConfig] = useState<DashboardConfig | null>(null);
+  const [panelEditorOpen, setPanelEditorOpen] = useState(false);
+  const [editingPanel, setEditingPanel] = useState<PanelConfig | null>(null);
+  const [explorerOpen, setExplorerOpen] = useState(false);
+
+  // The active config for rendering panels (draft in edit mode, committed otherwise)
+  const dashboardConfig = editMode ? draftConfig : committedConfig;
+
+  // Metrics display follows the backend config (ConfigMap). Fetch all persisted
+  // component dashboards; the active component's dashboard drives the layout.
+  const { data: remoteDashboards } = useQuery({
+    queryKey: ['metricsDashboards'],
+    queryFn: GetMetricsDashboards,
+  });
+
+  const editModeRef = useRef(editMode);
+  useEffect(() => {
+    editModeRef.current = editMode;
+  }, [editMode]);
+
+  useEffect(() => {
+    // Only re-apply the remote config on component switch or when the backend
+    // config changes — never merely because edit mode toggled (that would drop
+    // in-session edits). Skip while actively editing to avoid clobbering.
+    if (editModeRef.current) return;
+    const remote = remoteDashboards?.find(
+      (item) => item.component === activeComponent,
+    );
+    const config = remote ? (remote as DashboardConfig) : null;
+    setCommittedConfig(config);
+    setDraftConfig(config);
+    setPanelEditorOpen(false);
+    setEditingPanel(null);
+  }, [activeComponent, remoteDashboards]);
+
+  // API queries are driven ONLY by committedConfig (not draft)
+  const configuredMetrics = useMemo(
+    () =>
+      committedConfig ? getConfiguredMetricNames(committedConfig) : undefined,
+    [committedConfig],
+  );
+  const configuredMetricsKey = configuredMetrics?.join(',') ?? 'default';
+
+  const {
+    data: visualizationData,
+    isLoading: visualizationLoading,
+    error: visualizationError,
+  } = useQuery({
+    queryKey: [
+      'componentVisualization',
+      activeComponent,
+      visualizationPod,
+      defaultWindow,
+      configuredMetricsKey,
+    ],
+    queryFn: () =>
+      GetSchedulerVisualization(activeComponent, {
+        window: defaultWindow,
+        pod: visualizationPod,
+        refresh: false,
+        metrics: configuredMetrics,
+      }),
+    enabled: !!activeComponent,
+    refetchInterval: 10_000,
+  });
+
+  const { data: podScopeData } = useQuery({
+    queryKey: ['componentPodScope', activeComponent],
+    queryFn: () => GetComponentPods(activeComponent),
+    enabled: !!activeComponent,
+    refetchInterval: 10_000,
+  });
+
+  const refreshVisualizationMutation = useMutation({
+    mutationFn: () =>
+      GetSchedulerVisualization(activeComponent, {
+        window: defaultWindow,
+        pod: visualizationPod,
+        refresh: true,
+        metrics: configuredMetrics,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [
+          'componentVisualization',
+          activeComponent,
+          visualizationPod,
+          defaultWindow,
+        ],
+      });
+    },
+  });
+
+  const visualizationRows = useMemo(
+    () => mapVisualizationRows(visualizationData),
+    [visualizationData],
+  );
+
+  const visualizationPods = useMemo(
+    () => podScopeData?.pods ?? visualizationData?.pods ?? [],
+    [podScopeData, visualizationData],
+  );
+
+  const activeComponentLabel = useMemo(
+    () =>
+      KARMADA_COMPONENTS.find((item) => item.key === activeComponent)?.label ??
+      activeComponent,
+    [activeComponent],
+  );
+
+  const generatedAtLabel = visualizationData?.meta?.generatedAt
+    ? formatDateTime(visualizationData.meta.generatedAt)
+    : 'Waiting for data';
+
+  const sampleIntervalLabel = visualizationData?.meta?.sampleIntervalSec
+    ? `${visualizationData.meta.sampleIntervalSec}s`
+    : '--';
+
+  useEffect(() => {
+    if (committedConfig || draftConfig) return;
+    if (!visualizationData?.metricsCatalog?.length) return;
+    if (visualizationData.meta.appName !== activeComponent) return;
+
+    const config = buildDefaultConfig(
+      activeComponent,
+      visualizationData.metricsCatalog,
+    );
+    saveDashboardConfig(config);
+    setCommittedConfig(config);
+    setDraftConfig(config);
+  }, [activeComponent, committedConfig, draftConfig, visualizationData]);
+
+  useEffect(() => {
+    if (hasInitializedPodSelection || visualizationPods.length === 0) return;
+    setVisualizationPod(visualizationPods[0]);
+    setHasInitializedPodSelection(true);
+  }, [hasInitializedPodSelection, visualizationPods]);
+
+  useEffect(() => {
+    if (visualizationPod === 'all' || visualizationPods.length === 0) return;
+    if (!visualizationPods.includes(visualizationPod)) {
+      setVisualizationPod(visualizationPods[0]);
+    }
+  }, [visualizationPod, visualizationPods]);
+
+  const seriesKeysWithData = useMemo(() => {
+    if (!visualizationData?.timeseries) return [] as SeriesKey[];
+    return Object.keys(visualizationData.timeseries).filter(
+      (key) => (visualizationData.timeseries[key] ?? []).length > 0,
+    );
+  }, [visualizationData]);
+
+  const handleAddPanels = (panels: PanelConfig[]) => {
+    if (panels.length === 0) return;
+    const catalog = visualizationData?.metricsCatalog ?? [];
+    let config = draftConfig ?? buildDefaultConfig(activeComponent, catalog);
+    for (const panel of panels) {
+      config = addPanel(config, panel);
+    }
+    setDraftConfig(config);
+    if (!editMode) {
+      setCommittedConfig(config);
+    }
+  };
+
+  const handleUpdatePanel = (panel: PanelConfig) => {
+    if (!draftConfig) return;
+    const updated = updatePanel(draftConfig, panel.id, panel);
+    setDraftConfig(updated);
+    if (!editMode) {
+      setCommittedConfig(updated);
+    }
+  };
+
+  const handleDeletePanel = (panelId: string) => {
+    if (!draftConfig) return;
+    const updated = removePanel(draftConfig, panelId);
+    setDraftConfig(updated);
+    if (!editMode) {
+      setCommittedConfig(updated);
+    }
+  };
+
+  const handleResetConfig = () => {
+    resetDashboardConfig(activeComponent);
+    setCommittedConfig(null);
+    setDraftConfig(null);
+    setEditMode(false);
+  };
+
+  const handleSavePanel = (panels: PanelConfig[]) => {
+    if (editingPanel) {
+      if (panels[0]) handleUpdatePanel(panels[0]);
+    } else {
+      handleAddPanels(panels);
+    }
+    setEditingPanel(null);
+  };
+
+  const handleEnterEditMode = useCallback(() => {
+    if (!draftConfig && visualizationData?.metricsCatalog?.length) {
+      const config = buildDefaultConfig(
+        activeComponent,
+        visualizationData.metricsCatalog,
+      );
+      saveDashboardConfig(config);
+      setDraftConfig(config);
+      setCommittedConfig(config);
+    }
+    setEditMode(true);
+  }, [draftConfig, visualizationData, activeComponent]);
+
+  const handleExitEditMode = useCallback(() => {
+    // Commit draft to storage and update committed state
+    if (draftConfig) {
+      saveDashboardConfig(draftConfig);
+      setCommittedConfig(draftConfig);
+    }
+    setEditMode(false);
+  }, [draftConfig]);
+
+  // Copy the active component layout so it can be reviewed or pasted into the
+  // dashboard ConfigMap. Draft edits take precedence while edit mode is open.
+  const [exporting, setExporting] = useState(false);
+
+  const handleCopyComponentConfig = useCallback(async () => {
+    const current =
+      draftConfig ??
+      committedConfig ??
+      buildDefaultConfig(
+        activeComponent,
+        visualizationData?.metricsCatalog ?? [],
+      );
+    const text = serializeComponentDashboardConfig(current);
+    setExporting(true);
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      }
+      message.success(
+        `Copied ${current.component} metrics JSON (${current.panels.length} panels)`,
+      );
+    } catch (err) {
+      message.error(`Failed to copy configuration: ${(err as Error).message}`);
+    } finally {
+      setExporting(false);
+    }
+  }, [draftConfig, committedConfig, activeComponent, visualizationData]);
+
+  const handleExplorerAddPanel = useCallback(
+    (panel: PanelConfig) => {
+      const catalog = visualizationData?.metricsCatalog ?? [];
+      const config =
+        draftConfig ??
+        committedConfig ??
+        buildDefaultConfig(activeComponent, catalog);
+      const updated = addPanel(config, panel);
+      saveDashboardConfig(updated);
+      setDraftConfig(updated);
+      setCommittedConfig(updated);
+    },
+    [draftConfig, committedConfig, activeComponent, visualizationData],
+  );
+
+  // DnD sensors with activation constraint to prevent accidental drags
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id || !draftConfig) return;
+
+      const oldIndex = draftConfig.panels.findIndex((p) => p.id === active.id);
+      const newIndex = draftConfig.panels.findIndex((p) => p.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const newPanels = [...draftConfig.panels];
+      const [moved] = newPanels.splice(oldIndex, 1);
+      newPanels.splice(newIndex, 0, moved);
+
+      const updated = reorderPanels(draftConfig, newPanels);
+      setDraftConfig(updated);
+    },
+    [draftConfig],
+  );
+
+  const panelIds = useMemo(
+    () =>
+      (dashboardConfig?.panels ?? []).filter((p) => p.visible).map((p) => p.id),
+    [dashboardConfig],
+  );
+
+  const visibleCharts = useMemo((): ChartConfig[] => {
+    if (dashboardConfig?.panels?.length) {
+      return dashboardConfig.panels
+        .filter((panel) => panel.visible)
+        .map((panel, idx) => {
+          const formatters = getAutoFormatter(panel.metricName);
+          return {
+            key: panel.metricName,
+            title: panel.title,
+            color: CHART_COLORS[idx % CHART_COLORS.length],
+            chart: panel.chartType as ChartType,
+            panelId: panel.id,
+            valueFormatter: formatters.valueFormatter,
+            axisFormatter: formatters.axisFormatter,
+          };
+        });
+    }
+
+    if (visualizationData?.metricsCatalog?.length) {
+      const keysWithData = new Set(seriesKeysWithData);
+      return selectDefaultCatalogMetrics(
+        activeComponent,
+        visualizationData.metricsCatalog,
+      )
+        .filter((item) => keysWithData.has(item.name))
+        .map((item, idx) => buildChartConfigFromCatalog(item, idx));
+    }
+
+    const defaultMetricNames = new Set(
+      getDefaultMetricNamesForComponent(activeComponent),
+    );
+    return seriesKeysWithData
+      .filter((key) => defaultMetricNames.has(key))
+      .map((key, idx) => {
+        const formatters = getAutoFormatter(key);
+        return {
+          key,
+          title: metricNameToTitle(key),
+          color: CHART_COLORS[idx % CHART_COLORS.length],
+          chart: 'line' as ChartType,
+          valueFormatter: formatters.valueFormatter,
+          axisFormatter: formatters.axisFormatter,
+        };
+      });
+  }, [activeComponent, seriesKeysWithData, visualizationData, dashboardConfig]);
+
+  const visualizationErrorDescription = useMemo(() => {
+    if (!visualizationError) return null;
+
+    if (axios.isAxiosError(visualizationError)) {
+      const status = visualizationError.response?.status;
+      if (status === 400) {
+        return 'Invalid query parameters. Check selected component, pod mode, and window.';
+      }
+      if (status === 502) {
+        return 'Failed to reach upstream metrics endpoint. Verify proxy endpoint and component service.';
+      }
+      if (status === 503) {
+        return 'No usable metrics in the selected window. Wait for new samples or switch pod scope.';
+      }
+    }
+
+    return (visualizationError as Error).message;
+  }, [visualizationError]);
+
+  const isNoDataError = useMemo(() => {
+    if (!visualizationError) return false;
+    return (
+      axios.isAxiosError(visualizationError) &&
+      visualizationError.response?.status === 503
+    );
+  }, [visualizationError]);
+
+  const renderGauge = (
+    config: ChartConfig,
+    currentValue: number,
+    bounds: { min: number; max: number } | undefined,
+  ) => {
+    const min = bounds?.min ?? 0;
+    const max = bounds?.max ?? (currentValue * 1.5 || 100);
+    const ratio =
+      max > min ? Math.min((currentValue - min) / (max - min), 1) : 0;
+    const angle = ratio * 180;
+    const valueFormatter =
+      config.valueFormatter ?? ((v: number) => formatNumber(v));
+
+    const cx = 120;
+    const cy = 100;
+    const r = 80;
+    const startAngle = Math.PI;
+    const endAngle = Math.PI - (angle * Math.PI) / 180;
+
+    const arcX1 = cx + r * Math.cos(startAngle);
+    const arcY1 = cy - r * Math.sin(startAngle);
+    const arcX2 = cx + r * Math.cos(endAngle);
+    const arcY2 = cy - r * Math.sin(endAngle);
+    const largeArc = angle > 180 ? 1 : 0;
+
+    return (
+      <div className="flex flex-col items-center justify-center h-[240px]">
+        <svg width="240" height="140" viewBox="0 0 240 140">
+          {/* Background arc */}
+          <path
+            d={`M ${cx - r} ${cy} A ${r} ${r} 0 0 1 ${cx + r} ${cy}`}
+            fill="none"
+            stroke={token.colorBorderSecondary}
+            strokeWidth="12"
+            strokeLinecap="round"
+          />
+          {/* Value arc */}
+          {angle > 0 && (
+            <path
+              d={`M ${arcX1} ${arcY1} A ${r} ${r} 0 ${largeArc} 1 ${arcX2} ${arcY2}`}
+              fill="none"
+              stroke={config.color}
+              strokeWidth="12"
+              strokeLinecap="round"
+            />
+          )}
+          <text
+            x={cx}
+            y={cy + 10}
+            textAnchor="middle"
+            fontSize="18"
+            fontWeight="bold"
+            fill={token.colorText}
+          >
+            {valueFormatter(currentValue)}
+          </text>
+          <text
+            x={cx - r}
+            y={cy + 28}
+            textAnchor="start"
+            fontSize="10"
+            fill={token.colorTextTertiary}
+          >
+            {valueFormatter(min)}
+          </text>
+          <text
+            x={cx + r}
+            y={cy + 28}
+            textAnchor="end"
+            fontSize="10"
+            fill={token.colorTextTertiary}
+          >
+            {valueFormatter(max)}
+          </text>
+        </svg>
+      </div>
+    );
+  };
+
+  const renderChartContent = (config: ChartConfig) => {
+    const gradientId = `series-gradient-${config.key}`;
+
+    if (config.chart === 'gauge') {
+      const latestValue = getLatestSeriesValue(visualizationRows, config.key);
+      const bounds = getSeriesBounds(visualizationRows, config.key);
+      return renderGauge(config, latestValue ?? 0, bounds);
+    }
+
+    if (config.chart === 'bar') {
+      return (
+        <ResponsiveContainer width="100%" height={240}>
+          <BarChart
+            data={visualizationRows}
+            margin={{ left: 4, right: 8, top: 10, bottom: 2 }}
+          >
+            <CartesianGrid
+              vertical={false}
+              strokeDasharray="2 6"
+              stroke={token.colorBorderSecondary}
+            />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatTimestamp}
+              minTickGap={28}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <YAxis
+              width={54}
+              tickFormatter={
+                config.axisFormatter ?? ((value) => formatNumber(value, 1))
+              }
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <Tooltip
+              cursor={{ fill: token.colorFillQuaternary }}
+              contentStyle={{
+                borderRadius: 10,
+                border: `1px solid ${token.colorBorderSecondary}`,
+                boxShadow: token.boxShadowSecondary,
+                background: token.colorBgElevated,
+              }}
+              labelStyle={{ color: token.colorTextSecondary, fontSize: 12 }}
+              labelFormatter={(ts) => formatDateTime(ts as string)}
+              formatter={(value) => {
+                const numericValue =
+                  typeof value === 'number' ? value : Number(value);
+                return [
+                  (config.valueFormatter ?? formatNumber)(numericValue),
+                  config.title,
+                ];
+              }}
+            />
+            <Bar
+              dataKey={config.key}
+              fill={config.color}
+              fillOpacity={0.82}
+              radius={[4, 4, 0, 0]}
+              isAnimationActive={false}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      );
+    }
+
+    if (config.chart === 'line') {
+      return (
+        <ResponsiveContainer width="100%" height={240}>
+          <LineChart
+            data={visualizationRows}
+            margin={{ left: 4, right: 8, top: 10, bottom: 2 }}
+          >
+            <CartesianGrid
+              vertical={false}
+              strokeDasharray="2 6"
+              stroke={token.colorBorderSecondary}
+            />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatTimestamp}
+              minTickGap={28}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <YAxis
+              width={54}
+              tickFormatter={
+                config.axisFormatter ?? ((value) => formatNumber(value, 1))
+              }
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+            />
+            <Tooltip
+              cursor={{ stroke: token.colorBorder, strokeDasharray: '4 4' }}
+              contentStyle={{
+                borderRadius: 10,
+                border: `1px solid ${token.colorBorderSecondary}`,
+                boxShadow: token.boxShadowSecondary,
+                background: token.colorBgElevated,
+              }}
+              labelStyle={{ color: token.colorTextSecondary, fontSize: 12 }}
+              labelFormatter={(ts) => formatDateTime(ts as string)}
+              formatter={(value) => {
+                const numericValue =
+                  typeof value === 'number' ? value : Number(value);
+                return [
+                  (config.valueFormatter ?? formatNumber)(numericValue),
+                  config.title,
+                ];
+              }}
+            />
+            <Line
+              type="monotoneX"
+              dataKey={config.key}
+              stroke={config.color}
+              dot={false}
+              activeDot={{
+                r: 4,
+                fill: config.color,
+                stroke: token.colorBgContainer,
+                strokeWidth: 2,
+              }}
+              strokeWidth={2.4}
+              connectNulls
+              isAnimationActive={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      );
+    }
+
+    // Default: area chart
+    return (
+      <ResponsiveContainer width="100%" height={240}>
+        <AreaChart
+          data={visualizationRows}
+          margin={{ left: 4, right: 8, top: 10, bottom: 2 }}
+        >
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={config.color} stopOpacity={0.24} />
+              <stop offset="65%" stopColor={config.color} stopOpacity={0.08} />
+              <stop offset="100%" stopColor={config.color} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid
+            vertical={false}
+            strokeDasharray="2 6"
+            stroke={token.colorBorderSecondary}
+          />
+          <XAxis
+            dataKey="timestamp"
+            tickFormatter={formatTimestamp}
+            minTickGap={28}
+            axisLine={false}
+            tickLine={false}
+            tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+          />
+          <YAxis
+            width={54}
+            tickFormatter={
+              config.axisFormatter ?? ((value) => formatNumber(value, 1))
+            }
+            axisLine={false}
+            tickLine={false}
+            tick={{ fontSize: 11, fill: token.colorTextTertiary }}
+          />
+          <Tooltip
+            cursor={{ stroke: token.colorBorder, strokeDasharray: '4 4' }}
+            contentStyle={{
+              borderRadius: 10,
+              border: `1px solid ${token.colorBorderSecondary}`,
+              boxShadow: token.boxShadowSecondary,
+              background: token.colorBgElevated,
+            }}
+            labelStyle={{ color: token.colorTextSecondary, fontSize: 12 }}
+            labelFormatter={(ts) => formatDateTime(ts as string)}
+            formatter={(value) => {
+              const numericValue =
+                typeof value === 'number' ? value : Number(value);
+              return [
+                (config.valueFormatter ?? formatNumber)(numericValue),
+                config.title,
+              ];
+            }}
+          />
+          <Area
+            type="monotoneX"
+            dataKey={config.key}
+            stroke={config.color}
+            fill={`url(#${gradientId})`}
+            fillOpacity={1}
+            strokeWidth={2.4}
+            connectNulls
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    );
+  };
+
+  const renderChartCard = (config: ChartConfig) => {
+    const latestValue = getLatestSeriesValue(visualizationRows, config.key);
+    const valueFormatter =
+      config.valueFormatter ?? ((value: number) => formatNumber(value));
+    const bounds = getSeriesBounds(visualizationRows, config.key);
+    const panel = config.panelId
+      ? dashboardConfig?.panels.find((item) => item.id === config.panelId)
+      : undefined;
+
+    return (
+      <Card
+        key={config.panelId ?? config.key}
+        size="small"
+        variant="borderless"
+        className={styles.chartCard}
+        title={
+          <div className={styles.chartHeader}>
+            <div className={styles.chartTitleRow}>
+              <Space size={8} className={styles.chartName}>
+                <Text strong className={styles.chartTitle}>
+                  {config.title}
+                </Text>
+              </Space>
+              <Text className={styles.latestValue}>
+                {typeof latestValue === 'number'
+                  ? valueFormatter(latestValue)
+                  : '--'}
+              </Text>
+            </div>
+            {bounds ? (
+              <Text type="secondary" className={styles.chartRange}>
+                {valueFormatter(bounds.min)} to {valueFormatter(bounds.max)}
+              </Text>
+            ) : null}
+          </div>
+        }
+      >
+        {editMode && panel ? (
+          <Space size="small" className={styles.panelActions}>
+            <Button
+              size="small"
+              type="text"
+              onClick={() => {
+                setEditingPanel(panel);
+                setPanelEditorOpen(true);
+              }}
+            >
+              Edit
+            </Button>
+            <Popconfirm
+              title="Delete this panel?"
+              onConfirm={() => handleDeletePanel(panel.id)}
+            >
+              <Button size="small" type="text" danger>
+                Delete
+              </Button>
+            </Popconfirm>
+          </Space>
+        ) : null}
+        {visualizationRows.length === 0 ? (
+          <LazyChart height={252} loading={visualizationLoading}>
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="No samples in this window"
+            />
+          </LazyChart>
+        ) : (
+          <LazyChart height={252} loading={visualizationLoading}>
+            <div className={styles.chartCanvas}>
+              {renderChartContent(config)}
+            </div>
+          </LazyChart>
+        )}
+      </Card>
+    );
+  };
+
+  return (
+    <Panel>
+      <main className={styles.metricsPage}>
+        <section className={styles.hero}>
+          <div className={styles.heroCopy}>
+            <Text className={styles.eyebrow}>Karmada telemetry</Text>
+            <Title level={2} className={styles.pageTitle}>
+              Control plane metrics
+            </Title>
+            <div className={styles.heroMeta}>
+              <span>{activeComponentLabel}</span>
+              <span>
+                {visualizationPod === 'all' ? 'All pods' : visualizationPod}
+              </span>
+              <span>{generatedAtLabel}</span>
+            </div>
+          </div>
+
+          <div className={styles.heroActions}>
+            <AntTooltip title="Refresh now">
+              <Button
+                icon={<Icons.spinner size={14} />}
+                size="middle"
+                className={styles.refreshButton}
+                loading={refreshVisualizationMutation.isPending}
+                onClick={() => refreshVisualizationMutation.mutate()}
+              />
+            </AntTooltip>
+            <DashboardToolbar
+              editMode={editMode}
+              hasCustomConfig={!!committedConfig}
+              onToggleEdit={() => {
+                if (editMode) {
+                  handleExitEditMode();
+                } else {
+                  handleEnterEditMode();
+                }
+              }}
+              onAddPanel={() => {
+                setEditingPanel(null);
+                setPanelEditorOpen(true);
+              }}
+              onReset={handleResetConfig}
+              onExplore={() => setExplorerOpen(true)}
+              onCopy={handleCopyComponentConfig}
+              exporting={exporting}
+            />
+          </div>
+        </section>
+
+        <Card size="small" variant="borderless" className={styles.scopeCard}>
+          <div className={styles.scopeGrid}>
+            <label className={styles.controlField}>
+              <Text strong className={styles.controlLabel}>
+                Component
+              </Text>
+              <Select
+                size="middle"
+                variant="filled"
+                showSearch={{ optionFilterProp: 'label' }}
+                value={activeComponent}
+                options={KARMADA_COMPONENTS.map((item) => ({
+                  value: item.key,
+                  label: item.label,
+                }))}
+                className={styles.componentSelect}
+                onChange={(value) => {
+                  setActiveComponent(value as KarmadaComponentKey);
+                  setVisualizationPod('all');
+                  setHasInitializedPodSelection(false);
+                  setEditMode(false);
+                }}
+              />
+            </label>
+
+            <label className={styles.controlField}>
+              <Text strong className={styles.controlLabel}>
+                Window
+              </Text>
+              <Select
+                size="middle"
+                variant="filled"
+                value={defaultWindow}
+                disabled
+                options={[{ label: '15 minutes', value: defaultWindow }]}
+                className={styles.windowSelect}
+              />
+            </label>
+
+            <label className={styles.controlField}>
+              <Text strong className={styles.controlLabel}>
+                Pod
+              </Text>
+              <Select
+                size="middle"
+                variant="filled"
+                showSearch={{ optionFilterProp: 'label' }}
+                value={visualizationPod}
+                className={styles.podSelect}
+                options={[
+                  { label: 'All pods (sum)', value: 'all' },
+                  ...visualizationPods.map((pod) => ({
+                    label: pod,
+                    value: pod,
+                  })),
+                ]}
+                onChange={(value) => setVisualizationPod(value)}
+              />
+            </label>
+
+            <div className={styles.scopeMeta}>
+              {visualizationData?.meta?.sampleIntervalSec ? (
+                <Text type="secondary" className={styles.metaLine}>
+                  Sample interval: {visualizationData.meta.sampleIntervalSec}s
+                </Text>
+              ) : null}
+              {visualizationData?.meta?.generatedAt ? (
+                <Text type="secondary" className={styles.metaLine}>
+                  Last fetched: {formatDateTime(visualizationData.meta.generatedAt)}
+                </Text>
+              ) : null}
+            </div>
+          </div>
+        </Card>
+
+        <section className={styles.summaryGrid}>
+          <div className={styles.summaryItem}>
+            <Text className={styles.summaryLabel}>Panels</Text>
+            <Text className={styles.summaryValue}>{visibleCharts.length}</Text>
+          </div>
+          <div className={styles.summaryItem}>
+            <Text className={styles.summaryLabel}>Pods</Text>
+            <Text className={styles.summaryValue}>
+              {visualizationPods.length || '--'}
+            </Text>
+          </div>
+          <div className={styles.summaryItem}>
+            <Text className={styles.summaryLabel}>Sample</Text>
+            <Text className={styles.summaryValue}>{sampleIntervalLabel}</Text>
+          </div>
+          <div className={styles.summaryItem}>
+            <Text className={styles.summaryLabel}>Window</Text>
+            <Text className={styles.summaryValue}>15m</Text>
+          </div>
+        </section>
+
+        {visualizationData?.warnings?.length ? (
+          <Alert
+            type="warning"
+            className={styles.inlineAlert}
+            title="Partial data detected"
+            description={visualizationData.warnings.join(' ')}
+          />
+        ) : null}
+
+        <section className={styles.metricsSection}>
+          {visualizationError && !isNoDataError ? (
+            <Alert
+              type="error"
+              className={styles.inlineAlert}
+              title={`Failed to load ${activeComponent} visualization`}
+              description={visualizationErrorDescription}
+              action={
+                <Button
+                  size="small"
+                  onClick={() => refreshVisualizationMutation.mutate()}
+                >
+                  Retry now
+                </Button>
+              }
+            />
+          ) : isNoDataError ? (
+            <Card
+              size="small"
+              variant="borderless"
+              className={styles.emptyCard}
+            >
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="No metrics available in the selected window. Wait for new samples or switch pod scope."
+              >
+                <Button
+                  size="small"
+                  onClick={() => refreshVisualizationMutation.mutate()}
+                >
+                  Refresh
+                </Button>
+              </Empty>
+            </Card>
+          ) : (
+            <div className="space-y-4">
+              {visibleCharts.length > 0 ? (
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={handleDragEnd}
+                >
+                  <SortableContext
+                    items={panelIds}
+                    strategy={rectSortingStrategy}
+                  >
+                    <div className={styles.chartGrid}>
+                      {visibleCharts.map((chart) => (
+                        <DragPanel
+                          key={chart.panelId ?? chart.key}
+                          id={chart.panelId ?? chart.key}
+                          disabled={!editMode}
+                        >
+                          {renderChartCard(chart)}
+                        </DragPanel>
+                      ))}
+                    </div>
+                  </SortableContext>
+                </DndContext>
+              ) : (
+                <Card
+                  size="small"
+                  variant="borderless"
+                  className={styles.emptyCard}
+                >
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description="No chartable metric series for this scope."
+                  />
+                </Card>
+              )}
+            </div>
+          )}
+        </section>
+        <PanelEditor
+          open={panelEditorOpen}
+          onClose={() => {
+            setPanelEditorOpen(false);
+            setEditingPanel(null);
+          }}
+          onSave={handleSavePanel}
+          catalog={visualizationData?.metricsCatalog ?? []}
+          editingPanel={editingPanel}
+          existingMetricNames={(dashboardConfig?.panels ?? []).map((p) => p.metricName)}
+        />
+        <MetricExplorer
+          open={explorerOpen}
+          onClose={() => setExplorerOpen(false)}
+          onAddToDashboard={handleExplorerAddPanel}
+          catalog={visualizationData?.metricsCatalog ?? []}
+          component={activeComponent}
+          pod={visualizationPod}
+        />
+      </main>
+    </Panel>
+  );
+};
+
+export default MetricsPage;

--- a/ui/apps/dashboard/src/routes/route.tsx
+++ b/ui/apps/dashboard/src/routes/route.tsx
@@ -65,6 +65,7 @@ import MemberClusterRoles from '@/pages/member-cluster/cluster/roles';
 import MemberClusterServiceAccounts from '@/pages/member-cluster/cluster/service-accounts';
 import Login from '@/pages/login';
 import OIDCCallbackPage from '@/pages/login/callback';
+import MetricsPage from '@/pages/metrics';
 import { Icons } from '@/components/icons';
 
 export interface IRouteObjectHandle {
@@ -318,6 +319,15 @@ export function getRoutes() {
               },
             },
           ],
+        },
+        {
+          path: '/metrics',
+          element: <MetricsPage />,
+          handle: {
+            sidebarKey: 'METRICS',
+            sidebarName: 'Metrics',
+            icon: <Icons.metrics {...IconStyles} />,
+          },
         },
       ],
     },

--- a/ui/apps/dashboard/src/services/index.ts
+++ b/ui/apps/dashboard/src/services/index.ts
@@ -89,6 +89,9 @@ export * from './dashboard-config';
 // Overview/statistics
 export * from './overview';
 
+// Metrics scraper
+export * from './metrics';
+
 // Member cluster services
 const memberClusterServices = {
   workload: () => import('./member-cluster/workload'),

--- a/ui/apps/dashboard/src/services/metrics.ts
+++ b/ui/apps/dashboard/src/services/metrics.ts
@@ -1,0 +1,271 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import axios from 'axios';
+import _ from 'lodash';
+
+let pathPrefix = window.__path_prefix__ || '';
+if (!pathPrefix.startsWith('/')) {
+  pathPrefix = '/' + pathPrefix;
+}
+if (!pathPrefix.endsWith('/')) {
+  pathPrefix = pathPrefix + '/';
+}
+
+const metricsBaseURL: string = _.join(
+  [pathPrefix, 'metrics-scraper/api/v1'],
+  '',
+);
+
+export const metricsScraperClient = axios.create({
+  baseURL: metricsBaseURL,
+});
+
+export const KARMADA_COMPONENTS = [
+  { key: 'karmada-scheduler', label: 'Scheduler' },
+  { key: 'karmada-controller-manager', label: 'Controller Manager' },
+  { key: 'karmada-agent', label: 'Agent' },
+  { key: 'karmada-aggregated-apiserver', label: 'Aggregated APIServer' },
+  { key: 'karmada-apiserver', label: 'APIServer' },
+  { key: 'karmada-descheduler', label: 'Descheduler' },
+  { key: 'karmada-kube-controller-manager', label: 'Kube Controller Manager' },
+  { key: 'karmada-metrics-adapter', label: 'Metrics Adapter' },
+  { key: 'karmada-scheduler-estimator-member1', label: 'Scheduler Estimator (member1)' },
+  { key: 'karmada-scheduler-estimator-member2', label: 'Scheduler Estimator (member2)' },
+  { key: 'karmada-scheduler-estimator-member3', label: 'Scheduler Estimator (member3)' },
+  { key: 'karmada-search', label: 'Search' },
+  { key: 'karmada-webhook', label: 'Webhook' },
+] as const;
+
+export type KarmadaComponentKey = (typeof KARMADA_COMPONENTS)[number]['key'];
+
+export interface MetricValue {
+  labels?: Record<string, string>;
+  value: string;
+  measure: string;
+}
+
+export interface Metric {
+  name: string;
+  help: string;
+  type: string;
+  values?: MetricValue[];
+}
+
+export interface ParsedData {
+  currentTime: string;
+  metrics: Record<string, Metric>;
+}
+
+export interface VisualizationPoint {
+  timestamp: string;
+  value: number;
+}
+
+export interface SchedulerVisualizationMeta {
+  appName: string;
+  window: string;
+  podMode: string;
+  sampleIntervalSec: number;
+  generatedAt: string;
+}
+
+export interface MetricInfo {
+  name: string;
+  type: string;
+  suggestedChart: 'line' | 'area' | 'bar' | 'gauge';
+}
+
+export interface MetricCatalogItem {
+  name: string;
+  help: string;
+  prometheusType: 'gauge' | 'counter' | 'histogram' | 'summary';
+  suggestedChart: 'line' | 'area' | 'bar' | 'gauge';
+  group: string;
+}
+
+export interface SchedulerVisualizationResponse {
+  meta: SchedulerVisualizationMeta;
+  timeseries: Record<string, VisualizationPoint[]>;
+  pods: string[];
+  warnings?: string[];
+  availableMetrics?: MetricInfo[];
+  metricsCatalog?: MetricCatalogItem[];
+}
+
+export interface ComponentPodsResponse {
+  appName: string;
+  pods: string[];
+  warnings?: string[];
+}
+
+/** Response from GET /metrics/:app_name — maps pod name → parsed metrics snapshot */
+export type ComponentMetricsResponse = Record<string, ParsedData>;
+
+/** Response from GET /metrics?type=sync_status — maps component name → syncing */
+export type SyncStatusResponse = Record<string, boolean>;
+
+export async function GetComponentMetrics(
+  appName: string,
+): Promise<ComponentMetricsResponse> {
+  const resp =
+    await metricsScraperClient.get<ComponentMetricsResponse>(
+      `/metrics/${appName}`,
+    );
+  return resp.data;
+}
+
+export async function GetSyncStatus(): Promise<SyncStatusResponse> {
+  const resp = await metricsScraperClient.get<SyncStatusResponse>('/metrics', {
+    params: { type: 'sync_status' },
+  });
+  return resp.data;
+}
+
+export async function SetComponentSync(
+  appName: string | null,
+  enabled: boolean,
+): Promise<void> {
+  const type = enabled ? 'sync_on' : 'sync_off';
+  if (appName) {
+    await metricsScraperClient.get(`/metrics/${appName}`, {
+      params: { type },
+    });
+  } else {
+    await metricsScraperClient.get('/metrics', { params: { type } });
+  }
+}
+
+export async function GetSchedulerVisualization(
+  appName: string,
+  params?: {
+    window?: string;
+    pod?: string;
+    refresh?: boolean;
+    metrics?: string[];
+  },
+): Promise<SchedulerVisualizationResponse> {
+  const queryParams: Record<string, string | boolean | undefined> = {
+    window: params?.window,
+    pod: params?.pod,
+    refresh: params?.refresh,
+  };
+  if (params?.metrics?.length) {
+    queryParams.metrics = params.metrics.join(',');
+  }
+  const resp =
+    await metricsScraperClient.get<SchedulerVisualizationResponse>(
+      `/metrics/${appName}/visualization`,
+      { params: queryParams },
+    );
+  return resp.data;
+}
+
+export async function GetComponentPods(
+  appName: string,
+): Promise<ComponentPodsResponse> {
+  const resp = await metricsScraperClient.get<ComponentPodsResponse>(
+    `/metrics/${appName}/pods`,
+  );
+  return resp.data;
+}
+
+export interface LabelFilter {
+  key: string;
+  value: string;
+}
+
+export interface ExploreResponse {
+  meta: {
+    metric: string;
+    aggregation: string;
+    labels: LabelFilter[];
+    window: string;
+    podMode: string;
+    generatedAt: string;
+  };
+  timeseries: VisualizationPoint[];
+  availableLabels: Record<string, string[]>;
+}
+
+export async function ExploreMetric(
+  appName: string,
+  params: {
+    metric: string;
+    aggregation?: string;
+    labels?: LabelFilter[];
+    window?: string;
+    pod?: string;
+  },
+): Promise<ExploreResponse> {
+  const queryParams: Record<string, string | undefined> = {
+    metric: params.metric,
+    aggregation: params.aggregation,
+    window: params.window,
+    pod: params.pod,
+  };
+  if (params.labels?.length) {
+    queryParams.labels = JSON.stringify(params.labels);
+  }
+  const resp = await metricsScraperClient.get<ExploreResponse>(
+    `/metrics/${appName}/explore`,
+    { params: queryParams },
+  );
+  return resp.data;
+}
+
+export interface MetricsDashboardPanel {
+  id: string;
+  metricName: string;
+  chartType: 'line' | 'area' | 'bar' | 'gauge';
+  title: string;
+  visible: boolean;
+  query?: {
+    metric: string;
+    aggregation: string;
+    labelFilters?: { key: string; value: string }[];
+  };
+  order?: number;
+}
+
+export interface MetricsDashboard {
+  version: number;
+  component: string;
+  panels: MetricsDashboardPanel[];
+}
+
+export interface MetricsDashboardConfigResponse {
+  dashboards: MetricsDashboard[];
+}
+
+/** Fetch all persisted metrics dashboards (from the dashboard ConfigMap). */
+export async function GetMetricsDashboards(): Promise<MetricsDashboard[]> {
+  const resp = await metricsScraperClient.get<MetricsDashboardConfigResponse>(
+    '/metrics-config',
+  );
+  return resp.data?.dashboards ?? [];
+}
+
+/** Persist (upsert) a single component's metrics dashboard to the ConfigMap. */
+export async function SaveMetricsDashboard(
+  dashboard: MetricsDashboard,
+): Promise<MetricsDashboard[]> {
+  const resp = await metricsScraperClient.put<MetricsDashboardConfigResponse>(
+    '/metrics-config',
+    { dashboard },
+  );
+  return resp.data?.dashboards ?? [];
+}

--- a/ui/apps/dashboard/vite.config.ts
+++ b/ui/apps/dashboard/vite.config.ts
@@ -74,7 +74,24 @@ export default defineConfig(({ mode }) => {
       }),
     ],
     resolve: {
-      alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
+      alias: [
+        { find: '@', replacement: path.resolve(__dirname, 'src') },
+        // Vite 8 + rolldown has a CJS transform issue with es-toolkit compat modules
+        // used by recharts. Map them to equivalent lodash helpers to avoid runtime errors.
+        { find: 'es-toolkit/compat/get', replacement: 'lodash/get' },
+        { find: 'es-toolkit/compat/sortBy', replacement: 'lodash/sortBy' },
+        { find: 'es-toolkit/compat/maxBy', replacement: 'lodash/maxBy' },
+        { find: 'es-toolkit/compat/sumBy', replacement: 'lodash/sumBy' },
+        { find: 'es-toolkit/compat/throttle', replacement: 'lodash/throttle' },
+        { find: 'es-toolkit/compat/omit', replacement: 'lodash/omit' },
+        { find: 'es-toolkit/compat/minBy', replacement: 'lodash/minBy' },
+        { find: 'es-toolkit/compat/last', replacement: 'lodash/last' },
+        { find: 'es-toolkit/compat/range', replacement: 'lodash/range' },
+        { find: 'es-toolkit/compat/isPlainObject', replacement: 'lodash/isPlainObject' },
+        { find: 'es-toolkit/compat/uniqBy', replacement: 'lodash/uniqBy' },
+        { find: 'react', replacement: path.resolve(__dirname, 'node_modules/react') },
+        { find: 'react-dom', replacement: path.resolve(__dirname, 'node_modules/react-dom') },
+      ],
       dedupe: ['react', 'react-dom'],
     },
     optimizeDeps: {

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -51,6 +51,15 @@ importers:
       '@chatui/core':
         specifier: ^3.8.0
         version: 3.8.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.7)
       '@karmada/chatui':
         specifier: workspace:*
         version: link:../../packages/chatui
@@ -83,7 +92,7 @@ importers:
         version: 6.0.0
       '@xyflow/react':
         specifier: ^12.10.2
-        version: 12.10.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 12.10.2(@types/react@19.2.17)(immer@11.1.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       antd:
         specifier: ^6.5.0
         version: 6.5.0(moment@2.30.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -126,6 +135,9 @@ importers:
       react-router-dom:
         specifier: ^7.14.2
         version: 7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.10.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)
       sockjs-client:
         specifier: ^1.6.1
         version: 1.6.1
@@ -137,7 +149,7 @@ importers:
         version: 2.9.0
       zustand:
         specifier: ^5.0.14
-        version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+        version: 5.0.14(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     devDependencies:
       '@karmada/eslint-config-ts-react':
         specifier: workspace:*
@@ -668,6 +680,28 @@ packages:
     peerDependencies:
       react: ^19.2.7
       react-dom: ^19.2.7
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: ^19.2.7
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: ^19.2.7
+      react-dom: ^19.2.7
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: ^19.2.7
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: ^19.2.7
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1446,6 +1480,17 @@ packages:
       react: ^19.2.7
       react-dom: ^19.2.7
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^19.2.7
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1805,6 +1850,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
     engines: {node: '>=14'}
@@ -2102,17 +2150,38 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
   '@types/d3-drag@3.0.7':
     resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
 
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
 
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
   '@types/d3-selection@3.0.11':
     resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/d3-transition@3.0.9':
     resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
@@ -2193,6 +2262,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.64.0':
     resolution: {integrity: sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==}
@@ -2778,6 +2850,10 @@ packages:
   csv-parse@7.0.0:
     resolution: {integrity: sha512-CSssqPAK5us09FhMI9juM0jnqXUJP+rtWeIfivTYBLNH/8rnxkQlZvoRemF6MAyfNov9XU8mN2wwF/pP68sxTA==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
@@ -2794,12 +2870,36 @@ packages:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
     engines: {node: '>=12'}
 
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
 
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
   d3-selection@3.0.0:
     resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
     engines: {node: '>=12'}
 
   d3-timer@3.0.1:
@@ -2861,6 +2961,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decompress-response@10.0.0:
     resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
@@ -2996,6 +3099,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   esbuild@0.27.0:
     resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
@@ -3456,6 +3562,9 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
+  immer@11.1.15:
+    resolution: {integrity: sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -3474,6 +3583,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   intersection-observer@0.12.2:
     resolution: {integrity: sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==}
@@ -4312,6 +4425,18 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^19.2.7
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-router-dom@7.14.2:
     resolution: {integrity: sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==}
     engines: {node: '>=20.0.0'}
@@ -4341,6 +4466,22 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  recharts@3.10.0:
+    resolution: {integrity: sha512-wulMvfncpIlmu2uFtRU/mE5/+NiVtASXkw2KdwJTdHs3WsASX0WxZlX+rpKgyn5BDbIhkPtCpUKkB9XNK5KE0w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^19.2.7
+      react-dom: ^19.2.7
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -4351,6 +4492,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -4699,6 +4843,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -4850,6 +4997,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^19.2.7
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-plugin-banner@0.8.1:
     resolution: {integrity: sha512-0+gGguHk3MH0HvzMSOCJC6fGgH4+jtY9KlKVZh+hwwE+PBkGVzY8xe657JL74vEgbeUJD37XjVqTrmve8XvZBQ==}
@@ -5439,6 +5589,31 @@ snapshots:
       intersection-observer: 0.12.2
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -6163,6 +6338,18 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.15
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 19.2.7
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -6359,6 +6546,8 @@ snapshots:
   '@sindresorhus/is@7.2.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
@@ -6594,17 +6783,35 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
   '@types/d3-color@3.1.3': {}
 
   '@types/d3-drag@3.0.7':
     dependencies:
       '@types/d3-selection': 3.0.11
 
+  '@types/d3-ease@3.0.2': {}
+
   '@types/d3-interpolate@3.0.4':
     dependencies:
       '@types/d3-color': 3.1.3
 
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
   '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/d3-transition@3.0.9':
     dependencies:
@@ -6683,6 +6890,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.61.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -6999,13 +7208,13 @@ snapshots:
 
   '@xterm/xterm@6.0.0': {}
 
-  '@xyflow/react@12.10.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@xyflow/react@12.10.2(@types/react@19.2.17)(immer@11.1.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@xyflow/system': 0.0.76
       classcat: 5.0.5
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      zustand: 4.5.7(@types/react@19.2.17)(react@19.2.7)
+      zustand: 4.5.7(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -7412,6 +7621,10 @@ snapshots:
 
   csv-parse@7.0.0: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
   d3-color@3.1.0: {}
 
   d3-dispatch@3.0.1: {}
@@ -7423,11 +7636,35 @@ snapshots:
 
   d3-ease@3.0.1: {}
 
+  d3-format@3.1.2: {}
+
   d3-interpolate@3.0.1:
     dependencies:
       d3-color: 3.1.0
 
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
   d3-selection@3.0.0: {}
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
 
@@ -7487,6 +7724,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decompress-response@10.0.0:
     dependencies:
@@ -7694,6 +7933,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.49.0: {}
 
   esbuild@0.27.0:
     optionalDependencies:
@@ -8282,6 +8523,8 @@ snapshots:
 
   ignore@7.0.6: {}
 
+  immer@11.1.15: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -8301,6 +8544,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   intersection-observer@0.12.2: {}
 
@@ -9070,6 +9315,15 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      redux: 5.0.1
+
   react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -9095,6 +9349,32 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  recharts@3.10.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.49.0
+      eventemitter3: 5.0.4
+      immer: 11.1.15
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-is: 18.3.1
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
+      reselect: 5.2.0
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -9116,6 +9396,8 @@ snapshots:
       set-function-name: 2.0.2
 
   requires-port@1.0.0: {}
+
+  reselect@5.2.0: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -9575,6 +9857,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -9737,6 +10021,23 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-plugin-banner@0.8.1: {}
 
@@ -9934,15 +10235,17 @@ snapshots:
 
   zod@4.2.1: {}
 
-  zustand@4.5.7(@types/react@19.2.17)(react@19.2.7):
+  zustand@4.5.7(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7):
     dependencies:
       use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
+      immer: 11.1.15
       react: 19.2.7
 
-  zustand@5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
+  zustand@5.0.14(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:
       '@types/react': 19.2.17
+      immer: 11.1.15
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

- adds component metrics dashboards and chart visualization
- supports dashboard panel editing and metric exploration
- allows copying the active component metrics JSON
- adds the Metrics navigation and frontend service integration

This is PR 2 of 3 for component metrics support. It consumes the metrics APIs introduced by #673.

## Which issue(s) this PR fixes

None

## Special notes for reviewers

Frontend validation completed: 5 dashboard config tests, targeted ESLint, TypeScript compilation, and Vite production build. The single commit includes a DCO Signed-off-by trailer matching the commit author.