### PR TITLE
feat(deploy): deploy for metrics scraper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ VERSION 				?= $(shell hack/version.sh)
 # Build targets
 TARGETS := karmada-dashboard-api \
 		   karmada-dashboard-web \
-		   kubernetes-dashboard-api
+		   kubernetes-dashboard-api \
+		   karmada-dashboard-metrics-scraper
 
 # Docker image related variables
 REGISTRY				?= docker.io/karmada
@@ -148,6 +149,20 @@ endif
 .PHONY: run-web
 run-web: install-ui-deps build
 	cd ui && VITE_API_HOST=$(API_HOST) pnpm run dashboard:dev
+
+# Run Metrics Scraper only
+.PHONY: run-metrics-scraper
+run-metrics-scraper: build
+ifndef KUBECONFIG
+	$(error KUBECONFIG is required. Please specify the path to karmada kubeconfig)
+endif
+	_output/bin/$(GOOS)/$(GOARCH)/karmada-dashboard-metrics-scraper \
+		--karmada-kubeconfig=$(KUBECONFIG) \
+		--karmada-context=$(KARMADA_CTX) \
+		--kubeconfig=$(KUBECONFIG) \
+		--context=$(HOST_CTX) \
+		--insecure-port=8001 \
+		$(if $(filter true,$(SKIP_TLS_VERIFY)),--skip-karmada-apiserver-tls-verify)
 
 # Generate JWT token for dashboard login
 .PHONY: gen-token

--- a/artifacts/dashboard/karmada-dashboard-configmap.yaml
+++ b/artifacts/dashboard/karmada-dashboard-configmap.yaml
@@ -14,6 +14,9 @@ data:
       - path: /topology
         enable: true
         sidebar_key: TOPOLOGY
+      - path: /metrics
+        enable: true
+        sidebar_key: METRICS
       - path: /multicloud-resource-manage
         enable: true
         sidebar_key: MULTICLOUD-RESOURCE-MANAGE
@@ -88,6 +91,724 @@ data:
   prod.yaml: |-
     docker_registries: [ ]
     chart_registries: [ ]
+    metrics_dashboards:
+      - version: 1
+        component: karmada-scheduler
+        panels:
+          - id: karmada-scheduler-01
+            metric_name: karmada_scheduler_schedule_attempts_total
+            chart_type: line
+            title: Karmada Scheduler Schedule Attempts Total
+            visible: true
+            order: 0
+          - id: karmada-scheduler-02
+            metric_name: karmada_scheduler_queue_incoming_bindings_total
+            chart_type: line
+            title: Karmada Scheduler Queue Incoming Bindings Total
+            visible: true
+            order: 1
+          - id: karmada-scheduler-03
+            metric_name: karmada_scheduler_e2e_scheduling_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler E2e Scheduling Duration Seconds
+            visible: true
+            order: 2
+          - id: karmada-scheduler-04
+            metric_name: karmada_scheduler_scheduling_algorithm_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Scheduling Algorithm Duration Seconds
+            visible: true
+            order: 3
+          - id: karmada-scheduler-05
+            metric_name: karmada_scheduler_framework_extension_point_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Framework Extension Point Duration Seconds
+            visible: true
+            order: 4
+          - id: karmada-scheduler-06
+            metric_name: karmada_scheduler_plugin_execution_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Plugin Execution Duration Seconds
+            visible: true
+            order: 5
+          - id: karmada-scheduler-07
+            metric_name: leader_election_master_status
+            chart_type: gauge
+            title: Leader Election Master Status
+            visible: true
+            order: 6
+          - id: karmada-scheduler-08
+            metric_name: workqueue_depth
+            chart_type: gauge
+            title: Workqueue Depth
+            visible: true
+            order: 7
+          - id: karmada-scheduler-09
+            metric_name: workqueue_retries_total
+            chart_type: line
+            title: Workqueue Retries Total
+            visible: true
+            order: 8
+          - id: karmada-scheduler-10
+            metric_name: workqueue_longest_running_processor_seconds
+            chart_type: gauge
+            title: Workqueue Longest Running Processor Seconds
+            visible: true
+            order: 9
+      - version: 1
+        component: karmada-controller-manager
+        panels:
+          - id: karmada-controller-manager-01
+            metric_name: cluster_ready_state
+            chart_type: gauge
+            title: Cluster Ready State
+            visible: true
+            order: 0
+          - id: karmada-controller-manager-02
+            metric_name: cluster_ready_node_number
+            chart_type: gauge
+            title: Cluster Ready Node Number
+            visible: true
+            order: 1
+          - id: karmada-controller-manager-03
+            metric_name: cluster_node_number
+            chart_type: gauge
+            title: Cluster Node Number
+            visible: true
+            order: 2
+          - id: karmada-controller-manager-04
+            metric_name: cluster_cpu_allocatable_number
+            chart_type: gauge
+            title: Cluster Cpu Allocatable Number
+            visible: true
+            order: 3
+          - id: karmada-controller-manager-05
+            metric_name: cluster_cpu_allocated_number
+            chart_type: gauge
+            title: Cluster Cpu Allocated Number
+            visible: true
+            order: 4
+          - id: karmada-controller-manager-06
+            metric_name: cluster_memory_allocatable_bytes
+            chart_type: area
+            title: Cluster Memory Allocatable Bytes
+            visible: true
+            order: 5
+          - id: karmada-controller-manager-07
+            metric_name: cluster_memory_allocated_bytes
+            chart_type: area
+            title: Cluster Memory Allocated Bytes
+            visible: true
+            order: 6
+          - id: karmada-controller-manager-08
+            metric_name: cluster_pod_allocatable_number
+            chart_type: gauge
+            title: Cluster Pod Allocatable Number
+            visible: true
+            order: 7
+          - id: karmada-controller-manager-09
+            metric_name: cluster_pod_allocated_number
+            chart_type: gauge
+            title: Cluster Pod Allocated Number
+            visible: true
+            order: 8
+          - id: karmada-controller-manager-10
+            metric_name: cluster_sync_status_duration_seconds
+            chart_type: bar
+            title: Cluster Sync Status Duration Seconds
+            visible: true
+            order: 9
+          - id: karmada-controller-manager-11
+            metric_name: policy_apply_attempts_total
+            chart_type: line
+            title: Policy Apply Attempts Total
+            visible: true
+            order: 10
+          - id: karmada-controller-manager-12
+            metric_name: resource_apply_policy_duration_seconds
+            chart_type: bar
+            title: Resource Apply Policy Duration Seconds
+            visible: true
+            order: 11
+      - version: 1
+        component: karmada-agent
+        panels:
+          - id: karmada-agent-01
+            metric_name: cluster_ready_state
+            chart_type: gauge
+            title: Cluster Ready State
+            visible: true
+            order: 0
+          - id: karmada-agent-02
+            metric_name: cluster_ready_node_number
+            chart_type: gauge
+            title: Cluster Ready Node Number
+            visible: true
+            order: 1
+          - id: karmada-agent-03
+            metric_name: cluster_node_number
+            chart_type: gauge
+            title: Cluster Node Number
+            visible: true
+            order: 2
+          - id: karmada-agent-04
+            metric_name: cluster_cpu_allocatable_number
+            chart_type: gauge
+            title: Cluster Cpu Allocatable Number
+            visible: true
+            order: 3
+          - id: karmada-agent-05
+            metric_name: cluster_cpu_allocated_number
+            chart_type: gauge
+            title: Cluster Cpu Allocated Number
+            visible: true
+            order: 4
+          - id: karmada-agent-06
+            metric_name: cluster_memory_allocatable_bytes
+            chart_type: area
+            title: Cluster Memory Allocatable Bytes
+            visible: true
+            order: 5
+          - id: karmada-agent-07
+            metric_name: cluster_memory_allocated_bytes
+            chart_type: area
+            title: Cluster Memory Allocated Bytes
+            visible: true
+            order: 6
+          - id: karmada-agent-08
+            metric_name: cluster_pod_allocatable_number
+            chart_type: gauge
+            title: Cluster Pod Allocatable Number
+            visible: true
+            order: 7
+          - id: karmada-agent-09
+            metric_name: cluster_pod_allocated_number
+            chart_type: gauge
+            title: Cluster Pod Allocated Number
+            visible: true
+            order: 8
+          - id: karmada-agent-10
+            metric_name: cluster_sync_status_duration_seconds
+            chart_type: bar
+            title: Cluster Sync Status Duration Seconds
+            visible: true
+            order: 9
+          - id: karmada-agent-11
+            metric_name: workqueue_depth
+            chart_type: gauge
+            title: Workqueue Depth
+            visible: true
+            order: 10
+      - version: 1
+        component: karmada-aggregated-apiserver
+        panels:
+          - id: karmada-aggregated-apiserver-01
+            metric_name: apiserver_request_total
+            chart_type: line
+            title: Apiserver Request Total
+            visible: true
+            order: 0
+          - id: karmada-aggregated-apiserver-02
+            metric_name: apiserver_request_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-aggregated-apiserver-03
+            metric_name: apiserver_current_inflight_requests
+            chart_type: gauge
+            title: Apiserver Current Inflight Requests
+            visible: true
+            order: 2
+          - id: karmada-aggregated-apiserver-04
+            metric_name: apiserver_longrunning_requests
+            chart_type: gauge
+            title: Apiserver Longrunning Requests
+            visible: true
+            order: 3
+          - id: karmada-aggregated-apiserver-05
+            metric_name: apiserver_request_sli_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Sli Duration Seconds
+            visible: true
+            order: 4
+          - id: karmada-aggregated-apiserver-06
+            metric_name: apiserver_response_sizes
+            chart_type: bar
+            title: Apiserver Response Sizes
+            visible: true
+            order: 5
+          - id: karmada-aggregated-apiserver-07
+            metric_name: apiserver_storage_objects
+            chart_type: gauge
+            title: Apiserver Storage Objects
+            visible: true
+            order: 6
+          - id: karmada-aggregated-apiserver-08
+            metric_name: apiserver_storage_size_bytes
+            chart_type: area
+            title: Apiserver Storage Size Bytes
+            visible: true
+            order: 7
+          - id: karmada-aggregated-apiserver-09
+            metric_name: apiserver_storage_db_total_size_in_bytes
+            chart_type: area
+            title: Apiserver Storage Db Total Size In Bytes
+            visible: true
+            order: 8
+          - id: karmada-aggregated-apiserver-10
+            metric_name: apiserver_tls_handshake_errors_total
+            chart_type: line
+            title: Apiserver Tls Handshake Errors Total
+            visible: true
+            order: 9
+          - id: karmada-aggregated-apiserver-11
+            metric_name: apiserver_delegated_authz_request_total
+            chart_type: line
+            title: Apiserver Delegated Authz Request Total
+            visible: true
+            order: 10
+          - id: karmada-aggregated-apiserver-12
+            metric_name: apiserver_delegated_authz_request_duration_seconds
+            chart_type: bar
+            title: Apiserver Delegated Authz Request Duration Seconds
+            visible: true
+            order: 11
+      - version: 1
+        component: karmada-apiserver
+        panels:
+          - id: karmada-apiserver-01
+            metric_name: apiserver_request_total
+            chart_type: line
+            title: Apiserver Request Total
+            visible: true
+            order: 0
+          - id: karmada-apiserver-02
+            metric_name: apiserver_request_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-apiserver-03
+            metric_name: apiserver_current_inflight_requests
+            chart_type: gauge
+            title: Apiserver Current Inflight Requests
+            visible: true
+            order: 2
+          - id: karmada-apiserver-04
+            metric_name: apiserver_current_inqueue_requests
+            chart_type: gauge
+            title: Apiserver Current Inqueue Requests
+            visible: true
+            order: 3
+          - id: karmada-apiserver-05
+            metric_name: apiserver_longrunning_requests
+            chart_type: gauge
+            title: Apiserver Longrunning Requests
+            visible: true
+            order: 4
+          - id: karmada-apiserver-06
+            metric_name: apiserver_flowcontrol_current_executing_requests
+            chart_type: gauge
+            title: Apiserver Flowcontrol Current Executing Requests
+            visible: true
+            order: 5
+          - id: karmada-apiserver-07
+            metric_name: apiserver_flowcontrol_current_inqueue_requests
+            chart_type: gauge
+            title: Apiserver Flowcontrol Current Inqueue Requests
+            visible: true
+            order: 6
+          - id: karmada-apiserver-08
+            metric_name: apiserver_flowcontrol_request_wait_duration_seconds
+            chart_type: bar
+            title: Apiserver Flowcontrol Request Wait Duration Seconds
+            visible: true
+            order: 7
+          - id: karmada-apiserver-09
+            metric_name: apiserver_admission_controller_admission_duration_seconds
+            chart_type: bar
+            title: Apiserver Admission Controller Admission Duration Seconds
+            visible: true
+            order: 8
+          - id: karmada-apiserver-10
+            metric_name: apiserver_storage_objects
+            chart_type: gauge
+            title: Apiserver Storage Objects
+            visible: true
+            order: 9
+          - id: karmada-apiserver-11
+            metric_name: apiserver_storage_size_bytes
+            chart_type: area
+            title: Apiserver Storage Size Bytes
+            visible: true
+            order: 10
+          - id: karmada-apiserver-12
+            metric_name: apiserver_tls_handshake_errors_total
+            chart_type: line
+            title: Apiserver Tls Handshake Errors Total
+            visible: true
+            order: 11
+      - version: 1
+        component: karmada-descheduler
+        panels:
+          - id: karmada-descheduler-01
+            metric_name: leader_election_master_status
+            chart_type: gauge
+            title: Leader Election Master Status
+            visible: true
+            order: 0
+          - id: karmada-descheduler-02
+            metric_name: workqueue_depth
+            chart_type: gauge
+            title: Workqueue Depth
+            visible: true
+            order: 1
+          - id: karmada-descheduler-03
+            metric_name: workqueue_adds_total
+            chart_type: line
+            title: Workqueue Adds Total
+            visible: true
+            order: 2
+          - id: karmada-descheduler-04
+            metric_name: workqueue_retries_total
+            chart_type: line
+            title: Workqueue Retries Total
+            visible: true
+            order: 3
+          - id: karmada-descheduler-05
+            metric_name: workqueue_queue_duration_seconds
+            chart_type: bar
+            title: Workqueue Queue Duration Seconds
+            visible: true
+            order: 4
+          - id: karmada-descheduler-06
+            metric_name: workqueue_work_duration_seconds
+            chart_type: bar
+            title: Workqueue Work Duration Seconds
+            visible: true
+            order: 5
+          - id: karmada-descheduler-07
+            metric_name: workqueue_longest_running_processor_seconds
+            chart_type: gauge
+            title: Workqueue Longest Running Processor Seconds
+            visible: true
+            order: 6
+          - id: karmada-descheduler-08
+            metric_name: workqueue_unfinished_work_seconds
+            chart_type: gauge
+            title: Workqueue Unfinished Work Seconds
+            visible: true
+            order: 7
+      - version: 1
+        component: karmada-kube-controller-manager
+        panels:
+          - id: karmada-kube-controller-manager-01
+            metric_name: node_collector_update_all_nodes_health_duration_seconds
+            chart_type: bar
+            title: Node Collector Update All Nodes Health Duration Seconds
+            visible: true
+            order: 0
+          - id: karmada-kube-controller-manager-02
+            metric_name: node_collector_update_node_health_duration_seconds
+            chart_type: bar
+            title: Node Collector Update Node Health Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-kube-controller-manager-03
+            metric_name: garbagecollector_controller_resources_sync_error_total
+            chart_type: line
+            title: Garbagecollector Controller Resources Sync Error Total
+            visible: true
+            order: 2
+          - id: karmada-kube-controller-manager-04
+            metric_name: ttl_after_finished_controller_job_deletion_duration_seconds
+            chart_type: bar
+            title: Ttl After Finished Controller Job Deletion Duration Seconds
+            visible: true
+            order: 3
+          - id: karmada-kube-controller-manager-05
+            metric_name: leader_election_master_status
+            chart_type: gauge
+            title: Leader Election Master Status
+            visible: true
+            order: 4
+          - id: karmada-kube-controller-manager-06
+            metric_name: workqueue_depth
+            chart_type: gauge
+            title: Workqueue Depth
+            visible: true
+            order: 5
+          - id: karmada-kube-controller-manager-07
+            metric_name: workqueue_adds_total
+            chart_type: line
+            title: Workqueue Adds Total
+            visible: true
+            order: 6
+          - id: karmada-kube-controller-manager-08
+            metric_name: workqueue_retries_total
+            chart_type: line
+            title: Workqueue Retries Total
+            visible: true
+            order: 7
+          - id: karmada-kube-controller-manager-09
+            metric_name: workqueue_longest_running_processor_seconds
+            chart_type: gauge
+            title: Workqueue Longest Running Processor Seconds
+            visible: true
+            order: 8
+          - id: karmada-kube-controller-manager-10
+            metric_name: workqueue_unfinished_work_seconds
+            chart_type: gauge
+            title: Workqueue Unfinished Work Seconds
+            visible: true
+            order: 9
+      - version: 1
+        component: karmada-metrics-adapter
+        panels:
+          - id: karmada-metrics-adapter-01
+            metric_name: apiserver_request_total
+            chart_type: line
+            title: Apiserver Request Total
+            visible: true
+            order: 0
+          - id: karmada-metrics-adapter-02
+            metric_name: apiserver_request_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-metrics-adapter-03
+            metric_name: apiserver_request_sli_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Sli Duration Seconds
+            visible: true
+            order: 2
+          - id: karmada-metrics-adapter-04
+            metric_name: apiserver_request_slo_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Slo Duration Seconds
+            visible: true
+            order: 3
+          - id: karmada-metrics-adapter-05
+            metric_name: apiserver_request_filter_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Filter Duration Seconds
+            visible: true
+            order: 4
+          - id: karmada-metrics-adapter-06
+            metric_name: apiserver_current_inflight_requests
+            chart_type: gauge
+            title: Apiserver Current Inflight Requests
+            visible: true
+            order: 5
+          - id: karmada-metrics-adapter-07
+            metric_name: workqueue_depth
+            chart_type: gauge
+            title: Workqueue Depth
+            visible: true
+            order: 6
+          - id: karmada-metrics-adapter-08
+            metric_name: workqueue_adds_total
+            chart_type: line
+            title: Workqueue Adds Total
+            visible: true
+            order: 7
+          - id: karmada-metrics-adapter-09
+            metric_name: workqueue_retries_total
+            chart_type: line
+            title: Workqueue Retries Total
+            visible: true
+            order: 8
+      - version: 1
+        component: karmada-scheduler-estimator-member1
+        panels:
+          - id: karmada-scheduler-estimator-member1-01
+            metric_name: karmada_scheduler_estimator_estimating_request_total
+            chart_type: line
+            title: Karmada Scheduler Estimator Estimating Request Total
+            visible: true
+            order: 0
+          - id: karmada-scheduler-estimator-member1-02
+            metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-scheduler-estimator-member1-03
+            metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+            visible: true
+            order: 2
+          - id: karmada-scheduler-estimator-member1-04
+            metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+            visible: true
+            order: 3
+      - version: 1
+        component: karmada-scheduler-estimator-member2
+        panels:
+          - id: karmada-scheduler-estimator-member2-01
+            metric_name: karmada_scheduler_estimator_estimating_request_total
+            chart_type: line
+            title: Karmada Scheduler Estimator Estimating Request Total
+            visible: true
+            order: 0
+          - id: karmada-scheduler-estimator-member2-02
+            metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-scheduler-estimator-member2-03
+            metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+            visible: true
+            order: 2
+          - id: karmada-scheduler-estimator-member2-04
+            metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+            visible: true
+            order: 3
+      - version: 1
+        component: karmada-scheduler-estimator-member3
+        panels:
+          - id: karmada-scheduler-estimator-member3-01
+            metric_name: karmada_scheduler_estimator_estimating_request_total
+            chart_type: line
+            title: Karmada Scheduler Estimator Estimating Request Total
+            visible: true
+            order: 0
+          - id: karmada-scheduler-estimator-member3-02
+            metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-scheduler-estimator-member3-03
+            metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+            visible: true
+            order: 2
+          - id: karmada-scheduler-estimator-member3-04
+            metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+            chart_type: bar
+            title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+            visible: true
+            order: 3
+      - version: 1
+        component: karmada-search
+        panels:
+          - id: karmada-search-01
+            metric_name: apiserver_request_total
+            chart_type: line
+            title: Apiserver Request Total
+            visible: true
+            order: 0
+          - id: karmada-search-02
+            metric_name: apiserver_request_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Duration Seconds
+            visible: true
+            order: 1
+          - id: karmada-search-03
+            metric_name: apiserver_current_inflight_requests
+            chart_type: gauge
+            title: Apiserver Current Inflight Requests
+            visible: true
+            order: 2
+          - id: karmada-search-04
+            metric_name: apiserver_longrunning_requests
+            chart_type: gauge
+            title: Apiserver Longrunning Requests
+            visible: true
+            order: 3
+          - id: karmada-search-05
+            metric_name: apiserver_request_sli_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Sli Duration Seconds
+            visible: true
+            order: 4
+          - id: karmada-search-06
+            metric_name: apiserver_request_slo_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Slo Duration Seconds
+            visible: true
+            order: 5
+          - id: karmada-search-07
+            metric_name: apiserver_request_filter_duration_seconds
+            chart_type: bar
+            title: Apiserver Request Filter Duration Seconds
+            visible: true
+            order: 6
+          - id: karmada-search-08
+            metric_name: apiserver_storage_objects
+            chart_type: gauge
+            title: Apiserver Storage Objects
+            visible: true
+            order: 7
+          - id: karmada-search-09
+            metric_name: apiserver_storage_size_bytes
+            chart_type: area
+            title: Apiserver Storage Size Bytes
+            visible: true
+            order: 8
+          - id: karmada-search-10
+            metric_name: etcd_request_duration_seconds
+            chart_type: bar
+            title: Etcd Request Duration Seconds
+            visible: true
+            order: 9
+          - id: karmada-search-11
+            metric_name: etcd_requests_total
+            chart_type: line
+            title: Etcd Requests Total
+            visible: true
+            order: 10
+          - id: karmada-search-12
+            metric_name: workqueue_depth
+            chart_type: gauge
+            title: Workqueue Depth
+            visible: true
+            order: 11
+      - version: 1
+        component: karmada-webhook
+        panels:
+          - id: karmada-webhook-01
+            metric_name: controller_runtime_webhook_requests_total
+            chart_type: line
+            title: Controller Runtime Webhook Requests Total
+            visible: true
+            order: 0
+          - id: karmada-webhook-02
+            metric_name: controller_runtime_webhook_latency_seconds
+            chart_type: bar
+            title: Controller Runtime Webhook Latency Seconds
+            visible: true
+            order: 1
+          - id: karmada-webhook-03
+            metric_name: controller_runtime_webhook_requests_in_flight
+            chart_type: gauge
+            title: Controller Runtime Webhook Requests In Flight
+            visible: true
+            order: 2
+          - id: karmada-webhook-04
+            metric_name: controller_runtime_webhook_panics_total
+            chart_type: line
+            title: Controller Runtime Webhook Panics Total
+            visible: true
+            order: 3
+          - id: karmada-webhook-05
+            metric_name: controller_runtime_conversion_webhook_panics_total
+            chart_type: line
+            title: Controller Runtime Conversion Webhook Panics Total
+            visible: true
+            order: 4
     menu_configs:
       - path: /overview
         enable: true
@@ -95,6 +816,9 @@ data:
       - path: /topology
         enable: true
         sidebar_key: TOPOLOGY
+      - path: /metrics
+        enable: true
+        sidebar_key: METRICS
       - path: /multicloud-resource-manage
         enable: true
         sidebar_key: MULTICLOUD-RESOURCE-MANAGE

--- a/artifacts/overlays/ingress-mode/dashboard-config.yaml
+++ b/artifacts/overlays/ingress-mode/dashboard-config.yaml
@@ -2,6 +2,724 @@ docker_registries: []
 chart_registries: []
 # path_prefix: '/karmada'
 path_prefix: ''
+metrics_dashboards:
+  - version: 1
+    component: karmada-scheduler
+    panels:
+      - id: karmada-scheduler-01
+        metric_name: karmada_scheduler_schedule_attempts_total
+        chart_type: line
+        title: Karmada Scheduler Schedule Attempts Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-02
+        metric_name: karmada_scheduler_queue_incoming_bindings_total
+        chart_type: line
+        title: Karmada Scheduler Queue Incoming Bindings Total
+        visible: true
+        order: 1
+      - id: karmada-scheduler-03
+        metric_name: karmada_scheduler_e2e_scheduling_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler E2e Scheduling Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-04
+        metric_name: karmada_scheduler_scheduling_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Scheduling Algorithm Duration Seconds
+        visible: true
+        order: 3
+      - id: karmada-scheduler-05
+        metric_name: karmada_scheduler_framework_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Framework Extension Point Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-scheduler-06
+        metric_name: karmada_scheduler_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Plugin Execution Duration Seconds
+        visible: true
+        order: 5
+      - id: karmada-scheduler-07
+        metric_name: leader_election_master_status
+        chart_type: gauge
+        title: Leader Election Master Status
+        visible: true
+        order: 6
+      - id: karmada-scheduler-08
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 7
+      - id: karmada-scheduler-09
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 8
+      - id: karmada-scheduler-10
+        metric_name: workqueue_longest_running_processor_seconds
+        chart_type: gauge
+        title: Workqueue Longest Running Processor Seconds
+        visible: true
+        order: 9
+  - version: 1
+    component: karmada-controller-manager
+    panels:
+      - id: karmada-controller-manager-01
+        metric_name: cluster_ready_state
+        chart_type: gauge
+        title: Cluster Ready State
+        visible: true
+        order: 0
+      - id: karmada-controller-manager-02
+        metric_name: cluster_ready_node_number
+        chart_type: gauge
+        title: Cluster Ready Node Number
+        visible: true
+        order: 1
+      - id: karmada-controller-manager-03
+        metric_name: cluster_node_number
+        chart_type: gauge
+        title: Cluster Node Number
+        visible: true
+        order: 2
+      - id: karmada-controller-manager-04
+        metric_name: cluster_cpu_allocatable_number
+        chart_type: gauge
+        title: Cluster Cpu Allocatable Number
+        visible: true
+        order: 3
+      - id: karmada-controller-manager-05
+        metric_name: cluster_cpu_allocated_number
+        chart_type: gauge
+        title: Cluster Cpu Allocated Number
+        visible: true
+        order: 4
+      - id: karmada-controller-manager-06
+        metric_name: cluster_memory_allocatable_bytes
+        chart_type: area
+        title: Cluster Memory Allocatable Bytes
+        visible: true
+        order: 5
+      - id: karmada-controller-manager-07
+        metric_name: cluster_memory_allocated_bytes
+        chart_type: area
+        title: Cluster Memory Allocated Bytes
+        visible: true
+        order: 6
+      - id: karmada-controller-manager-08
+        metric_name: cluster_pod_allocatable_number
+        chart_type: gauge
+        title: Cluster Pod Allocatable Number
+        visible: true
+        order: 7
+      - id: karmada-controller-manager-09
+        metric_name: cluster_pod_allocated_number
+        chart_type: gauge
+        title: Cluster Pod Allocated Number
+        visible: true
+        order: 8
+      - id: karmada-controller-manager-10
+        metric_name: cluster_sync_status_duration_seconds
+        chart_type: bar
+        title: Cluster Sync Status Duration Seconds
+        visible: true
+        order: 9
+      - id: karmada-controller-manager-11
+        metric_name: policy_apply_attempts_total
+        chart_type: line
+        title: Policy Apply Attempts Total
+        visible: true
+        order: 10
+      - id: karmada-controller-manager-12
+        metric_name: resource_apply_policy_duration_seconds
+        chart_type: bar
+        title: Resource Apply Policy Duration Seconds
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-agent
+    panels:
+      - id: karmada-agent-01
+        metric_name: cluster_ready_state
+        chart_type: gauge
+        title: Cluster Ready State
+        visible: true
+        order: 0
+      - id: karmada-agent-02
+        metric_name: cluster_ready_node_number
+        chart_type: gauge
+        title: Cluster Ready Node Number
+        visible: true
+        order: 1
+      - id: karmada-agent-03
+        metric_name: cluster_node_number
+        chart_type: gauge
+        title: Cluster Node Number
+        visible: true
+        order: 2
+      - id: karmada-agent-04
+        metric_name: cluster_cpu_allocatable_number
+        chart_type: gauge
+        title: Cluster Cpu Allocatable Number
+        visible: true
+        order: 3
+      - id: karmada-agent-05
+        metric_name: cluster_cpu_allocated_number
+        chart_type: gauge
+        title: Cluster Cpu Allocated Number
+        visible: true
+        order: 4
+      - id: karmada-agent-06
+        metric_name: cluster_memory_allocatable_bytes
+        chart_type: area
+        title: Cluster Memory Allocatable Bytes
+        visible: true
+        order: 5
+      - id: karmada-agent-07
+        metric_name: cluster_memory_allocated_bytes
+        chart_type: area
+        title: Cluster Memory Allocated Bytes
+        visible: true
+        order: 6
+      - id: karmada-agent-08
+        metric_name: cluster_pod_allocatable_number
+        chart_type: gauge
+        title: Cluster Pod Allocatable Number
+        visible: true
+        order: 7
+      - id: karmada-agent-09
+        metric_name: cluster_pod_allocated_number
+        chart_type: gauge
+        title: Cluster Pod Allocated Number
+        visible: true
+        order: 8
+      - id: karmada-agent-10
+        metric_name: cluster_sync_status_duration_seconds
+        chart_type: bar
+        title: Cluster Sync Status Duration Seconds
+        visible: true
+        order: 9
+      - id: karmada-agent-11
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 10
+  - version: 1
+    component: karmada-aggregated-apiserver
+    panels:
+      - id: karmada-aggregated-apiserver-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-aggregated-apiserver-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-aggregated-apiserver-03
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 2
+      - id: karmada-aggregated-apiserver-04
+        metric_name: apiserver_longrunning_requests
+        chart_type: gauge
+        title: Apiserver Longrunning Requests
+        visible: true
+        order: 3
+      - id: karmada-aggregated-apiserver-05
+        metric_name: apiserver_request_sli_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Sli Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-aggregated-apiserver-06
+        metric_name: apiserver_response_sizes
+        chart_type: bar
+        title: Apiserver Response Sizes
+        visible: true
+        order: 5
+      - id: karmada-aggregated-apiserver-07
+        metric_name: apiserver_storage_objects
+        chart_type: gauge
+        title: Apiserver Storage Objects
+        visible: true
+        order: 6
+      - id: karmada-aggregated-apiserver-08
+        metric_name: apiserver_storage_size_bytes
+        chart_type: area
+        title: Apiserver Storage Size Bytes
+        visible: true
+        order: 7
+      - id: karmada-aggregated-apiserver-09
+        metric_name: apiserver_storage_db_total_size_in_bytes
+        chart_type: area
+        title: Apiserver Storage Db Total Size In Bytes
+        visible: true
+        order: 8
+      - id: karmada-aggregated-apiserver-10
+        metric_name: apiserver_tls_handshake_errors_total
+        chart_type: line
+        title: Apiserver Tls Handshake Errors Total
+        visible: true
+        order: 9
+      - id: karmada-aggregated-apiserver-11
+        metric_name: apiserver_delegated_authz_request_total
+        chart_type: line
+        title: Apiserver Delegated Authz Request Total
+        visible: true
+        order: 10
+      - id: karmada-aggregated-apiserver-12
+        metric_name: apiserver_delegated_authz_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Delegated Authz Request Duration Seconds
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-apiserver
+    panels:
+      - id: karmada-apiserver-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-apiserver-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-apiserver-03
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 2
+      - id: karmada-apiserver-04
+        metric_name: apiserver_current_inqueue_requests
+        chart_type: gauge
+        title: Apiserver Current Inqueue Requests
+        visible: true
+        order: 3
+      - id: karmada-apiserver-05
+        metric_name: apiserver_longrunning_requests
+        chart_type: gauge
+        title: Apiserver Longrunning Requests
+        visible: true
+        order: 4
+      - id: karmada-apiserver-06
+        metric_name: apiserver_flowcontrol_current_executing_requests
+        chart_type: gauge
+        title: Apiserver Flowcontrol Current Executing Requests
+        visible: true
+        order: 5
+      - id: karmada-apiserver-07
+        metric_name: apiserver_flowcontrol_current_inqueue_requests
+        chart_type: gauge
+        title: Apiserver Flowcontrol Current Inqueue Requests
+        visible: true
+        order: 6
+      - id: karmada-apiserver-08
+        metric_name: apiserver_flowcontrol_request_wait_duration_seconds
+        chart_type: bar
+        title: Apiserver Flowcontrol Request Wait Duration Seconds
+        visible: true
+        order: 7
+      - id: karmada-apiserver-09
+        metric_name: apiserver_admission_controller_admission_duration_seconds
+        chart_type: bar
+        title: Apiserver Admission Controller Admission Duration Seconds
+        visible: true
+        order: 8
+      - id: karmada-apiserver-10
+        metric_name: apiserver_storage_objects
+        chart_type: gauge
+        title: Apiserver Storage Objects
+        visible: true
+        order: 9
+      - id: karmada-apiserver-11
+        metric_name: apiserver_storage_size_bytes
+        chart_type: area
+        title: Apiserver Storage Size Bytes
+        visible: true
+        order: 10
+      - id: karmada-apiserver-12
+        metric_name: apiserver_tls_handshake_errors_total
+        chart_type: line
+        title: Apiserver Tls Handshake Errors Total
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-descheduler
+    panels:
+      - id: karmada-descheduler-01
+        metric_name: leader_election_master_status
+        chart_type: gauge
+        title: Leader Election Master Status
+        visible: true
+        order: 0
+      - id: karmada-descheduler-02
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 1
+      - id: karmada-descheduler-03
+        metric_name: workqueue_adds_total
+        chart_type: line
+        title: Workqueue Adds Total
+        visible: true
+        order: 2
+      - id: karmada-descheduler-04
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 3
+      - id: karmada-descheduler-05
+        metric_name: workqueue_queue_duration_seconds
+        chart_type: bar
+        title: Workqueue Queue Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-descheduler-06
+        metric_name: workqueue_work_duration_seconds
+        chart_type: bar
+        title: Workqueue Work Duration Seconds
+        visible: true
+        order: 5
+      - id: karmada-descheduler-07
+        metric_name: workqueue_longest_running_processor_seconds
+        chart_type: gauge
+        title: Workqueue Longest Running Processor Seconds
+        visible: true
+        order: 6
+      - id: karmada-descheduler-08
+        metric_name: workqueue_unfinished_work_seconds
+        chart_type: gauge
+        title: Workqueue Unfinished Work Seconds
+        visible: true
+        order: 7
+  - version: 1
+    component: karmada-kube-controller-manager
+    panels:
+      - id: karmada-kube-controller-manager-01
+        metric_name: node_collector_update_all_nodes_health_duration_seconds
+        chart_type: bar
+        title: Node Collector Update All Nodes Health Duration Seconds
+        visible: true
+        order: 0
+      - id: karmada-kube-controller-manager-02
+        metric_name: node_collector_update_node_health_duration_seconds
+        chart_type: bar
+        title: Node Collector Update Node Health Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-kube-controller-manager-03
+        metric_name: garbagecollector_controller_resources_sync_error_total
+        chart_type: line
+        title: Garbagecollector Controller Resources Sync Error Total
+        visible: true
+        order: 2
+      - id: karmada-kube-controller-manager-04
+        metric_name: ttl_after_finished_controller_job_deletion_duration_seconds
+        chart_type: bar
+        title: Ttl After Finished Controller Job Deletion Duration Seconds
+        visible: true
+        order: 3
+      - id: karmada-kube-controller-manager-05
+        metric_name: leader_election_master_status
+        chart_type: gauge
+        title: Leader Election Master Status
+        visible: true
+        order: 4
+      - id: karmada-kube-controller-manager-06
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 5
+      - id: karmada-kube-controller-manager-07
+        metric_name: workqueue_adds_total
+        chart_type: line
+        title: Workqueue Adds Total
+        visible: true
+        order: 6
+      - id: karmada-kube-controller-manager-08
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 7
+      - id: karmada-kube-controller-manager-09
+        metric_name: workqueue_longest_running_processor_seconds
+        chart_type: gauge
+        title: Workqueue Longest Running Processor Seconds
+        visible: true
+        order: 8
+      - id: karmada-kube-controller-manager-10
+        metric_name: workqueue_unfinished_work_seconds
+        chart_type: gauge
+        title: Workqueue Unfinished Work Seconds
+        visible: true
+        order: 9
+  - version: 1
+    component: karmada-metrics-adapter
+    panels:
+      - id: karmada-metrics-adapter-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-metrics-adapter-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-metrics-adapter-03
+        metric_name: apiserver_request_sli_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Sli Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-metrics-adapter-04
+        metric_name: apiserver_request_slo_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Slo Duration Seconds
+        visible: true
+        order: 3
+      - id: karmada-metrics-adapter-05
+        metric_name: apiserver_request_filter_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Filter Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-metrics-adapter-06
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 5
+      - id: karmada-metrics-adapter-07
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 6
+      - id: karmada-metrics-adapter-08
+        metric_name: workqueue_adds_total
+        chart_type: line
+        title: Workqueue Adds Total
+        visible: true
+        order: 7
+      - id: karmada-metrics-adapter-09
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 8
+  - version: 1
+    component: karmada-scheduler-estimator-member1
+    panels:
+      - id: karmada-scheduler-estimator-member1-01
+        metric_name: karmada_scheduler_estimator_estimating_request_total
+        chart_type: line
+        title: Karmada Scheduler Estimator Estimating Request Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-estimator-member1-02
+        metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-scheduler-estimator-member1-03
+        metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-estimator-member1-04
+        metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+        visible: true
+        order: 3
+  - version: 1
+    component: karmada-scheduler-estimator-member2
+    panels:
+      - id: karmada-scheduler-estimator-member2-01
+        metric_name: karmada_scheduler_estimator_estimating_request_total
+        chart_type: line
+        title: Karmada Scheduler Estimator Estimating Request Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-estimator-member2-02
+        metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-scheduler-estimator-member2-03
+        metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-estimator-member2-04
+        metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+        visible: true
+        order: 3
+  - version: 1
+    component: karmada-scheduler-estimator-member3
+    panels:
+      - id: karmada-scheduler-estimator-member3-01
+        metric_name: karmada_scheduler_estimator_estimating_request_total
+        chart_type: line
+        title: Karmada Scheduler Estimator Estimating Request Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-estimator-member3-02
+        metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-scheduler-estimator-member3-03
+        metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-estimator-member3-04
+        metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+        visible: true
+        order: 3
+  - version: 1
+    component: karmada-search
+    panels:
+      - id: karmada-search-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-search-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-search-03
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 2
+      - id: karmada-search-04
+        metric_name: apiserver_longrunning_requests
+        chart_type: gauge
+        title: Apiserver Longrunning Requests
+        visible: true
+        order: 3
+      - id: karmada-search-05
+        metric_name: apiserver_request_sli_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Sli Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-search-06
+        metric_name: apiserver_request_slo_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Slo Duration Seconds
+        visible: true
+        order: 5
+      - id: karmada-search-07
+        metric_name: apiserver_request_filter_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Filter Duration Seconds
+        visible: true
+        order: 6
+      - id: karmada-search-08
+        metric_name: apiserver_storage_objects
+        chart_type: gauge
+        title: Apiserver Storage Objects
+        visible: true
+        order: 7
+      - id: karmada-search-09
+        metric_name: apiserver_storage_size_bytes
+        chart_type: area
+        title: Apiserver Storage Size Bytes
+        visible: true
+        order: 8
+      - id: karmada-search-10
+        metric_name: etcd_request_duration_seconds
+        chart_type: bar
+        title: Etcd Request Duration Seconds
+        visible: true
+        order: 9
+      - id: karmada-search-11
+        metric_name: etcd_requests_total
+        chart_type: line
+        title: Etcd Requests Total
+        visible: true
+        order: 10
+      - id: karmada-search-12
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-webhook
+    panels:
+      - id: karmada-webhook-01
+        metric_name: controller_runtime_webhook_requests_total
+        chart_type: line
+        title: Controller Runtime Webhook Requests Total
+        visible: true
+        order: 0
+      - id: karmada-webhook-02
+        metric_name: controller_runtime_webhook_latency_seconds
+        chart_type: bar
+        title: Controller Runtime Webhook Latency Seconds
+        visible: true
+        order: 1
+      - id: karmada-webhook-03
+        metric_name: controller_runtime_webhook_requests_in_flight
+        chart_type: gauge
+        title: Controller Runtime Webhook Requests In Flight
+        visible: true
+        order: 2
+      - id: karmada-webhook-04
+        metric_name: controller_runtime_webhook_panics_total
+        chart_type: line
+        title: Controller Runtime Webhook Panics Total
+        visible: true
+        order: 3
+      - id: karmada-webhook-05
+        metric_name: controller_runtime_conversion_webhook_panics_total
+        chart_type: line
+        title: Controller Runtime Conversion Webhook Panics Total
+        visible: true
+        order: 4
 menu_configs:
   - path: /overview
     enable: true
@@ -9,6 +727,9 @@ menu_configs:
   - path: /topology
     enable: true
     sidebar_key: TOPOLOGY
+  - path: /metrics
+    enable: true
+    sidebar_key: METRICS
   - path: /multicloud-resource-manage
     enable: true
     sidebar_key: MULTICLOUD-RESOURCE-MANAGE

--- a/artifacts/overlays/nodeport-mode/dashboard-config.yaml
+++ b/artifacts/overlays/nodeport-mode/dashboard-config.yaml
@@ -2,6 +2,724 @@ docker_registries: []
 chart_registries: []
 # path_prefix: '/karmada'
 path_prefix: ''
+metrics_dashboards:
+  - version: 1
+    component: karmada-scheduler
+    panels:
+      - id: karmada-scheduler-01
+        metric_name: karmada_scheduler_schedule_attempts_total
+        chart_type: line
+        title: Karmada Scheduler Schedule Attempts Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-02
+        metric_name: karmada_scheduler_queue_incoming_bindings_total
+        chart_type: line
+        title: Karmada Scheduler Queue Incoming Bindings Total
+        visible: true
+        order: 1
+      - id: karmada-scheduler-03
+        metric_name: karmada_scheduler_e2e_scheduling_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler E2e Scheduling Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-04
+        metric_name: karmada_scheduler_scheduling_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Scheduling Algorithm Duration Seconds
+        visible: true
+        order: 3
+      - id: karmada-scheduler-05
+        metric_name: karmada_scheduler_framework_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Framework Extension Point Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-scheduler-06
+        metric_name: karmada_scheduler_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Plugin Execution Duration Seconds
+        visible: true
+        order: 5
+      - id: karmada-scheduler-07
+        metric_name: leader_election_master_status
+        chart_type: gauge
+        title: Leader Election Master Status
+        visible: true
+        order: 6
+      - id: karmada-scheduler-08
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 7
+      - id: karmada-scheduler-09
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 8
+      - id: karmada-scheduler-10
+        metric_name: workqueue_longest_running_processor_seconds
+        chart_type: gauge
+        title: Workqueue Longest Running Processor Seconds
+        visible: true
+        order: 9
+  - version: 1
+    component: karmada-controller-manager
+    panels:
+      - id: karmada-controller-manager-01
+        metric_name: cluster_ready_state
+        chart_type: gauge
+        title: Cluster Ready State
+        visible: true
+        order: 0
+      - id: karmada-controller-manager-02
+        metric_name: cluster_ready_node_number
+        chart_type: gauge
+        title: Cluster Ready Node Number
+        visible: true
+        order: 1
+      - id: karmada-controller-manager-03
+        metric_name: cluster_node_number
+        chart_type: gauge
+        title: Cluster Node Number
+        visible: true
+        order: 2
+      - id: karmada-controller-manager-04
+        metric_name: cluster_cpu_allocatable_number
+        chart_type: gauge
+        title: Cluster Cpu Allocatable Number
+        visible: true
+        order: 3
+      - id: karmada-controller-manager-05
+        metric_name: cluster_cpu_allocated_number
+        chart_type: gauge
+        title: Cluster Cpu Allocated Number
+        visible: true
+        order: 4
+      - id: karmada-controller-manager-06
+        metric_name: cluster_memory_allocatable_bytes
+        chart_type: area
+        title: Cluster Memory Allocatable Bytes
+        visible: true
+        order: 5
+      - id: karmada-controller-manager-07
+        metric_name: cluster_memory_allocated_bytes
+        chart_type: area
+        title: Cluster Memory Allocated Bytes
+        visible: true
+        order: 6
+      - id: karmada-controller-manager-08
+        metric_name: cluster_pod_allocatable_number
+        chart_type: gauge
+        title: Cluster Pod Allocatable Number
+        visible: true
+        order: 7
+      - id: karmada-controller-manager-09
+        metric_name: cluster_pod_allocated_number
+        chart_type: gauge
+        title: Cluster Pod Allocated Number
+        visible: true
+        order: 8
+      - id: karmada-controller-manager-10
+        metric_name: cluster_sync_status_duration_seconds
+        chart_type: bar
+        title: Cluster Sync Status Duration Seconds
+        visible: true
+        order: 9
+      - id: karmada-controller-manager-11
+        metric_name: policy_apply_attempts_total
+        chart_type: line
+        title: Policy Apply Attempts Total
+        visible: true
+        order: 10
+      - id: karmada-controller-manager-12
+        metric_name: resource_apply_policy_duration_seconds
+        chart_type: bar
+        title: Resource Apply Policy Duration Seconds
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-agent
+    panels:
+      - id: karmada-agent-01
+        metric_name: cluster_ready_state
+        chart_type: gauge
+        title: Cluster Ready State
+        visible: true
+        order: 0
+      - id: karmada-agent-02
+        metric_name: cluster_ready_node_number
+        chart_type: gauge
+        title: Cluster Ready Node Number
+        visible: true
+        order: 1
+      - id: karmada-agent-03
+        metric_name: cluster_node_number
+        chart_type: gauge
+        title: Cluster Node Number
+        visible: true
+        order: 2
+      - id: karmada-agent-04
+        metric_name: cluster_cpu_allocatable_number
+        chart_type: gauge
+        title: Cluster Cpu Allocatable Number
+        visible: true
+        order: 3
+      - id: karmada-agent-05
+        metric_name: cluster_cpu_allocated_number
+        chart_type: gauge
+        title: Cluster Cpu Allocated Number
+        visible: true
+        order: 4
+      - id: karmada-agent-06
+        metric_name: cluster_memory_allocatable_bytes
+        chart_type: area
+        title: Cluster Memory Allocatable Bytes
+        visible: true
+        order: 5
+      - id: karmada-agent-07
+        metric_name: cluster_memory_allocated_bytes
+        chart_type: area
+        title: Cluster Memory Allocated Bytes
+        visible: true
+        order: 6
+      - id: karmada-agent-08
+        metric_name: cluster_pod_allocatable_number
+        chart_type: gauge
+        title: Cluster Pod Allocatable Number
+        visible: true
+        order: 7
+      - id: karmada-agent-09
+        metric_name: cluster_pod_allocated_number
+        chart_type: gauge
+        title: Cluster Pod Allocated Number
+        visible: true
+        order: 8
+      - id: karmada-agent-10
+        metric_name: cluster_sync_status_duration_seconds
+        chart_type: bar
+        title: Cluster Sync Status Duration Seconds
+        visible: true
+        order: 9
+      - id: karmada-agent-11
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 10
+  - version: 1
+    component: karmada-aggregated-apiserver
+    panels:
+      - id: karmada-aggregated-apiserver-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-aggregated-apiserver-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-aggregated-apiserver-03
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 2
+      - id: karmada-aggregated-apiserver-04
+        metric_name: apiserver_longrunning_requests
+        chart_type: gauge
+        title: Apiserver Longrunning Requests
+        visible: true
+        order: 3
+      - id: karmada-aggregated-apiserver-05
+        metric_name: apiserver_request_sli_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Sli Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-aggregated-apiserver-06
+        metric_name: apiserver_response_sizes
+        chart_type: bar
+        title: Apiserver Response Sizes
+        visible: true
+        order: 5
+      - id: karmada-aggregated-apiserver-07
+        metric_name: apiserver_storage_objects
+        chart_type: gauge
+        title: Apiserver Storage Objects
+        visible: true
+        order: 6
+      - id: karmada-aggregated-apiserver-08
+        metric_name: apiserver_storage_size_bytes
+        chart_type: area
+        title: Apiserver Storage Size Bytes
+        visible: true
+        order: 7
+      - id: karmada-aggregated-apiserver-09
+        metric_name: apiserver_storage_db_total_size_in_bytes
+        chart_type: area
+        title: Apiserver Storage Db Total Size In Bytes
+        visible: true
+        order: 8
+      - id: karmada-aggregated-apiserver-10
+        metric_name: apiserver_tls_handshake_errors_total
+        chart_type: line
+        title: Apiserver Tls Handshake Errors Total
+        visible: true
+        order: 9
+      - id: karmada-aggregated-apiserver-11
+        metric_name: apiserver_delegated_authz_request_total
+        chart_type: line
+        title: Apiserver Delegated Authz Request Total
+        visible: true
+        order: 10
+      - id: karmada-aggregated-apiserver-12
+        metric_name: apiserver_delegated_authz_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Delegated Authz Request Duration Seconds
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-apiserver
+    panels:
+      - id: karmada-apiserver-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-apiserver-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-apiserver-03
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 2
+      - id: karmada-apiserver-04
+        metric_name: apiserver_current_inqueue_requests
+        chart_type: gauge
+        title: Apiserver Current Inqueue Requests
+        visible: true
+        order: 3
+      - id: karmada-apiserver-05
+        metric_name: apiserver_longrunning_requests
+        chart_type: gauge
+        title: Apiserver Longrunning Requests
+        visible: true
+        order: 4
+      - id: karmada-apiserver-06
+        metric_name: apiserver_flowcontrol_current_executing_requests
+        chart_type: gauge
+        title: Apiserver Flowcontrol Current Executing Requests
+        visible: true
+        order: 5
+      - id: karmada-apiserver-07
+        metric_name: apiserver_flowcontrol_current_inqueue_requests
+        chart_type: gauge
+        title: Apiserver Flowcontrol Current Inqueue Requests
+        visible: true
+        order: 6
+      - id: karmada-apiserver-08
+        metric_name: apiserver_flowcontrol_request_wait_duration_seconds
+        chart_type: bar
+        title: Apiserver Flowcontrol Request Wait Duration Seconds
+        visible: true
+        order: 7
+      - id: karmada-apiserver-09
+        metric_name: apiserver_admission_controller_admission_duration_seconds
+        chart_type: bar
+        title: Apiserver Admission Controller Admission Duration Seconds
+        visible: true
+        order: 8
+      - id: karmada-apiserver-10
+        metric_name: apiserver_storage_objects
+        chart_type: gauge
+        title: Apiserver Storage Objects
+        visible: true
+        order: 9
+      - id: karmada-apiserver-11
+        metric_name: apiserver_storage_size_bytes
+        chart_type: area
+        title: Apiserver Storage Size Bytes
+        visible: true
+        order: 10
+      - id: karmada-apiserver-12
+        metric_name: apiserver_tls_handshake_errors_total
+        chart_type: line
+        title: Apiserver Tls Handshake Errors Total
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-descheduler
+    panels:
+      - id: karmada-descheduler-01
+        metric_name: leader_election_master_status
+        chart_type: gauge
+        title: Leader Election Master Status
+        visible: true
+        order: 0
+      - id: karmada-descheduler-02
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 1
+      - id: karmada-descheduler-03
+        metric_name: workqueue_adds_total
+        chart_type: line
+        title: Workqueue Adds Total
+        visible: true
+        order: 2
+      - id: karmada-descheduler-04
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 3
+      - id: karmada-descheduler-05
+        metric_name: workqueue_queue_duration_seconds
+        chart_type: bar
+        title: Workqueue Queue Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-descheduler-06
+        metric_name: workqueue_work_duration_seconds
+        chart_type: bar
+        title: Workqueue Work Duration Seconds
+        visible: true
+        order: 5
+      - id: karmada-descheduler-07
+        metric_name: workqueue_longest_running_processor_seconds
+        chart_type: gauge
+        title: Workqueue Longest Running Processor Seconds
+        visible: true
+        order: 6
+      - id: karmada-descheduler-08
+        metric_name: workqueue_unfinished_work_seconds
+        chart_type: gauge
+        title: Workqueue Unfinished Work Seconds
+        visible: true
+        order: 7
+  - version: 1
+    component: karmada-kube-controller-manager
+    panels:
+      - id: karmada-kube-controller-manager-01
+        metric_name: node_collector_update_all_nodes_health_duration_seconds
+        chart_type: bar
+        title: Node Collector Update All Nodes Health Duration Seconds
+        visible: true
+        order: 0
+      - id: karmada-kube-controller-manager-02
+        metric_name: node_collector_update_node_health_duration_seconds
+        chart_type: bar
+        title: Node Collector Update Node Health Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-kube-controller-manager-03
+        metric_name: garbagecollector_controller_resources_sync_error_total
+        chart_type: line
+        title: Garbagecollector Controller Resources Sync Error Total
+        visible: true
+        order: 2
+      - id: karmada-kube-controller-manager-04
+        metric_name: ttl_after_finished_controller_job_deletion_duration_seconds
+        chart_type: bar
+        title: Ttl After Finished Controller Job Deletion Duration Seconds
+        visible: true
+        order: 3
+      - id: karmada-kube-controller-manager-05
+        metric_name: leader_election_master_status
+        chart_type: gauge
+        title: Leader Election Master Status
+        visible: true
+        order: 4
+      - id: karmada-kube-controller-manager-06
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 5
+      - id: karmada-kube-controller-manager-07
+        metric_name: workqueue_adds_total
+        chart_type: line
+        title: Workqueue Adds Total
+        visible: true
+        order: 6
+      - id: karmada-kube-controller-manager-08
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 7
+      - id: karmada-kube-controller-manager-09
+        metric_name: workqueue_longest_running_processor_seconds
+        chart_type: gauge
+        title: Workqueue Longest Running Processor Seconds
+        visible: true
+        order: 8
+      - id: karmada-kube-controller-manager-10
+        metric_name: workqueue_unfinished_work_seconds
+        chart_type: gauge
+        title: Workqueue Unfinished Work Seconds
+        visible: true
+        order: 9
+  - version: 1
+    component: karmada-metrics-adapter
+    panels:
+      - id: karmada-metrics-adapter-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-metrics-adapter-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-metrics-adapter-03
+        metric_name: apiserver_request_sli_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Sli Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-metrics-adapter-04
+        metric_name: apiserver_request_slo_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Slo Duration Seconds
+        visible: true
+        order: 3
+      - id: karmada-metrics-adapter-05
+        metric_name: apiserver_request_filter_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Filter Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-metrics-adapter-06
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 5
+      - id: karmada-metrics-adapter-07
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 6
+      - id: karmada-metrics-adapter-08
+        metric_name: workqueue_adds_total
+        chart_type: line
+        title: Workqueue Adds Total
+        visible: true
+        order: 7
+      - id: karmada-metrics-adapter-09
+        metric_name: workqueue_retries_total
+        chart_type: line
+        title: Workqueue Retries Total
+        visible: true
+        order: 8
+  - version: 1
+    component: karmada-scheduler-estimator-member1
+    panels:
+      - id: karmada-scheduler-estimator-member1-01
+        metric_name: karmada_scheduler_estimator_estimating_request_total
+        chart_type: line
+        title: Karmada Scheduler Estimator Estimating Request Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-estimator-member1-02
+        metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-scheduler-estimator-member1-03
+        metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-estimator-member1-04
+        metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+        visible: true
+        order: 3
+  - version: 1
+    component: karmada-scheduler-estimator-member2
+    panels:
+      - id: karmada-scheduler-estimator-member2-01
+        metric_name: karmada_scheduler_estimator_estimating_request_total
+        chart_type: line
+        title: Karmada Scheduler Estimator Estimating Request Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-estimator-member2-02
+        metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-scheduler-estimator-member2-03
+        metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-estimator-member2-04
+        metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+        visible: true
+        order: 3
+  - version: 1
+    component: karmada-scheduler-estimator-member3
+    panels:
+      - id: karmada-scheduler-estimator-member3-01
+        metric_name: karmada_scheduler_estimator_estimating_request_total
+        chart_type: line
+        title: Karmada Scheduler Estimator Estimating Request Total
+        visible: true
+        order: 0
+      - id: karmada-scheduler-estimator-member3-02
+        metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-scheduler-estimator-member3-03
+        metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+        visible: true
+        order: 2
+      - id: karmada-scheduler-estimator-member3-04
+        metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+        chart_type: bar
+        title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+        visible: true
+        order: 3
+  - version: 1
+    component: karmada-search
+    panels:
+      - id: karmada-search-01
+        metric_name: apiserver_request_total
+        chart_type: line
+        title: Apiserver Request Total
+        visible: true
+        order: 0
+      - id: karmada-search-02
+        metric_name: apiserver_request_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Duration Seconds
+        visible: true
+        order: 1
+      - id: karmada-search-03
+        metric_name: apiserver_current_inflight_requests
+        chart_type: gauge
+        title: Apiserver Current Inflight Requests
+        visible: true
+        order: 2
+      - id: karmada-search-04
+        metric_name: apiserver_longrunning_requests
+        chart_type: gauge
+        title: Apiserver Longrunning Requests
+        visible: true
+        order: 3
+      - id: karmada-search-05
+        metric_name: apiserver_request_sli_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Sli Duration Seconds
+        visible: true
+        order: 4
+      - id: karmada-search-06
+        metric_name: apiserver_request_slo_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Slo Duration Seconds
+        visible: true
+        order: 5
+      - id: karmada-search-07
+        metric_name: apiserver_request_filter_duration_seconds
+        chart_type: bar
+        title: Apiserver Request Filter Duration Seconds
+        visible: true
+        order: 6
+      - id: karmada-search-08
+        metric_name: apiserver_storage_objects
+        chart_type: gauge
+        title: Apiserver Storage Objects
+        visible: true
+        order: 7
+      - id: karmada-search-09
+        metric_name: apiserver_storage_size_bytes
+        chart_type: area
+        title: Apiserver Storage Size Bytes
+        visible: true
+        order: 8
+      - id: karmada-search-10
+        metric_name: etcd_request_duration_seconds
+        chart_type: bar
+        title: Etcd Request Duration Seconds
+        visible: true
+        order: 9
+      - id: karmada-search-11
+        metric_name: etcd_requests_total
+        chart_type: line
+        title: Etcd Requests Total
+        visible: true
+        order: 10
+      - id: karmada-search-12
+        metric_name: workqueue_depth
+        chart_type: gauge
+        title: Workqueue Depth
+        visible: true
+        order: 11
+  - version: 1
+    component: karmada-webhook
+    panels:
+      - id: karmada-webhook-01
+        metric_name: controller_runtime_webhook_requests_total
+        chart_type: line
+        title: Controller Runtime Webhook Requests Total
+        visible: true
+        order: 0
+      - id: karmada-webhook-02
+        metric_name: controller_runtime_webhook_latency_seconds
+        chart_type: bar
+        title: Controller Runtime Webhook Latency Seconds
+        visible: true
+        order: 1
+      - id: karmada-webhook-03
+        metric_name: controller_runtime_webhook_requests_in_flight
+        chart_type: gauge
+        title: Controller Runtime Webhook Requests In Flight
+        visible: true
+        order: 2
+      - id: karmada-webhook-04
+        metric_name: controller_runtime_webhook_panics_total
+        chart_type: line
+        title: Controller Runtime Webhook Panics Total
+        visible: true
+        order: 3
+      - id: karmada-webhook-05
+        metric_name: controller_runtime_conversion_webhook_panics_total
+        chart_type: line
+        title: Controller Runtime Conversion Webhook Panics Total
+        visible: true
+        order: 4
 menu_configs:
   - path: /overview
     enable: true
@@ -9,6 +727,9 @@ menu_configs:
   - path: /topology
     enable: true
     sidebar_key: TOPOLOGY
+  - path: /metrics
+    enable: true
+    sidebar_key: METRICS
   - path: /multicloud-resource-manage
     enable: true
     sidebar_key: MULTICLOUD-RESOURCE-MANAGE

--- a/charts/karmada-dashboard/templates/_helpers.tpl
+++ b/charts/karmada-dashboard/templates/_helpers.tpl
@@ -119,5 +119,25 @@ app: {{ include "karmada-dashboard.name" . }}-kubernetes-dashboard-api
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "karmada-dashboard.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.api.image .Values.web.image .Values.kubernetes_dashboard_api.image) "global" .Values.global) }}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.api.image .Values.web.image .Values.kubernetes_dashboard_api.image .Values.metrics_scraper.image) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper metrics-scraper image name
+*/}}
+{{- define "karmada-dashboard.metrics-scraper.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.metrics_scraper.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+metrics-scraper labels
+*/}}
+{{- define "karmada-dashboard.metrics-scraper.labels" -}}
+{{ include "karmada-dashboard.labels" . }}
+app: {{ include "karmada-dashboard.name" . }}-metrics-scraper
+{{- if .Values.metrics_scraper.labels }}
+{{- range $key, $value := .Values.metrics_scraper.labels }}
+{{ $key }}: {{ $value }}
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/charts/karmada-dashboard/templates/karmada-dashboard-configmap.yaml
+++ b/charts/karmada-dashboard/templates/karmada-dashboard-configmap.yaml
@@ -14,6 +14,9 @@ data:
       - path: /topology
         enable: true
         sidebar_key: TOPOLOGY
+      - path: /metrics
+        enable: true
+        sidebar_key: METRICS
       - path: /multicloud-resource-manage
         enable: true
         sidebar_key: MULTICLOUD-RESOURCE-MANAGE
@@ -88,6 +91,10 @@ data:
   prod.yaml: |-
     docker_registries: [ ]
     chart_registries: [ ]
+{{ with .Values.dashboardConfig.metricsDashboards }}
+    metrics_dashboards:
+{{ toYaml . | nindent 6 }}
+{{ end }}
     menu_configs:
       - path: /overview
         enable: true
@@ -95,6 +102,9 @@ data:
       - path: /topology
         enable: true
         sidebar_key: TOPOLOGY
+      - path: /metrics
+        enable: true
+        sidebar_key: METRICS
       - path: /multicloud-resource-manage
         enable: true
         sidebar_key: MULTICLOUD-RESOURCE-MANAGE

--- a/charts/karmada-dashboard/templates/karmada-dashboard-metrics-scraper-service.yaml
+++ b/charts/karmada-dashboard/templates/karmada-dashboard-metrics-scraper-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "karmada-dashboard.name" . }}-metrics-scraper
+  namespace: {{ include "karmada-dashboard.namespace" . }}
+  labels:
+    {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.metrics_scraper.service.type }}
+  ports:
+    - port: {{ .Values.metrics_scraper.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 4 }}

--- a/charts/karmada-dashboard/templates/karmada-dashboard-metrics-scraper.yaml
+++ b/charts/karmada-dashboard/templates/karmada-dashboard-metrics-scraper.yaml
@@ -1,0 +1,108 @@
+{{- $name := include "karmada-dashboard.name" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}-metrics-scraper
+  namespace: {{ include "karmada-dashboard.namespace" . }}
+  labels:
+    {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 6 }}
+  replicas: {{ .Values.metrics_scraper.replicaCount }}
+  {{- with .Values.metrics_scraper.strategy }}
+  strategy:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      {{- with .Values.metrics_scraper.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 8 }}
+        {{- with .Values.metrics_scraper.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: karmada-dashboard
+      {{- include "karmada-dashboard.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.metrics_scraper.podSecurityContext | nindent 8 }}
+      containers:
+        - name: metrics-scraper
+          securityContext:
+            {{- toYaml .Values.metrics_scraper.securityContext | nindent 12 }}
+          image: {{ template "karmada-dashboard.metrics-scraper.image" . }}
+          imagePullPolicy: {{ .Values.metrics_scraper.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.metrics_scraper.service.port }}
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 15
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 8000
+              scheme: HTTP
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 15
+          resources:
+            {{- toYaml .Values.metrics_scraper.resources | nindent 12 }}
+          volumeMounts:
+            - name: kubeconfig-secret
+              subPath: kubeconfig
+              mountPath: /etc/kubeconfig
+          command:
+            - karmada-dashboard-metrics-scraper
+            - --karmada-kubeconfig=/etc/kubeconfig
+            - --karmada-context={{ .Values.metrics_scraper.kubeconfigContext }}
+            - --kubeconfig=/etc/kubeconfig
+            - --context={{ .Values.metrics_scraper.kubeconfigContext }}
+            - --insecure-bind-address=0.0.0.0
+            - --bind-address=0.0.0.0
+      volumes:
+        - name: kubeconfig-secret
+          secret:
+            secretName: {{ .Values.metrics_scraper.kubeconfigName }}
+      {{- with .Values.metrics_scraper.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics_scraper.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics_scraper.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+{{ if .Values.metrics_scraper.podDisruptionBudget }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}-metrics-scraper
+  namespace: {{ include "karmada-dashboard.namespace" . }}
+  labels:
+    {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "karmada-dashboard.metrics-scraper.labels" . | nindent 6 }}
+  {{ toYaml .Values.metrics_scraper.podDisruptionBudget | nindent 2 }}
+{{- end -}}

--- a/charts/karmada-dashboard/values.yaml
+++ b/charts/karmada-dashboard/values.yaml
@@ -27,6 +27,728 @@ karmadaDashboardImagePullPolicy: &karmadaDashboardImagePullPolicy IfNotPresent
 
 podDisruptionBudget: &podDisruptionBudget { }
 
+## Default component dashboard layouts persisted in karmada-dashboard-configmap.
+## @param dashboardConfig.metricsDashboards metrics panels displayed for each Karmada component
+dashboardConfig:
+  metricsDashboards:
+    - version: 1
+      component: karmada-scheduler
+      panels:
+        - id: karmada-scheduler-01
+          metric_name: karmada_scheduler_schedule_attempts_total
+          chart_type: line
+          title: Karmada Scheduler Schedule Attempts Total
+          visible: true
+          order: 0
+        - id: karmada-scheduler-02
+          metric_name: karmada_scheduler_queue_incoming_bindings_total
+          chart_type: line
+          title: Karmada Scheduler Queue Incoming Bindings Total
+          visible: true
+          order: 1
+        - id: karmada-scheduler-03
+          metric_name: karmada_scheduler_e2e_scheduling_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler E2e Scheduling Duration Seconds
+          visible: true
+          order: 2
+        - id: karmada-scheduler-04
+          metric_name: karmada_scheduler_scheduling_algorithm_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Scheduling Algorithm Duration Seconds
+          visible: true
+          order: 3
+        - id: karmada-scheduler-05
+          metric_name: karmada_scheduler_framework_extension_point_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Framework Extension Point Duration Seconds
+          visible: true
+          order: 4
+        - id: karmada-scheduler-06
+          metric_name: karmada_scheduler_plugin_execution_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Plugin Execution Duration Seconds
+          visible: true
+          order: 5
+        - id: karmada-scheduler-07
+          metric_name: leader_election_master_status
+          chart_type: gauge
+          title: Leader Election Master Status
+          visible: true
+          order: 6
+        - id: karmada-scheduler-08
+          metric_name: workqueue_depth
+          chart_type: gauge
+          title: Workqueue Depth
+          visible: true
+          order: 7
+        - id: karmada-scheduler-09
+          metric_name: workqueue_retries_total
+          chart_type: line
+          title: Workqueue Retries Total
+          visible: true
+          order: 8
+        - id: karmada-scheduler-10
+          metric_name: workqueue_longest_running_processor_seconds
+          chart_type: gauge
+          title: Workqueue Longest Running Processor Seconds
+          visible: true
+          order: 9
+    - version: 1
+      component: karmada-controller-manager
+      panels:
+        - id: karmada-controller-manager-01
+          metric_name: cluster_ready_state
+          chart_type: gauge
+          title: Cluster Ready State
+          visible: true
+          order: 0
+        - id: karmada-controller-manager-02
+          metric_name: cluster_ready_node_number
+          chart_type: gauge
+          title: Cluster Ready Node Number
+          visible: true
+          order: 1
+        - id: karmada-controller-manager-03
+          metric_name: cluster_node_number
+          chart_type: gauge
+          title: Cluster Node Number
+          visible: true
+          order: 2
+        - id: karmada-controller-manager-04
+          metric_name: cluster_cpu_allocatable_number
+          chart_type: gauge
+          title: Cluster Cpu Allocatable Number
+          visible: true
+          order: 3
+        - id: karmada-controller-manager-05
+          metric_name: cluster_cpu_allocated_number
+          chart_type: gauge
+          title: Cluster Cpu Allocated Number
+          visible: true
+          order: 4
+        - id: karmada-controller-manager-06
+          metric_name: cluster_memory_allocatable_bytes
+          chart_type: area
+          title: Cluster Memory Allocatable Bytes
+          visible: true
+          order: 5
+        - id: karmada-controller-manager-07
+          metric_name: cluster_memory_allocated_bytes
+          chart_type: area
+          title: Cluster Memory Allocated Bytes
+          visible: true
+          order: 6
+        - id: karmada-controller-manager-08
+          metric_name: cluster_pod_allocatable_number
+          chart_type: gauge
+          title: Cluster Pod Allocatable Number
+          visible: true
+          order: 7
+        - id: karmada-controller-manager-09
+          metric_name: cluster_pod_allocated_number
+          chart_type: gauge
+          title: Cluster Pod Allocated Number
+          visible: true
+          order: 8
+        - id: karmada-controller-manager-10
+          metric_name: cluster_sync_status_duration_seconds
+          chart_type: bar
+          title: Cluster Sync Status Duration Seconds
+          visible: true
+          order: 9
+        - id: karmada-controller-manager-11
+          metric_name: policy_apply_attempts_total
+          chart_type: line
+          title: Policy Apply Attempts Total
+          visible: true
+          order: 10
+        - id: karmada-controller-manager-12
+          metric_name: resource_apply_policy_duration_seconds
+          chart_type: bar
+          title: Resource Apply Policy Duration Seconds
+          visible: true
+          order: 11
+    - version: 1
+      component: karmada-agent
+      panels:
+        - id: karmada-agent-01
+          metric_name: cluster_ready_state
+          chart_type: gauge
+          title: Cluster Ready State
+          visible: true
+          order: 0
+        - id: karmada-agent-02
+          metric_name: cluster_ready_node_number
+          chart_type: gauge
+          title: Cluster Ready Node Number
+          visible: true
+          order: 1
+        - id: karmada-agent-03
+          metric_name: cluster_node_number
+          chart_type: gauge
+          title: Cluster Node Number
+          visible: true
+          order: 2
+        - id: karmada-agent-04
+          metric_name: cluster_cpu_allocatable_number
+          chart_type: gauge
+          title: Cluster Cpu Allocatable Number
+          visible: true
+          order: 3
+        - id: karmada-agent-05
+          metric_name: cluster_cpu_allocated_number
+          chart_type: gauge
+          title: Cluster Cpu Allocated Number
+          visible: true
+          order: 4
+        - id: karmada-agent-06
+          metric_name: cluster_memory_allocatable_bytes
+          chart_type: area
+          title: Cluster Memory Allocatable Bytes
+          visible: true
+          order: 5
+        - id: karmada-agent-07
+          metric_name: cluster_memory_allocated_bytes
+          chart_type: area
+          title: Cluster Memory Allocated Bytes
+          visible: true
+          order: 6
+        - id: karmada-agent-08
+          metric_name: cluster_pod_allocatable_number
+          chart_type: gauge
+          title: Cluster Pod Allocatable Number
+          visible: true
+          order: 7
+        - id: karmada-agent-09
+          metric_name: cluster_pod_allocated_number
+          chart_type: gauge
+          title: Cluster Pod Allocated Number
+          visible: true
+          order: 8
+        - id: karmada-agent-10
+          metric_name: cluster_sync_status_duration_seconds
+          chart_type: bar
+          title: Cluster Sync Status Duration Seconds
+          visible: true
+          order: 9
+        - id: karmada-agent-11
+          metric_name: workqueue_depth
+          chart_type: gauge
+          title: Workqueue Depth
+          visible: true
+          order: 10
+    - version: 1
+      component: karmada-aggregated-apiserver
+      panels:
+        - id: karmada-aggregated-apiserver-01
+          metric_name: apiserver_request_total
+          chart_type: line
+          title: Apiserver Request Total
+          visible: true
+          order: 0
+        - id: karmada-aggregated-apiserver-02
+          metric_name: apiserver_request_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-aggregated-apiserver-03
+          metric_name: apiserver_current_inflight_requests
+          chart_type: gauge
+          title: Apiserver Current Inflight Requests
+          visible: true
+          order: 2
+        - id: karmada-aggregated-apiserver-04
+          metric_name: apiserver_longrunning_requests
+          chart_type: gauge
+          title: Apiserver Longrunning Requests
+          visible: true
+          order: 3
+        - id: karmada-aggregated-apiserver-05
+          metric_name: apiserver_request_sli_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Sli Duration Seconds
+          visible: true
+          order: 4
+        - id: karmada-aggregated-apiserver-06
+          metric_name: apiserver_response_sizes
+          chart_type: bar
+          title: Apiserver Response Sizes
+          visible: true
+          order: 5
+        - id: karmada-aggregated-apiserver-07
+          metric_name: apiserver_storage_objects
+          chart_type: gauge
+          title: Apiserver Storage Objects
+          visible: true
+          order: 6
+        - id: karmada-aggregated-apiserver-08
+          metric_name: apiserver_storage_size_bytes
+          chart_type: area
+          title: Apiserver Storage Size Bytes
+          visible: true
+          order: 7
+        - id: karmada-aggregated-apiserver-09
+          metric_name: apiserver_storage_db_total_size_in_bytes
+          chart_type: area
+          title: Apiserver Storage Db Total Size In Bytes
+          visible: true
+          order: 8
+        - id: karmada-aggregated-apiserver-10
+          metric_name: apiserver_tls_handshake_errors_total
+          chart_type: line
+          title: Apiserver Tls Handshake Errors Total
+          visible: true
+          order: 9
+        - id: karmada-aggregated-apiserver-11
+          metric_name: apiserver_delegated_authz_request_total
+          chart_type: line
+          title: Apiserver Delegated Authz Request Total
+          visible: true
+          order: 10
+        - id: karmada-aggregated-apiserver-12
+          metric_name: apiserver_delegated_authz_request_duration_seconds
+          chart_type: bar
+          title: Apiserver Delegated Authz Request Duration Seconds
+          visible: true
+          order: 11
+    - version: 1
+      component: karmada-apiserver
+      panels:
+        - id: karmada-apiserver-01
+          metric_name: apiserver_request_total
+          chart_type: line
+          title: Apiserver Request Total
+          visible: true
+          order: 0
+        - id: karmada-apiserver-02
+          metric_name: apiserver_request_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-apiserver-03
+          metric_name: apiserver_current_inflight_requests
+          chart_type: gauge
+          title: Apiserver Current Inflight Requests
+          visible: true
+          order: 2
+        - id: karmada-apiserver-04
+          metric_name: apiserver_current_inqueue_requests
+          chart_type: gauge
+          title: Apiserver Current Inqueue Requests
+          visible: true
+          order: 3
+        - id: karmada-apiserver-05
+          metric_name: apiserver_longrunning_requests
+          chart_type: gauge
+          title: Apiserver Longrunning Requests
+          visible: true
+          order: 4
+        - id: karmada-apiserver-06
+          metric_name: apiserver_flowcontrol_current_executing_requests
+          chart_type: gauge
+          title: Apiserver Flowcontrol Current Executing Requests
+          visible: true
+          order: 5
+        - id: karmada-apiserver-07
+          metric_name: apiserver_flowcontrol_current_inqueue_requests
+          chart_type: gauge
+          title: Apiserver Flowcontrol Current Inqueue Requests
+          visible: true
+          order: 6
+        - id: karmada-apiserver-08
+          metric_name: apiserver_flowcontrol_request_wait_duration_seconds
+          chart_type: bar
+          title: Apiserver Flowcontrol Request Wait Duration Seconds
+          visible: true
+          order: 7
+        - id: karmada-apiserver-09
+          metric_name: apiserver_admission_controller_admission_duration_seconds
+          chart_type: bar
+          title: Apiserver Admission Controller Admission Duration Seconds
+          visible: true
+          order: 8
+        - id: karmada-apiserver-10
+          metric_name: apiserver_storage_objects
+          chart_type: gauge
+          title: Apiserver Storage Objects
+          visible: true
+          order: 9
+        - id: karmada-apiserver-11
+          metric_name: apiserver_storage_size_bytes
+          chart_type: area
+          title: Apiserver Storage Size Bytes
+          visible: true
+          order: 10
+        - id: karmada-apiserver-12
+          metric_name: apiserver_tls_handshake_errors_total
+          chart_type: line
+          title: Apiserver Tls Handshake Errors Total
+          visible: true
+          order: 11
+    - version: 1
+      component: karmada-descheduler
+      panels:
+        - id: karmada-descheduler-01
+          metric_name: leader_election_master_status
+          chart_type: gauge
+          title: Leader Election Master Status
+          visible: true
+          order: 0
+        - id: karmada-descheduler-02
+          metric_name: workqueue_depth
+          chart_type: gauge
+          title: Workqueue Depth
+          visible: true
+          order: 1
+        - id: karmada-descheduler-03
+          metric_name: workqueue_adds_total
+          chart_type: line
+          title: Workqueue Adds Total
+          visible: true
+          order: 2
+        - id: karmada-descheduler-04
+          metric_name: workqueue_retries_total
+          chart_type: line
+          title: Workqueue Retries Total
+          visible: true
+          order: 3
+        - id: karmada-descheduler-05
+          metric_name: workqueue_queue_duration_seconds
+          chart_type: bar
+          title: Workqueue Queue Duration Seconds
+          visible: true
+          order: 4
+        - id: karmada-descheduler-06
+          metric_name: workqueue_work_duration_seconds
+          chart_type: bar
+          title: Workqueue Work Duration Seconds
+          visible: true
+          order: 5
+        - id: karmada-descheduler-07
+          metric_name: workqueue_longest_running_processor_seconds
+          chart_type: gauge
+          title: Workqueue Longest Running Processor Seconds
+          visible: true
+          order: 6
+        - id: karmada-descheduler-08
+          metric_name: workqueue_unfinished_work_seconds
+          chart_type: gauge
+          title: Workqueue Unfinished Work Seconds
+          visible: true
+          order: 7
+    - version: 1
+      component: karmada-kube-controller-manager
+      panels:
+        - id: karmada-kube-controller-manager-01
+          metric_name: node_collector_update_all_nodes_health_duration_seconds
+          chart_type: bar
+          title: Node Collector Update All Nodes Health Duration Seconds
+          visible: true
+          order: 0
+        - id: karmada-kube-controller-manager-02
+          metric_name: node_collector_update_node_health_duration_seconds
+          chart_type: bar
+          title: Node Collector Update Node Health Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-kube-controller-manager-03
+          metric_name: garbagecollector_controller_resources_sync_error_total
+          chart_type: line
+          title: Garbagecollector Controller Resources Sync Error Total
+          visible: true
+          order: 2
+        - id: karmada-kube-controller-manager-04
+          metric_name: ttl_after_finished_controller_job_deletion_duration_seconds
+          chart_type: bar
+          title: Ttl After Finished Controller Job Deletion Duration Seconds
+          visible: true
+          order: 3
+        - id: karmada-kube-controller-manager-05
+          metric_name: leader_election_master_status
+          chart_type: gauge
+          title: Leader Election Master Status
+          visible: true
+          order: 4
+        - id: karmada-kube-controller-manager-06
+          metric_name: workqueue_depth
+          chart_type: gauge
+          title: Workqueue Depth
+          visible: true
+          order: 5
+        - id: karmada-kube-controller-manager-07
+          metric_name: workqueue_adds_total
+          chart_type: line
+          title: Workqueue Adds Total
+          visible: true
+          order: 6
+        - id: karmada-kube-controller-manager-08
+          metric_name: workqueue_retries_total
+          chart_type: line
+          title: Workqueue Retries Total
+          visible: true
+          order: 7
+        - id: karmada-kube-controller-manager-09
+          metric_name: workqueue_longest_running_processor_seconds
+          chart_type: gauge
+          title: Workqueue Longest Running Processor Seconds
+          visible: true
+          order: 8
+        - id: karmada-kube-controller-manager-10
+          metric_name: workqueue_unfinished_work_seconds
+          chart_type: gauge
+          title: Workqueue Unfinished Work Seconds
+          visible: true
+          order: 9
+    - version: 1
+      component: karmada-metrics-adapter
+      panels:
+        - id: karmada-metrics-adapter-01
+          metric_name: apiserver_request_total
+          chart_type: line
+          title: Apiserver Request Total
+          visible: true
+          order: 0
+        - id: karmada-metrics-adapter-02
+          metric_name: apiserver_request_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-metrics-adapter-03
+          metric_name: apiserver_request_sli_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Sli Duration Seconds
+          visible: true
+          order: 2
+        - id: karmada-metrics-adapter-04
+          metric_name: apiserver_request_slo_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Slo Duration Seconds
+          visible: true
+          order: 3
+        - id: karmada-metrics-adapter-05
+          metric_name: apiserver_request_filter_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Filter Duration Seconds
+          visible: true
+          order: 4
+        - id: karmada-metrics-adapter-06
+          metric_name: apiserver_current_inflight_requests
+          chart_type: gauge
+          title: Apiserver Current Inflight Requests
+          visible: true
+          order: 5
+        - id: karmada-metrics-adapter-07
+          metric_name: workqueue_depth
+          chart_type: gauge
+          title: Workqueue Depth
+          visible: true
+          order: 6
+        - id: karmada-metrics-adapter-08
+          metric_name: workqueue_adds_total
+          chart_type: line
+          title: Workqueue Adds Total
+          visible: true
+          order: 7
+        - id: karmada-metrics-adapter-09
+          metric_name: workqueue_retries_total
+          chart_type: line
+          title: Workqueue Retries Total
+          visible: true
+          order: 8
+    - version: 1
+      component: karmada-scheduler-estimator-member1
+      panels:
+        - id: karmada-scheduler-estimator-member1-01
+          metric_name: karmada_scheduler_estimator_estimating_request_total
+          chart_type: line
+          title: Karmada Scheduler Estimator Estimating Request Total
+          visible: true
+          order: 0
+        - id: karmada-scheduler-estimator-member1-02
+          metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-scheduler-estimator-member1-03
+          metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+          visible: true
+          order: 2
+        - id: karmada-scheduler-estimator-member1-04
+          metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+          visible: true
+          order: 3
+    - version: 1
+      component: karmada-scheduler-estimator-member2
+      panels:
+        - id: karmada-scheduler-estimator-member2-01
+          metric_name: karmada_scheduler_estimator_estimating_request_total
+          chart_type: line
+          title: Karmada Scheduler Estimator Estimating Request Total
+          visible: true
+          order: 0
+        - id: karmada-scheduler-estimator-member2-02
+          metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-scheduler-estimator-member2-03
+          metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+          visible: true
+          order: 2
+        - id: karmada-scheduler-estimator-member2-04
+          metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+          visible: true
+          order: 3
+    - version: 1
+      component: karmada-scheduler-estimator-member3
+      panels:
+        - id: karmada-scheduler-estimator-member3-01
+          metric_name: karmada_scheduler_estimator_estimating_request_total
+          chart_type: line
+          title: Karmada Scheduler Estimator Estimating Request Total
+          visible: true
+          order: 0
+        - id: karmada-scheduler-estimator-member3-02
+          metric_name: karmada_scheduler_estimator_estimating_algorithm_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Algorithm Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-scheduler-estimator-member3-03
+          metric_name: karmada_scheduler_estimator_estimating_plugin_execution_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Plugin Execution Duration Seconds
+          visible: true
+          order: 2
+        - id: karmada-scheduler-estimator-member3-04
+          metric_name: karmada_scheduler_estimator_estimating_plugin_extension_point_duration_seconds
+          chart_type: bar
+          title: Karmada Scheduler Estimator Estimating Plugin Extension Point Duration Seconds
+          visible: true
+          order: 3
+    - version: 1
+      component: karmada-search
+      panels:
+        - id: karmada-search-01
+          metric_name: apiserver_request_total
+          chart_type: line
+          title: Apiserver Request Total
+          visible: true
+          order: 0
+        - id: karmada-search-02
+          metric_name: apiserver_request_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Duration Seconds
+          visible: true
+          order: 1
+        - id: karmada-search-03
+          metric_name: apiserver_current_inflight_requests
+          chart_type: gauge
+          title: Apiserver Current Inflight Requests
+          visible: true
+          order: 2
+        - id: karmada-search-04
+          metric_name: apiserver_longrunning_requests
+          chart_type: gauge
+          title: Apiserver Longrunning Requests
+          visible: true
+          order: 3
+        - id: karmada-search-05
+          metric_name: apiserver_request_sli_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Sli Duration Seconds
+          visible: true
+          order: 4
+        - id: karmada-search-06
+          metric_name: apiserver_request_slo_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Slo Duration Seconds
+          visible: true
+          order: 5
+        - id: karmada-search-07
+          metric_name: apiserver_request_filter_duration_seconds
+          chart_type: bar
+          title: Apiserver Request Filter Duration Seconds
+          visible: true
+          order: 6
+        - id: karmada-search-08
+          metric_name: apiserver_storage_objects
+          chart_type: gauge
+          title: Apiserver Storage Objects
+          visible: true
+          order: 7
+        - id: karmada-search-09
+          metric_name: apiserver_storage_size_bytes
+          chart_type: area
+          title: Apiserver Storage Size Bytes
+          visible: true
+          order: 8
+        - id: karmada-search-10
+          metric_name: etcd_request_duration_seconds
+          chart_type: bar
+          title: Etcd Request Duration Seconds
+          visible: true
+          order: 9
+        - id: karmada-search-11
+          metric_name: etcd_requests_total
+          chart_type: line
+          title: Etcd Requests Total
+          visible: true
+          order: 10
+        - id: karmada-search-12
+          metric_name: workqueue_depth
+          chart_type: gauge
+          title: Workqueue Depth
+          visible: true
+          order: 11
+    - version: 1
+      component: karmada-webhook
+      panels:
+        - id: karmada-webhook-01
+          metric_name: controller_runtime_webhook_requests_total
+          chart_type: line
+          title: Controller Runtime Webhook Requests Total
+          visible: true
+          order: 0
+        - id: karmada-webhook-02
+          metric_name: controller_runtime_webhook_latency_seconds
+          chart_type: bar
+          title: Controller Runtime Webhook Latency Seconds
+          visible: true
+          order: 1
+        - id: karmada-webhook-03
+          metric_name: controller_runtime_webhook_requests_in_flight
+          chart_type: gauge
+          title: Controller Runtime Webhook Requests In Flight
+          visible: true
+          order: 2
+        - id: karmada-webhook-04
+          metric_name: controller_runtime_webhook_panics_total
+          chart_type: line
+          title: Controller Runtime Webhook Panics Total
+          visible: true
+          order: 3
+        - id: karmada-webhook-05
+          metric_name: controller_runtime_conversion_webhook_panics_total
+          chart_type: line
+          title: Controller Runtime Conversion Webhook Panics Total
+          visible: true
+          order: 4
+
 ingress:
   enabled: false
   className: ""
@@ -241,6 +963,75 @@ kubernetes_dashboard_api:
     #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  service:
+    type: ClusterIP
+    port: 8000
+
+metrics_scraper:
+  ## @param metrics_scraper.labels labels of the metrics-scraper deployment
+  labels: {}
+  replicaCount: 1
+  ## @param metrics_scraper.podAnnotations annotations of the metrics-scraper pods
+  podAnnotations: { }
+  ## @param metrics_scraper.podLabels labels of the metrics-scraper pods
+  podLabels: { }
+  ## @param metrics_scraper.image.registry metrics-scraper image registry
+  ## @param metrics_scraper.image.repository metrics-scraper image repository
+  ## @param metrics_scraper.image.tag karmada metrics-scraper image tag (immutable tags are recommended)
+  ## @param metrics_scraper.image.pullPolicy metrics-scraper image pull policy
+  ## @param metrics_scraper.image.pullSecrets Specify docker-registry secret names as an array
+  ##
+  image:
+    registry: docker.io
+    repository: karmada/karmada-dashboard-metrics-scraper
+    tag: *karmadaDashboardImageVersion
+    pullPolicy: *karmadaDashboardImagePullPolicy
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: [ ]
+  ## @param metrics_scraper.resources resource quota of the metrics-scraper
+  resources: { }
+    # If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  ## @param metrics_scraper.nodeSelector node selector of the metrics-scraper
+  nodeSelector: { }
+  ## @param metrics_scraper.affinity affinity of the metrics-scraper
+  affinity: { }
+  ## @param metrics_scraper.tolerations tolerations of the metrics-scraper
+  tolerations: [ ]
+  # - key: node-role.kubernetes.io/master
+  #   operator: Exists
+  ## @param metrics_scraper.strategy strategy of the metrics-scraper
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 50%
+  ## @param metrics_scraper.kubeconfigName secret name of the Karmada kubeconfig
+  kubeconfigName: karmada-kubeconfig
+  ## @param metrics_scraper.kubeconfigContext context name used in the Karmada kubeconfig
+  kubeconfigContext: karmada-apiserver
+  ## @param metrics_scraper.podDisruptionBudget
+  podDisruptionBudget: *podDisruptionBudget
+  podSecurityContext: { }
+  # fsGroup: 2000
+  securityContext: { }
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
   service:

--- a/cmd/web/app/options/options.go
+++ b/cmd/web/app/options/options.go
@@ -34,6 +34,8 @@ type Options struct {
 	APIProxyEndpoint                    string
 	EnableKubernetesDashboardAPIProxy   bool
 	KubernetesDashboardAPIProxyEndpoint string
+	EnableMetricsScraperProxy           bool
+	MetricsScraperProxyEndpoint         string
 	DashboardConfigPath                 string
 }
 
@@ -57,5 +59,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.APIProxyEndpoint, "api-proxy-endpoint", "http://karmada-dashboard-api.karmada-system.svc.cluster.local:8000", "karmada-dashboard-api endpoint")
 	fs.BoolVar(&o.EnableKubernetesDashboardAPIProxy, "enable-kubernetes-dashboard-api-proxy", true, "whether enable proxy to kubernetes-dashboard-api, if set true, all requests with /clusterapi prefix will be proxied to kubernetes-dashboard-api.karmada-system.svc.cluster.local")
 	fs.StringVar(&o.KubernetesDashboardAPIProxyEndpoint, "kubernetes-dashboard-api-proxy-endpoint", "http://kubernetes-dashboard-api.karmada-system.svc.cluster.local:8000", "kubernetes-dashboard-api endpoint")
+	fs.BoolVar(&o.EnableMetricsScraperProxy, "enable-metrics-scraper-proxy", true, "whether enable proxy to karmada-dashboard-metrics-scraper, if set true, all requests with /metrics-scraper prefix will be proxied to the metrics-scraper endpoint")
+	fs.StringVar(&o.MetricsScraperProxyEndpoint, "metrics-scraper-proxy-endpoint", "http://karmada-dashboard-metrics-scraper.karmada-system.svc.cluster.local:8000", "karmada-dashboard-metrics-scraper endpoint")
 	fs.StringVar(&o.DashboardConfigPath, "dashboard-config-path", "./config/dashboard-config.yaml", "path to dashboard config file")
 }

--- a/cmd/web/app/web.go
+++ b/cmd/web/app/web.go
@@ -158,6 +158,15 @@ func serve(opts *options.Options) {
 				klog.Fatalf("failed to parse kubernetes-dashboard-api-proxy-endpoint: %v", err)
 			}
 		}
+		if opts.EnableMetricsScraperProxy {
+			if metricsScraperProxyFunc, err := generateAPIProxy(opts.MetricsScraperProxyEndpoint, func(req *http.Request, _ *gin.Context) {
+				req.URL.Path = strings.TrimPrefix(req.URL.Path, pathPrefix+"/metrics-scraper")
+			}); err == nil {
+				g.Any("/metrics-scraper/*path", metricsScraperProxyFunc)
+			} else {
+				klog.Fatalf("failed to parse metrics-scraper-proxy-endpoint: %v", err)
+			}
+		}
 		g.GET("/i18n/*path", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{})
 		})

--- a/hack/util/constant.sh
+++ b/hack/util/constant.sh
@@ -73,6 +73,7 @@ KARMADA_TARGET_SOURCE=(
   karmada-dashboard-api=cmd/api
   karmada-dashboard-web=cmd/web
   kubernetes-dashboard-api=cmd/kubernetes-dashboard-api
+  karmada-dashboard-metrics-scraper=cmd/metrics-scraper
 )
 
 

--- a/ui/apps/dashboard/vite.config.ts
+++ b/ui/apps/dashboard/vite.config.ts
@@ -110,6 +110,10 @@ export default defineConfig(({ mode }) => {
           secure: false,
           ws: true,
         },
+        '^/metrics-scraper/.*': {
+          target: 'http://localhost:8000',
+          changeOrigin: true,
+        },
       },
     },
   };


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

- adds metrics-scraper Deployment and Service templates
- adds default dashboard configuration to manifests and Helm values
- proxies metrics-scraper through the web backend and local Vite development server
- adds build and run targets for the metrics-scraper image

This is PR 3 of 3 for component metrics support. It deploys the backend introduced by #673 and supports the dashboard in #674.

## Which issue(s) this PR fixes

None

## Special notes for reviewers

Helm dependency build and helm template validation passed. The single commit includes a DCO Signed-off-by trailer matching the commit author.