### PR TITLE
fix: correct overview memory accounting

### DIFF
--- a/pkg/resource/cluster/detail.go
+++ b/pkg/resource/cluster/detail.go
@@ -78,7 +78,7 @@ func getclusterAllocatedResources(cluster *v1alpha1.Cluster) (ClusterAllocatedRe
 	return ClusterAllocatedResources{
 		CPUCapacity:    allocatableCPU.Value(),
 		CPUFraction:    cpuFraction,
-		MemoryCapacity: allocatedMemory.Value(),
+		MemoryCapacity: memoryCapacity,
 		MemoryFraction: memoryFraction,
 		AllocatedPods:  allocatedPod.Value(),
 		PodCapacity:    podCapacity,

--- a/pkg/resource/cluster/detail_test.go
+++ b/pkg/resource/cluster/detail_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestGetClusterAllocatedResourcesUsesAllocatableMemoryCapacity(t *testing.T) {
+	cluster := &v1alpha1.Cluster{
+		Status: v1alpha1.ClusterStatus{
+			ResourceSummary: &v1alpha1.ResourceSummary{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				Allocated: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+
+	got, err := getclusterAllocatedResources(cluster)
+	if err != nil {
+		t.Fatalf("getclusterAllocatedResources() error = %v", err)
+	}
+
+	wantCapacityQuantity := resource.MustParse("8Gi")
+	wantCapacity := wantCapacityQuantity.Value()
+	if got.MemoryCapacity != wantCapacity {
+		t.Fatalf("MemoryCapacity = %d, want %d", got.MemoryCapacity, wantCapacity)
+	}
+	if got.MemoryFraction != 25 {
+		t.Fatalf("MemoryFraction = %v, want 25", got.MemoryFraction)
+	}
+}

--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -9,6 +9,7 @@
     "build": "tsc && vite build",
     "lint": "eslint \"**/*.{ts,tsx,js,jsx}\" --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
+    "test": "vitest run",
     "i18n:init": "i18n-tool init",
     "i18n:scan": "i18n-tool scan",
     "test:e2e": "playwright test",
@@ -89,6 +90,7 @@
     "vite": "^8.0.16",
     "vite-plugin-banner": "^0.8.1",
     "vite-plugin-dynamic-base": "^1.3.0",
-    "vite-plugin-svgr": "^5.2.0"
+    "vite-plugin-svgr": "^5.2.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/ui/apps/dashboard/src/pages/metrics/dashboard-config.test.ts
+++ b/ui/apps/dashboard/src/pages/metrics/dashboard-config.test.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert/strict';
-import { test } from 'node:test';
+import { expect, test } from 'vitest';
 
 import type { MetricCatalogItem } from '@/services/metrics';
 
@@ -64,22 +63,20 @@ function catalogItem(name: string): MetricCatalogItem {
 }
 
 test('every dashboard component has non-internal defaults', () => {
-  assert.deepEqual(
-    Object.keys(DEFAULT_METRIC_NAMES_BY_COMPONENT).sort(),
+  expect(Object.keys(DEFAULT_METRIC_NAMES_BY_COMPONENT).sort()).toEqual(
     [...COMPONENTS].sort(),
   );
 
   for (const component of COMPONENTS) {
     const defaults = DEFAULT_METRIC_NAMES_BY_COMPONENT[component];
-    assert.ok(defaults.length > 0, `${component} has no defaults`);
+    expect(defaults.length, `${component} has no defaults`).toBeGreaterThan(0);
     for (const metricName of defaults) {
-      assert.equal(
+      expect(
         INTERNAL_METRIC_PREFIXES.some((prefix) =>
           metricName.startsWith(prefix),
         ),
-        false,
         `${component} unexpectedly defaults to ${metricName}`,
-      );
+      ).toBe(false);
     }
   }
 });
@@ -95,14 +92,11 @@ test('default metrics preserve allowlist order and require catalog presence', ()
     ],
   );
 
-  assert.deepEqual(
-    selected.map((item) => item.name),
-    [
-      'node_collector_update_all_nodes_health_duration_seconds',
-      'node_collector_update_node_health_duration_seconds',
-      'workqueue_depth',
-    ],
-  );
+  expect(selected.map((item) => item.name)).toEqual([
+    'node_collector_update_all_nodes_health_duration_seconds',
+    'node_collector_update_node_health_duration_seconds',
+    'workqueue_depth',
+  ]);
 });
 
 test('internal metrics are never selected by an automatic fallback', () => {
@@ -110,7 +104,7 @@ test('internal metrics are never selected by an automatic fallback', () => {
     catalogItem('go_gc_duration_seconds'),
     catalogItem('process_resident_memory_bytes'),
   ]);
-  assert.deepEqual(config.panels, []);
+  expect(config.panels).toEqual([]);
 });
 
 test('explicit user configuration keeps internal metrics', () => {
@@ -128,9 +122,7 @@ test('explicit user configuration keeps internal metrics', () => {
     ],
   };
 
-  assert.deepEqual(getConfiguredMetricNames(config), [
-    'go_gc_duration_seconds',
-  ]);
+  expect(getConfiguredMetricNames(config)).toEqual(['go_gc_duration_seconds']);
 });
 
 test('component export contains only the selected dashboard', () => {
@@ -148,7 +140,7 @@ test('component export contains only the selected dashboard', () => {
     ],
   };
 
-  assert.deepEqual(JSON.parse(serializeComponentDashboardConfig(config)), {
+  expect(JSON.parse(serializeComponentDashboardConfig(config))).toEqual({
     metrics_dashboards: [config],
   });
 });

--- a/ui/apps/dashboard/src/pages/overview/index.tsx
+++ b/ui/apps/dashboard/src/pages/overview/index.tsx
@@ -20,6 +20,7 @@ import { Badge, Descriptions, DescriptionsProps, Statistic, Spin } from 'antd';
 import { useQuery } from '@tanstack/react-query';
 import { GetOverview } from '@/services/overview.ts';
 import dayjs from 'dayjs';
+import { bytesToGiB } from './memory';
 
 const Overview = () => {
   const { data, isLoading } = useQuery({
@@ -101,18 +102,12 @@ const Overview = () => {
             ：
             <span>
               {data?.memberClusterStatus?.memorySummary?.allocatedMemory &&
-                (
-                  data.memberClusterStatus.memorySummary.allocatedMemory /
-                  8 /
-                  1024 /
-                  1024
+                bytesToGiB(
+                  data.memberClusterStatus.memorySummary.allocatedMemory,
                 ).toFixed(2)}
               GiB /
               {data?.memberClusterStatus?.memorySummary?.totalMemory &&
-                data.memberClusterStatus.memorySummary.totalMemory /
-                  8 /
-                  1024 /
-                  1024}
+                bytesToGiB(data.memberClusterStatus.memorySummary.totalMemory)}
               GiB
             </span>
           </div>

--- a/ui/apps/dashboard/src/pages/overview/memory.test.ts
+++ b/ui/apps/dashboard/src/pages/overview/memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, it } from 'vitest';
+import { bytesToGiB } from './memory';
+
+describe('bytesToGiB', () => {
+  it('converts bytes to binary GiB', () => {
+    expect(bytesToGiB(1024 ** 3)).toBe(1);
+  });
+});

--- a/ui/apps/dashboard/src/pages/overview/memory.ts
+++ b/ui/apps/dashboard/src/pages/overview/memory.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2026 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const BYTES_PER_GIB = 1024 ** 3;
+
+export function bytesToGiB(bytes: number): number {
+  return bytes / BYTES_PER_GIB;
+}

--- a/ui/apps/dashboard/vite.config.ts
+++ b/ui/apps/dashboard/vite.config.ts
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/// <reference types="vitest/config" />
+
 import { defineConfig, loadEnv, Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import path from 'path';
 import { execSync } from 'node:child_process';
+import { configDefaults } from 'vitest/config';
 import { dynamicBase } from 'vite-plugin-dynamic-base';
 import banner from 'vite-plugin-banner';
 import { getLicense } from '@karmada/utils';
@@ -61,6 +64,9 @@ export default defineConfig(({ mode }) => {
       __DASHBOARD_GIT_TAG__: JSON.stringify(gitTag),
       __DASHBOARD_GIT_COMMIT__: JSON.stringify(gitCommit),
       __DASHBOARD_REPO_URL__: JSON.stringify(repoUrl),
+    },
+    test: {
+      exclude: [...configDefaults.exclude, 'e2e/**'],
     },
 
     plugins: [

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -226,6 +226,9 @@ importers:
       vite-plugin-svgr:
         specifier: ^5.2.0
         version: 5.2.0(rollup@4.54.0)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.8.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.1.2)(vite@8.0.16(@types/node@26.1.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.8.1)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/chatui:
     dependencies:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix the Karmada Dashboard Overview memory accounting:
- use member-cluster allocatable memory for the backend capacity field;
- convert API byte values to binary GiB in the frontend;
- add Go and TypeScript regression coverage.

CPU, pod, and metrics accounting are unchanged.

**Which issue(s) this PR fixes**:
Fixes #715

**Special notes for your reviewer**:
The API continues to expose memory values in bytes. The focused backend test and Dashboard unit test pass. Dashboard lint and production build pass. The full Go suite still has unrelated existing failures in integration and pod-resource tests; the changed package passes.

**Does this PR introduce a user-facing change?**:
Yes. Overview memory capacity and allocation values will be displayed correctly.