### PR TITLE
fix(i18n-tool): move shebang to first line so the CLI can run

### DIFF
--- a/ui/packages/i18n-tool/src/index.js
+++ b/ui/packages/i18n-tool/src/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /*
 Copyright 2024 The Karmada Authors.
 
@@ -13,8 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-#!/usr/bin/env node
 
 const {Command} = require('commander');
 const chalk = require('chalk');


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`@karmada/i18n-tool` cannot start. Its shebang is on line 17, below the Apache license header, and a shebang is only honoured by Node when it is the **first** line of the file — anywhere else it is parsed as source and throws.

Reproduce on current `main`:

```console
$ cd ui/apps/dashboard
$ npx i18n-tool --help
D:\...\ui\packages\i18n-tool\src\index.js:17
#!/usr/bin/env node
^

SyntaxError: Invalid or unexpected token
    at wrapSafe (node:internal/modules/cjs/loader:1692:18)
    at Module._compile (node:internal/modules/cjs/loader:1735:20)
```

Because `packages/i18n-tool/package.json` declares `"bin": "src/index.js"`, this breaks **every** entry point — `i18n-tool scan`, `i18n-tool init`, and the `pnpm i18n:scan` / `pnpm i18n:init` scripts in `apps/dashboard`.

The header was most likely prepended by an automated license pass (`hack/verify-license.sh` / `addlicense`), which inserted it above the shebang.

**The fix** moves the shebang back to line 1 and keeps the license header immediately below, so both the license check and Node are satisfied. Two lines:

```diff
+#!/usr/bin/env node
+
 /*
 Copyright 2024 The Karmada Authors.
 ...
 */

-#!/usr/bin/env node
-
 const {Command} = require('commander');
```

After:

```console
$ npx i18n-tool --help
Usage: @karmada/i18n-tool [options] [command]

Commands:
  scan|s                  scan target language text from code
  init                    init i18n.config.js for current project
  help [command]          display help for command
```

**Which issue(s) this PR fixes**:

Related to #701 — I hit this while investigating the i18n gap in the member-cluster pages and tried to run `pnpm i18n:scan`.

**Special notes for your reviewer**:

- The license header is preserved, just moved one position down, so `hack/verify-license.sh` still passes. I confirmed the Apache header is still present within the first 20 lines of the file.
- `pnpm turbo build` passes (7/7 tasks).
- The file mode is already `100755`, so no permission change is involved.
- Worth noting for #701: with the CLI working, I confirmed that `i18n-tool scan` still does **not** extract the hardcoded English strings in `member-cluster/`. `src/scan/ast.js` matches only `[\u4e00-\u9fa5]`, i.e. Chinese characters, so English source strings are invisible to it by design. That means #701 can't be resolved simply by running the tool — which is why I raised the workflow question there rather than sending a bulk extraction PR.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
