### PR TITLE
refactor: improve typescript strictness in member-cluster services

### DIFF
--- a/ui/apps/dashboard/src/services/member-cluster/crd.ts
+++ b/ui/apps/dashboard/src/services/member-cluster/crd.ts
@@ -21,6 +21,7 @@ import {
   ObjectMeta,
   TypeMeta,
 } from '../base';
+import { Event } from './event';
 
 export interface CustomResourceDefinition {
   objectMeta: ObjectMeta;
@@ -133,7 +134,7 @@ export async function GetCustomResourceEvents(params: {
     listMeta: {
       totalItems: number;
     };
-    events: any[];
+    events: Event[];
   }>(`/crd/${namespace}/${crd}/${object}/event`);
   return resp;
 }

--- a/ui/apps/dashboard/src/services/member-cluster/namespace.ts
+++ b/ui/apps/dashboard/src/services/member-cluster/namespace.ts
@@ -21,6 +21,7 @@ import {
   ObjectMeta,
   TypeMeta,
 } from '../base';
+import { Event } from './event';
 
 export interface Namespace {
   objectMeta: ObjectMeta;
@@ -80,7 +81,7 @@ export async function GetMemberClusterNamespaceEvents(params: {
     listMeta: {
       totalItems: number;
     };
-    events: any[];
+    events: Event[];
   }>(`/clusterapi/${memberClusterName}/api/v1/namespace/${name}/event`);
   return resp;
 }

--- a/ui/apps/dashboard/src/services/member-cluster/node.ts
+++ b/ui/apps/dashboard/src/services/member-cluster/node.ts
@@ -21,6 +21,8 @@ import {
   ObjectMeta,
   TypeMeta
 } from '../base';
+import { Event } from './event';
+import { Pod } from './pod';
 export interface NodeCondition {
   type: string;
   status: string;
@@ -84,8 +86,8 @@ export interface AllocatedResources {
 export interface NodeDetail extends Node {
   spec: NodeSpec;
   status: NodeStatus;
-  pods: any[];
-  events: any[];
+  pods: Pod[];
+  events: Event[];
 }
 
 export async function GetMemberClusterNodes(params: {
@@ -134,7 +136,7 @@ export async function GetMemberClusterNodeEvents(params: {
     listMeta: {
       totalItems: number;
     };
-    events: any[];
+    events: Event[];
   }>(`/clusterapi/${memberClusterName}/api/v1/node/${name}/event`);
   return resp;
 }
@@ -149,7 +151,7 @@ export async function GetMemberClusterNodePods(params: {
     listMeta: {
       totalItems: number;
     };
-    pods: any[];
+    pods: Pod[];
   }>(`/clusterapi/${memberClusterName}/api/v1/node/${name}/pod`);
   return resp;
 }

--- a/ui/apps/dashboard/src/services/member-cluster/pod.ts
+++ b/ui/apps/dashboard/src/services/member-cluster/pod.ts
@@ -21,6 +21,7 @@ import {
   ObjectMeta,
   TypeMeta,
 } from '../base';
+import { Event } from './event';
 
 export interface Container {
   name: string;
@@ -55,7 +56,7 @@ export interface Pod {
   restartCount: number;
   containers: Container[];
   containerStatuses: ContainerStatus[];
-  warnings: any[];
+  warnings: Event[];
 }
 
 export interface PodDetail extends Pod {
@@ -129,7 +130,7 @@ export async function GetMemberClusterPodEvents(params: {
     listMeta: {
       totalItems: number;
     };
-    events: any[];
+    events: Event[];
   }>(`/clusterapi/${memberClusterName}/api/v1/pod/${namespace}/${name}/event`);
   return resp;
 }

--- a/ui/apps/dashboard/src/services/member-cluster/replicaset.ts
+++ b/ui/apps/dashboard/src/services/member-cluster/replicaset.ts
@@ -21,37 +21,35 @@ import {
   ObjectMeta,
   TypeMeta,
 } from '../base';
+import { Event } from './event';
+import { Pod } from './pod';
+import { Service } from './service';
+import { ScaleResource } from './scaling';
+
+export interface PodInfo {
+  current: number;
+  desired: number;
+  running: number;
+  pending: number;
+  failed: number;
+  succeeded: number;
+  warnings: Event[];
+}
 
 export interface ReplicaSet {
   objectMeta: ObjectMeta;
   typeMeta: TypeMeta;
-  pods: {
-    current: number;
-    desired: number;
-    running: number;
-    pending: number;
-    failed: number;
-    succeeded: number;
-    warnings: any[];
-  };
+  pods: PodInfo;
   containerImages: string[];
-  initContainerImages: any[];
+  initContainerImages: string[];
 }
 
 export interface ReplicationController {
   objectMeta: ObjectMeta;
   typeMeta: TypeMeta;
-  pods: {
-    current: number;
-    desired: number;
-    running: number;
-    pending: number;
-    failed: number;
-    succeeded: number;
-    warnings: any[];
-  };
+  pods: PodInfo;
   containerImages: string[];
-  initContainerImages: any[];
+  initContainerImages: string[];
 }
 
 // ReplicaSet APIs
@@ -102,7 +100,7 @@ export async function GetReplicaSetEvents(params: {
     listMeta: {
       totalItems: number;
     };
-    events: any[];
+    events: Event[];
   }>(`/replicaset/${namespace}/${name}/event`);
   return resp;
 }
@@ -117,7 +115,7 @@ export async function GetReplicaSetPods(params: {
     listMeta: {
       totalItems: number;
     };
-    pods: any[];
+    pods: Pod[];
   }>(`/replicaset/${namespace}/${name}/pod`);
   return resp;
 }
@@ -132,7 +130,7 @@ export async function GetReplicaSetServices(params: {
     listMeta: {
       totalItems: number;
     };
-    services: any[];
+    services: Service[];
   }>(`/replicaset/${namespace}/${name}/service`);
   return resp;
 }
@@ -185,7 +183,7 @@ export async function GetReplicationControllerEvents(params: {
     listMeta: {
       totalItems: number;
     };
-    events: any[];
+    events: Event[];
   }>(`/replicationcontroller/${namespace}/${name}/event`);
   return resp;
 }
@@ -200,7 +198,7 @@ export async function GetReplicationControllerPods(params: {
     listMeta: {
       totalItems: number;
     };
-    pods: any[];
+    pods: Pod[];
   }>(`/replicationcontroller/${namespace}/${name}/pod`);
   return resp;
 }
@@ -215,7 +213,7 @@ export async function GetReplicationControllerServices(params: {
     listMeta: {
       totalItems: number;
     };
-    services: any[];
+    services: Service[];
   }>(`/replicationcontroller/${namespace}/${name}/service`);
   return resp;
 }
@@ -226,6 +224,6 @@ export async function ScaleReplicationController(params: {
   replicas: number;
 }) {
   const { namespace, name, replicas } = params;
-  const resp = await karmadaMemberClusterClient.post<any>(`/replicationcontroller/${namespace}/${name}/update/pod`, { replicas });
+  const resp = await karmadaMemberClusterClient.post<ScaleResource>(`/replicationcontroller/${namespace}/${name}/update/pod`, { replicas });
   return resp;
 }

--- a/ui/apps/dashboard/src/services/member-cluster/service.ts
+++ b/ui/apps/dashboard/src/services/member-cluster/service.ts
@@ -23,6 +23,7 @@ import {
   TypeMeta,
 } from '../base';
 import { Event } from './event'
+import { Pod } from './pod';
 
 export enum Protocol {
   TCP = 'TCP',
@@ -172,7 +173,7 @@ export async function GetMemberClusterServicePods(params: {
     listMeta: {
       totalItems: number;
     };
-    pods: any[];
+    pods: Pod[];
   }>(`/clusterapi/${memberClusterName}/api/v1/service/${namespace}/${name}/pod`);
   return resp;
 }

--- a/ui/apps/dashboard/src/services/member-cluster/workload.ts
+++ b/ui/apps/dashboard/src/services/member-cluster/workload.ts
@@ -16,6 +16,9 @@ limitations under the License.
 
 import { convertDataSelectQuery, karmadaMemberClusterClient } from '../base';
 import type { ObjectMeta, TypeMeta, WorkloadKind, Selector, RollingUpdateStrategy, DataSelectQuery } from '../base';
+import type { Event } from './event';
+import type { Pod } from './pod';
+import type { Service } from './service';
 
 export interface DeploymentWorkload {
   objectMeta: ObjectMeta;
@@ -41,7 +44,7 @@ export interface Pods {
   pending: number;
   failed: number;
   succeeded: number;
-  warnings: any[];
+  warnings: Event[];
 }
 
 export interface WorkloadStatus {
@@ -421,7 +424,7 @@ export async function GetMemberClusterDaemonSetPods(params: {
     listMeta: {
       totalItems: number;
     };
-    pods: any[];
+    pods: Pod[];
   }>(
     `/clusterapi/${memberClusterName}/api/v1/daemonset/${namespace}/${name}/pod`,
   );
@@ -439,7 +442,7 @@ export async function GetMemberClusterDaemonSetServices(params: {
     listMeta: {
       totalItems: number;
     };
-    services: any[];
+    services: Service[];
   }>(
     `/clusterapi/${memberClusterName}/api/v1/daemonset/${namespace}/${name}/service`,
   );
@@ -458,7 +461,7 @@ export async function GetMemberClusterStatefulSetPods(params: {
     listMeta: {
       totalItems: number;
     };
-    pods: any[];
+    pods: Pod[];
   }>(
     `/clusterapi/${memberClusterName}/api/v1/statefulset/${namespace}/${name}/pod`,
   );
@@ -477,7 +480,7 @@ export async function GetMemberClusterJobPods(params: {
     listMeta: {
       totalItems: number;
     };
-    pods: any[];
+    pods: Pod[];
   }>(`/clusterapi/${memberClusterName}/api/v1/job/${namespace}/${name}/pod`);
   return resp;
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The `member-cluster` service layer types a number of API response fields as `any[]`, even though correct interfaces for those exact shapes already exist in the same directory.

This is inconsistent rather than intentional: `event.ts` already declares `events: Event[]`, and `service.ts` already imports `Event` from `./event`. The sibling files simply never adopted that convention, so identical API responses are typed two different ways depending on which file you read.

This PR replaces **22 `any[]` annotations** across 7 files with the existing `Event`, `Pod`, and `Service` interfaces.

**No new types are invented.** Every annotation was verified against the Go backend structs in this same repository:

| Field | Backend source | Type |
|---|---|---|
| `warnings` | `pkg/resource/common/podinfo.go:42` | `[]Event` |
| `events` | `pkg/resource/common/event.go:29` | `[]Event` |
| `services` | `pkg/resource/service/list.go:60` | `[]Service` |
| `initContainerImages` | `pkg/resource/common/pod.go:81` | `[]string` |

Note that `warnings` is `[]Event` on the backend, not `[]string` — the `any[]` made that easy to get wrong at call sites.

Two small related cleanups in `replicaset.ts`:
- The pod summary object was inlined twice, identically, in `ReplicaSet` and `ReplicationController`. Extracted to a shared `PodInfo` interface.
- `ScaleReplicationController` returned `post<any>`; it now uses the existing `ScaleResource` interface from `scaling.ts`.

Files changed: `crd.ts`, `namespace.ts`, `node.ts`, `pod.ts`, `replicaset.ts`, `service.ts`, `workload.ts`

**Which issue(s) this PR fixes**:

None — this is an incremental strictness cleanup. Happy to open a tracking issue first if maintainers prefer.

**Special notes for your reviewer**:

- **This is a types-only change.** No runtime behaviour changes and no emitted-JS changes; it is purely TypeScript annotations plus type-only imports.
- **No screenshots included** because there is no UI/visual change — this touches only the service/type layer.
- `tsconfig.json` already sets `"strict": true`, so these `any` annotations were the remaining gap rather than a config issue.
- No import cycles are introduced: `event.ts` imports only from `../base`, and the new import edges (`pod.ts → event.ts`, `service.ts → pod.ts`) are acyclic.
- The change is deliberately scoped to `services/member-cluster/`. There are further `any` usages elsewhere in the dashboard (~127 more); I'm happy to follow up in similarly scoped PRs if this approach looks right to you.

Verification performed locally:

- `tsc --noEmit` — passes (clean before and after, so no consumers broke on the stricter types)
- `eslint "src/**/*.{ts,tsx}" --max-warnings 0` — passes
- `pnpm turbo build` — all 7 tasks succeed
- Build warning count is unchanged vs. a stashed baseline (10 pre-existing `INEFFECTIVE_DYNAMIC_IMPORT` warnings before and after)
- License headers verified present on all 7 changed files

I was not able to run the Playwright e2e suite locally, as it requires a live Karmada cluster — relying on CI for that.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
